### PR TITLE
Repair ProjectDirectories.from arguments

### DIFF
--- a/bleep-core/src/main/scala/bleep/Paths.scala
+++ b/bleep-core/src/main/scala/bleep/Paths.scala
@@ -11,7 +11,7 @@ case class UserPaths(cacheDir: Path, configDir: Path) {
 
 object UserPaths {
   def fromAppDirs: UserPaths = {
-    val dirs = ProjectDirectories.from("bleep", "1", "com.olvind")
+    val dirs = ProjectDirectories.from("no", "arktekk", "bleep")
     val cacheDir = Paths.get(dirs.cacheDir)
     val configDir = Paths.get(dirs.configDir)
 


### PR DESCRIPTION
Fix of https://github.com/oyvindberg/bleep/pull/44/files#diff-a281fe835a2138723ccf0f9b5a508632df22792d9060cd60ff9006fa481139d3R14

The arguments to `ProjectDirectories.from` are different from `AppDirs#getUserCacheDir`
```
public static ProjectDirectories from​(java.lang.String qualifier, java.lang.String organization, java.lang.String application)
```
https://javadoc.io/doc/dev.dirs/directories/latest/dev/dirs/ProjectDirectories.html

```
abstract String getUserCacheDir(String appName, String appVersion, String appAuthor)
```
https://javadoc.io/doc/net.harawata/appdirs/latest/net/harawata/appdirs/AppDirs.html