### PR TITLE
render options as string in yaml instead. 

### DIFF
--- a/snapshot-tests/converter/bleep.yaml
+++ b/snapshot-tests/converter/bleep.yaml
@@ -95,46 +95,16 @@ templates:
     platform:
       name: jvm
     scala:
-      options:
-      - -Xcheckinit
-      - -Xlint:adapted-args
-      - -Xlint:by-name-right-associative
-      - -Xlint:constant
-      - -Xlint:delayedinit-select
-      - -Xlint:doc-detached
-      - -Xlint:inaccessible
-      - -Xlint:infer-any
-      - -Xlint:missing-interpolator
-      - -Xlint:nullary-override
-      - -Xlint:nullary-unit
-      - -Xlint:option-implicit
-      - -Xlint:package-object-classes
-      - -Xlint:poly-implicit-overload
-      - -Xlint:private-shadow
-      - -Xlint:stars-align
-      - -Xlint:type-parameter-shadow
-      - -Xlint:unsound-match
-      - -Yno-adapted-args
-      - -Ypartial-unification
-      - -Ywarn-dead-code
-      - -Ywarn-extra-implicit
-      - -Ywarn-nullary-override
-      - -Ywarn-nullary-unit
-      - -Ywarn-numeric-widen
-      - -Ywarn-unused:implicits
-      - -Ywarn-unused:locals
-      - -Ywarn-unused:patvars
-      - -Ywarn-unused:privates
-      - -Ywarn-value-discard
-      - -deprecation
-      - -encoding
-      - utf8
-      - -feature
-      - -language:existentials
-      - -language:experimental.macros
-      - -language:higherKinds
-      - -language:implicitConversions
-      - -unchecked
+      options: -Xcheckinit -Xlint:adapted-args -Xlint:by-name-right-associative -Xlint:constant
+        -Xlint:delayedinit-select -Xlint:doc-detached -Xlint:inaccessible -Xlint:infer-any
+        -Xlint:missing-interpolator -Xlint:nullary-override -Xlint:nullary-unit -Xlint:option-implicit
+        -Xlint:package-object-classes -Xlint:poly-implicit-overload -Xlint:private-shadow
+        -Xlint:stars-align -Xlint:type-parameter-shadow -Xlint:unsound-match -Yno-adapted-args
+        -Ypartial-unification -Ywarn-dead-code -Ywarn-extra-implicit -Ywarn-nullary-override
+        -Ywarn-nullary-unit -Ywarn-numeric-widen -Ywarn-unused:implicits -Ywarn-unused:locals
+        -Ywarn-unused:patvars -Ywarn-unused:privates -Ywarn-value-discard -deprecation
+        -encoding utf8 -feature -language:existentials -language:experimental.macros
+        -language:higherKinds -language:implicitConversions -unchecked
       version: 2.12.14
   template-common-main:
     extends: template-common

--- a/snapshot-tests/create-new-build/bleep.yaml
+++ b/snapshot-tests/create-new-build/bleep.yaml
@@ -16,11 +16,7 @@ projects:
 templates:
   template-common:
     scala:
-      options:
-      - -encoding
-      - utf8
-      - -feature
-      - -unchecked
+      options: -encoding utf8 -feature -unchecked
   template-cross-all:
     cross:
       js213:

--- a/snapshot-tests/doobie/bleep.yaml
+++ b/snapshot-tests/doobie/bleep.yaml
@@ -26,9 +26,7 @@ projects:
     - template-cross-all
     folder: ./../../snapshot-tests-in/doobie/modules/core
     scala:
-      options:
-      - -Xfatal-warnings
-      - -Yno-predef
+      options: -Xfatal-warnings -Yno-predef
   core-test:
     dependencies:
     - com.h2database:h2:1.4.200
@@ -276,14 +274,8 @@ templates:
     platform:
       name: jvm
     scala:
-      options:
-      - -encoding
-      - utf8
-      - -feature
-      - -language:experimental.macros
-      - -language:higherKinds
-      - -language:implicitConversions
-      - -unchecked
+      options: -encoding utf8 -feature -language:experimental.macros -language:higherKinds
+        -language:implicitConversions -unchecked
   template-common-main:
     extends: template-common
     sbt-scope: main
