### PR TITLE
feat: option to comment out lines in the bleep.json file

### DIFF
--- a/bleep-core/src/main/scala/bleep/model.scala
+++ b/bleep-core/src/main/scala/bleep/model.scala
@@ -593,5 +593,5 @@ object model {
   }
 
   def parseBuild(json: String): Either[Error, Build] =
-    parser.decode[model.Build](json)
+    parser.decode[model.Build](json.linesIterator.filterNot(_.trim().startsWith("//")).mkString("\n"))
 }


### PR DESCRIPTION
JSON does not support to comment out lines. Filter out lines to make it a bit easier to work with the build configuration.