### PR TITLE
Add coursier resolver authentication

### DIFF
--- a/bleep/src/test/scala/bleep/OutputSnapshotTest.scala
+++ b/bleep/src/test/scala/bleep/OutputSnapshotTest.scala
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 
 class OutputSnapshotTest extends AnyFunSuite with TripleEqualsSupport {
-  val resolver = CoursierResolver(scala.concurrent.ExecutionContext.global, downloadSources = true, None)
+  val resolver = CoursierResolver(scala.concurrent.ExecutionContext.global, downloadSources = true, None, CoursierResolver.Authentications.empty)
   val workspaceDirBase = Paths.get("bloop-test-files").toAbsolutePath
 
   def anonymize(str: String): String = {


### PR DESCRIPTION
Expects a format on the lines of:

```
{
  "<url>": {
   "user": "user", //optional
   "password": "password", //optional
   "realm": "Realm of maven central, nexus", //optional
   "optional": false //optional,
   "headers": {"Authentation": "foobar"}, //optional
   "httpsOnly": true, // optional
   "passOnRedirect": true //optional
  }
}
```

Failing to parse will log a messsage to the console.
We will also output an info message if we dont find this file.
The file is expected to be in a directory according to the [XDG](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) spec, or
whatver is native to the current platform.