@@ -305,74 +297,29 @@ templates:
   template-scala-2:
     scala:
       compilerPlugins: org.typelevel:::kind-projector:0.13.2
-      options:
-      - -Xcheckinit
-      - -Xlint:adapted-args
-      - -Xlint:constant
-      - -Xlint:delayedinit-select
-      - -Xlint:doc-detached
-      - -Xlint:inaccessible
-      - -Xlint:infer-any
-      - -Xlint:missing-interpolator
-      - -Xlint:nullary-unit
-      - -Xlint:option-implicit
-      - -Xlint:package-object-classes
-      - -Xlint:poly-implicit-overload
-      - -Xlint:private-shadow
-      - -Xlint:stars-align
-      - -Xlint:type-parameter-shadow
-      - -explaintypes
-      - -language:existentials
+      options: -Xcheckinit -Xlint:adapted-args -Xlint:constant -Xlint:delayedinit-select
+        -Xlint:doc-detached -Xlint:inaccessible -Xlint:infer-any -Xlint:missing-interpolator
+        -Xlint:nullary-unit -Xlint:option-implicit -Xlint:package-object-classes -Xlint:poly-implicit-overload
+        -Xlint:private-shadow -Xlint:stars-align -Xlint:type-parameter-shadow -explaintypes
+        -language:existentials
   template-scala-2.12:
     extends: template-scala-2
     scala:
-      options:
-      - -Xlint:by-name-right-associative
-      - -Xlint:nullary-override
-      - -Xlint:unsound-match
-      - -Yno-adapted-args
-      - -Ypartial-unification
-      - -Ywarn-dead-code
-      - -Ywarn-extra-implicit
-      - -Ywarn-nullary-override
-      - -Ywarn-nullary-unit
-      - -Ywarn-numeric-widen
-      - -Ywarn-unused:implicits
-      - -Ywarn-unused:imports
-      - -Ywarn-unused:locals
-      - -Ywarn-unused:params
-      - -Ywarn-unused:patvars
-      - -Ywarn-unused:privates
-      - -Ywarn-value-discard
-      - -deprecation
+      options: -Xlint:by-name-right-associative -Xlint:nullary-override -Xlint:unsound-match
+        -Yno-adapted-args -Ypartial-unification -Ywarn-dead-code -Ywarn-extra-implicit
+        -Ywarn-nullary-override -Ywarn-nullary-unit -Ywarn-numeric-widen -Ywarn-unused:implicits
+        -Ywarn-unused:imports -Ywarn-unused:locals -Ywarn-unused:params -Ywarn-unused:patvars
+        -Ywarn-unused:privates -Ywarn-value-discard -deprecation
       version: 2.12.15
   template-scala-2.13:
     extends: template-scala-2
     scala:
-      options:
-      - -Vimplicits
-      - -Vtype-diffs
-      - -Wdead-code
-      - -Wextra-implicit
-      - -Wnumeric-widen
-      - -Wunused:explicits
-      - -Wunused:implicits
-      - -Wunused:imports
-      - -Wunused:locals
-      - -Wunused:nowarn
-      - -Wunused:params
-      - -Wunused:patvars
-      - -Wunused:privates
-      - -Wvalue-discard
-      - -Xlint:-byname-implicit
-      - -Xlint:deprecation
-      - -Xlint:strict-unsealed-patmat
+      options: -Vimplicits -Vtype-diffs -Wdead-code -Wextra-implicit -Wnumeric-widen
+        -Wunused:explicits -Wunused:implicits -Wunused:imports -Wunused:locals -Wunused:nowarn
+        -Wunused:params -Wunused:patvars -Wunused:privates -Wvalue-discard -Xlint:-byname-implicit
+        -Xlint:deprecation -Xlint:strict-unsealed-patmat
       version: 2.13.8
   template-scala-3:
     scala:
-      options:
-      - -Ykind-projector
-      - -deprecation
-      - -explain
-      - -explain-types
+      options: -Ykind-projector -deprecation -explain -explain-types
       version: 3.1.1

