### PR TITLE
Support a richer model for dependencies

### DIFF
--- a/bleep-core/src/main/scala/bleep/model.scala
+++ b/bleep-core/src/main/scala/bleep/model.scala
@@ -3,8 +3,8 @@ package bleep
 import bleep.internal.codecs.codecURI
 import bleep.internal.{EnumCodec, SetLike, ShortenJson}
 import bloop.config.Config
-import coursier.core.Configuration
-import coursier.parse.{DependencyParser, JavaOrScalaDependency}
+import coursier.core.{Attributes, Classifier, Configuration}
+import coursier.parse.{DependencyParser, JavaOrScalaDependency, ModuleParser}
 import io.circe._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
@@ -12,24 +12,60 @@ import io.circe.syntax._
 import java.net.URI
 
 object model {
+  def asDependency(dep: JavaOrScalaDependency) = dep match {
+    case d: JavaOrScalaDependency.JavaDependency  => d.dependency
+    case d: JavaOrScalaDependency.ScalaDependency => d.dependency("2.13.1")
+  }
+
   implicit val decodesDep: Decoder[JavaOrScalaDependency] =
-    Decoder.instance(c =>
-      for {
-        str <- c.as[String]
-        tuple <- DependencyParser.javaOrScalaDependencyParams(str, Configuration.empty).left.map(err => DecodingFailure(err, c.history))
-      } yield tuple._1
-    )
+    Decoder.instance { c =>
+      def parseDep(s: String) =
+        DependencyParser.javaOrScalaDependencyParams(s, Configuration.empty).map(_._1).left.map(err => DecodingFailure(err, c.history))
+      def parseModule(modules: List[String]) =
+        ModuleParser.javaOrScalaModules(modules).either.left.map(err => DecodingFailure(err.mkString(" "), c.history))
+
+      val fromString = c.as[String].flatMap(parseDep)
+
+      val full = for {
+        dependency <- c.get[String]("module").flatMap(parseDep)
+        exclude <- c.get[Option[List[String]]]("excludes").map(_.getOrElse(Nil)).flatMap(parseModule)
+        classifier <- c.get[Option[String]]("classifier")
+        optional <- c.get[Option[Boolean]]("optional").map(_.getOrElse(false))
+      } yield dependency
+        .addExclude(exclude: _*)
+        .withUnderlyingDependency(d =>
+          classifier.map(cls => d.withAttributes(d.attributes.withClassifier(Classifier(cls)))).getOrElse(d).withOptional(optional)
+        )
+      fromString.orElse(full)
+    }
 
   implicit val encodesDep: Encoder[JavaOrScalaDependency] =
-    Encoder.instance {
-      case dep: JavaOrScalaDependency.JavaDependency =>
-        Json.fromString(s"${dep.module}:${dep.dependency.version}")
-      case dep: JavaOrScalaDependency.ScalaDependency => Json.fromString(dep.repr)
+    Encoder.instance { d =>
+      val dep = asDependency(d)
+
+      val needsFull = d.exclude.nonEmpty || dep.optional || dep.attributes.classifier.nonEmpty
+
+      val jsonString = d match {
+        case dep: JavaOrScalaDependency.JavaDependency =>
+          Json.fromString(s"${dep.module}:${dep.dependency.version}")
+        case dep: JavaOrScalaDependency.ScalaDependency =>
+          Json.fromString(dep.withUnderlyingDependency(_.withOptional(false).withAttributes(Attributes.empty)).repr)
+      }
+      if (needsFull) {
+        Json
+          .obj(
+            "module" := jsonString,
+            "excludes" := Option.when(d.exclude.nonEmpty)(d.exclude.map(_.toString)),
+            "optional" := dep.optional,
+            "classifier" := Option.when(dep.attributes.classifier.nonEmpty)(dep.attributes.classifier.value)
+          )
+          .dropNullValues
+      } else jsonString
     }
 
   implicit val orderingDep: Ordering[JavaOrScalaDependency] =
     Ordering.by { incompleteDep =>
-      val dep = incompleteDep.dependency("2.13.1")
+      val dep = asDependency(incompleteDep)
       (dep.module.repr, dep.version, dep.configuration)
     }
 


### PR DESCRIPTION
We now support a potential richer model for when we need to include classifiers, exclusions or optionallity

```json
"dependencies":  [
  "org.http4s::http4s-client:0.23.1",
  { 
    "module": "org.http4s::http4s-ember-client:0.23.1",
    "excludes": ["org.http4s::http4s"],
    "optional": false,
    "classifier": "sources"
  }
]
```