--- a/snapshot-tests/http4s/bleep.yaml
+++ b/snapshot-tests/http4s/bleep.yaml
@@ -706,17 +706,9 @@ projects:
 templates:
   template-common:
     java:
-      options:
-      - -Xlint:all
-      - -encoding
-      - utf8
+      options: -Xlint:all -encoding utf8
     scala:
-      options:
-      - -deprecation
-      - -encoding
-      - UTF-8
-      - -feature
-      - -unchecked
+      options: -deprecation -encoding UTF-8 -feature -unchecked
   template-common-main:
     extends: template-common
     sbt-scope: main
@@ -757,26 +749,10 @@ templates:
       - com.olegpy::better-monadic-for:0.3.1
       - org.scalameta:::semanticdb-scalac:4.4.32
       - org.typelevel:::kind-projector:0.13.2
-      options:
-      - -Wdead-code
-      - -Wextra-implicit
-      - -Wnumeric-widen
-      - -Wunused:explicits
-      - -Wunused:implicits
-      - -Wunused:imports
-      - -Wunused:locals
-      - -Wunused:nowarn
-      - -Wunused:params
-      - -Wunused:patvars
-      - -Wunused:privates
-      - -Wvalue-discard
-      - -Xlint:deprecation
-      - -Ybackend-parallelism
-      - '8'
-      - -Yrangepos
-      - -Ywarn-dead-code
-      - -Ywarn-numeric-widen
-      - -language:_
+      options: -Wdead-code -Wextra-implicit -Wnumeric-widen -Wunused:explicits -Wunused:implicits
+        -Wunused:imports -Wunused:locals -Wunused:nowarn -Wunused:params -Wunused:patvars
+        -Wunused:privates -Wvalue-discard -Xlint:deprecation -Ybackend-parallelism
+        8 -Yrangepos -Ywarn-dead-code -Ywarn-numeric-widen -language:_
       version: 2.13.8
   template-scala-2-js:
     extends: template-js
@@ -792,19 +768,14 @@ templates:
     - template-scala-2
   template-scala-3:
     scala:
-      options:
-      - -Ykind-projector
-      - -language:implicitConversions
-      - -source:${SCALA_BIN_VERSION}.0-migration
+      options: -Ykind-projector -language:implicitConversions -source:${SCALA_BIN_VERSION}.0-migration
       version: 3.1.1
   template-scala-3-js:
     extends:
     - template-js
     - template-scala-3
     scala:
-      options:
-      - -scala${PLATFORM}
-      - -scala${PLATFORM}-mapSourceURI:file:${BUILD_DIR}/->https://raw.githubusercontent.com/http4s/http4s/bc0662792fd0c4d8462c247f6${SCALA_BIN_VERSION}4c01fee0dd5712/
+      options: -scala${PLATFORM} -scala${PLATFORM}-mapSourceURI:file:${BUILD_DIR}/->https://raw.githubusercontent.com/http4s/http4s/bc0662792fd0c4d8462c247f6${SCALA_BIN_VERSION}4c01fee0dd5712/
   template-scala-3-jvm:
     extends:
     - template-jvm

--- a/snapshot-tests/tapir/bleep.yaml
+++ b/snapshot-tests/tapir/bleep.yaml
@@ -1203,15 +1203,8 @@ projects:
 templates:
   template-common:
     scala:
-      options:
-      - -Ywarn-macros:after
-      - -encoding
-      - utf8
-      - -feature
-      - -language:experimental.macros
-      - -language:higherKinds
-      - -language:implicitConversions
-      - -unchecked
+      options: -Ywarn-macros:after -encoding utf8 -feature -language:experimental.macros
+        -language:higherKinds -language:implicitConversions -unchecked
     source-layout: sbt-matrix
   template-common-main:
     extends: template-common
@@ -1260,46 +1253,19 @@ templates:
   template-scala-2:
     scala:
       compilerPlugins: org.typelevel:::kind-projector:0.13.2
-      options:
-      - -Xcheckinit
-      - -Xlint:adapted-args
-      - -Xlint:constant
-      - -Xlint:delayedinit-select
-      - -Xlint:doc-detached
-      - -Xlint:inaccessible
-      - -Xlint:infer-any
-      - -Xlint:missing-interpolator
-      - -Xlint:nullary-unit
-      - -Xlint:option-implicit
-      - -Xlint:package-object-classes
-      - -Xlint:poly-implicit-overload
-      - -Xlint:private-shadow
-      - -Xlint:stars-align
-      - -Xlint:type-parameter-shadow
-      - -explaintypes
-      - -language:existentials
+      options: -Xcheckinit -Xlint:adapted-args -Xlint:constant -Xlint:delayedinit-select
+        -Xlint:doc-detached -Xlint:inaccessible -Xlint:infer-any -Xlint:missing-interpolator
+        -Xlint:nullary-unit -Xlint:option-implicit -Xlint:package-object-classes -Xlint:poly-implicit-overload
+        -Xlint:private-shadow -Xlint:stars-align -Xlint:type-parameter-shadow -explaintypes
+        -language:existentials
   template-scala-2.12:
     extends: template-scala-2
     scala:
-      options:
-      - -Xlint:by-name-right-associative
-      - -Xlint:nullary-override
-      - -Xlint:unsound-match
-      - -Yno-adapted-args
-      - -Ypartial-unification
-      - -Ywarn-dead-code
-      - -Ywarn-extra-implicit
-      - -Ywarn-nullary-override
-      - -Ywarn-nullary-unit
-      - -Ywarn-numeric-widen
-      - -Ywarn-unused:implicits
-      - -Ywarn-unused:imports
-      - -Ywarn-unused:locals
-      - -Ywarn-unused:params
-      - -Ywarn-unused:patvars
-      - -Ywarn-unused:privates
-      - -Ywarn-value-discard
-      - -deprecation
+      options: -Xlint:by-name-right-associative -Xlint:nullary-override -Xlint:unsound-match
+        -Yno-adapted-args -Ypartial-unification -Ywarn-dead-code -Ywarn-extra-implicit
+        -Ywarn-nullary-override -Ywarn-nullary-unit -Ywarn-numeric-widen -Ywarn-unused:implicits
+        -Ywarn-unused:imports -Ywarn-unused:locals -Ywarn-unused:params -Ywarn-unused:patvars
+        -Ywarn-unused:privates -Ywarn-value-discard -deprecation
       version: 2.12.15
   template-scala-2.12-js:
     extends:
@@ -1312,25 +1278,10 @@ templates:
   template-scala-2.13:
     extends: template-scala-2
     scala:
-      options:
-      - -Vimplicits
-      - -Vtype-diffs
-      - -Wconf:cat=other-match-analysis:error
-      - -Wdead-code
-      - -Wextra-implicit
-      - -Wnumeric-widen
-      - -Wunused:explicits
-      - -Wunused:implicits
-      - -Wunused:imports
-      - -Wunused:locals
-      - -Wunused:nowarn
-      - -Wunused:params
-      - -Wunused:patvars
-      - -Wunused:privates
-      - -Wvalue-discard
-      - -Xlint:-byname-implicit
-      - -Xlint:deprecation
-      - -Xlint:strict-unsealed-patmat
+      options: -Vimplicits -Vtype-diffs -Wconf:cat=other-match-analysis:error -Wdead-code
+        -Wextra-implicit -Wnumeric-widen -Wunused:explicits -Wunused:implicits -Wunused:imports
+        -Wunused:locals -Wunused:nowarn -Wunused:params -Wunused:patvars -Wunused:privates
+        -Wvalue-discard -Xlint:-byname-implicit -Xlint:deprecation -Xlint:strict-unsealed-patmat
       version: 2.13.6
   template-scala-2.13-js:
     extends:
@@ -1342,11 +1293,7 @@ templates:
     - template-scala-2.13
   template-scala-3:
     scala:
-      options:
-      - -Ykind-projector
-      - -deprecation
-      - -explain
-      - -explain-types
+      options: -Ykind-projector -deprecation -explain -explain-types
       version: 3.1.0
   template-scala-3-js:
     extends:


### PR DESCRIPTION
list of strings looks horrible when ~all values starts with a dash