### PR TITLE
remove some ugly magic which luckily isn't needed anymore:

### DIFF
--- a/bleep-cli/src/main/scala/bleep/internal/importBloopFilesFromSbt.scala
+++ b/bleep-cli/src/main/scala/bleep/internal/importBloopFilesFromSbt.scala
@@ -159,8 +159,7 @@ object importBloopFilesFromSbt {
 
       val replacementsTarget = Replacements.targetDir(originalTarget)
       val replacementsDirs = Replacements.paths(sbtBuildDir, directory) ++ replacementsTarget
-      val replacementsVersions = Replacements.versions(scalaVersion, bloopProject.platform.map(_.name))
-      val replacements = replacementsDirs ++ replacementsVersions
+      val replacements = replacementsDirs
 
       val configuredPlatform: Option[model.Platform] =
         bloopProject.platform.map(translatePlatform(_, replacements, bloopProject.resolution))
@@ -195,12 +194,10 @@ object importBloopFilesFromSbt {
         val shortenedSourcesRelPaths =
           sourcesRelPaths
             .filterNot(inferredSourceLayout.sources(scalaVersion, maybePlatformId, Some(projectType.sbtScope)))
-            .map(replacementsVersions.templatize.relPath)
 
         val shortenedResourcesRelPaths =
           resourcesRelPaths
             .filterNot(inferredSourceLayout.resources(scalaVersion, maybePlatformId, Some(projectType.sbtScope)))
-            .map(replacementsVersions.templatize.relPath)
 
         Sources(inferredSourceLayout, shortenedSourcesRelPaths, shortenedResourcesRelPaths)
       }
@@ -214,7 +211,7 @@ object importBloopFilesFromSbt {
         bloopProject.java.map(translateJava(replacements))
 
       val configuredScala: Option[model.Scala] =
-        bloopProject.scala.map(translateScala(compilerPlugins, replacementsDirs, replacementsVersions, scalaVersions))
+        bloopProject.scala.map(translateScala(compilerPlugins, replacementsDirs, scalaVersions))
 
       val testFrameworks: JsonSet[model.TestFrameworkName] =
         if (projectType.testLike) {
@@ -401,7 +398,6 @@ object importBloopFilesFromSbt {
   def translateScala(
       compilerPlugins: Seq[Dep],
       replacementsDirs: Replacements,
-      replacementsVersions: Replacements,
       scalaVersions: ScalaVersions
   )(s: Config.Scala): model.Scala = {
     val options = parseOptionsDropSemanticDb(s.options, Some(replacementsDirs))
@@ -418,7 +414,7 @@ object importBloopFilesFromSbt {
 
     model.Scala(
       version = Some(Versions.Scala(s.version)),
-      options = replacementsVersions.templatize.opts(new Options(notCompilerPlugins)),
+      options = new Options(notCompilerPlugins),
       setup = s.setup.map(setup =>
         model.CompileSetup(
           order = Some(setup.order),

--- a/bleep-core/src/main/scala/bleep/BuildPaths.scala
+++ b/bleep-core/src/main/scala/bleep/BuildPaths.scala
@@ -26,7 +26,6 @@ case class BuildPaths(cwd: Path, bleepYamlFile: Path, mode: BuildPaths.Mode) {
     val dir = buildDir / p.folder.getOrElse(RelPath.force(crossName.name.value))
     val scalaVersion: Option[Versions.Scala] = p.scala.flatMap(_.version)
     val maybePlatformId = p.platform.flatMap(_.name)
-    val replacementsVersions = Replacements.versions(scalaVersion, maybePlatformId.map(_.value))
 
     def sourceLayout = p.`source-layout` match {
       case Some(sourceLayout) => sourceLayout
@@ -35,14 +34,14 @@ case class BuildPaths(cwd: Path, bleepYamlFile: Path, mode: BuildPaths.Mode) {
 
     val sources: JsonSet[Path] = {
       val fromSourceLayout = sourceLayout.sources(scalaVersion, maybePlatformId, p.`sbt-scope`).values.map(dir / _)
-      val fromJson = p.sources.values.map(relPath => dir / replacementsVersions.fill.relPath(relPath))
+      val fromJson = p.sources.values.map(relPath => dir / relPath)
       val generated = generatedSourcesDir(crossName)
       JsonSet.fromIterable(fromSourceLayout ++ fromJson ++ List(generated))
     }
 
     val resources: JsonSet[Path] = {
       val fromSourceLayout = sourceLayout.resources(scalaVersion, maybePlatformId, p.`sbt-scope`).values.map(dir / _)
-      val fromJson = p.resources.values.map(relPath => dir / replacementsVersions.fill.relPath(relPath))
+      val fromJson = p.resources.values.map(relPath => dir / relPath)
       val generated = generatedResourcesDir(crossName)
       JsonSet.fromIterable(fromSourceLayout ++ fromJson + generated)
     }

--- a/bleep-core/src/main/scala/bleep/GenBloopFiles.scala
+++ b/bleep-core/src/main/scala/bleep/GenBloopFiles.scala
@@ -145,9 +145,7 @@ object GenBloopFiles {
       }
 
     val templateDirs =
-      Replacements.paths(buildPaths.buildDir, projectPaths.dir) ++
-        Replacements.targetDir(projectPaths.targetDir) ++
-        Replacements.versions(maybeScala.flatMap(_.version), explodedPlatform.flatMap(_.name).map(_.value))
+      Replacements.paths(buildPaths.buildDir, projectPaths.dir) ++ Replacements.targetDir(projectPaths.targetDir)
 
     val configuredPlatform: Option[Config.Platform] =
       explodedPlatform.map {

--- a/bleep-core/src/main/scala/bleep/SourceLayout.scala
+++ b/bleep-core/src/main/scala/bleep/SourceLayout.scala
@@ -53,8 +53,7 @@ object SourceLayout {
             RelPath.force(s"src/$scope/scala"),
             RelPath.force(s"src/$scope/java"),
             RelPath.force(s"src/$scope/scala-${scalaVersion.binVersion}"),
-            RelPath.force(s"src/$scope/scala-${scalaVersion.epoch}"),
-            RelPath.force(s"src/$scope/scala-2.13${if (scalaVersion.binVersion >= "2.13") "+" else "-"}")
+            RelPath.force(s"src/$scope/scala-${scalaVersion.epoch}")
           )
         case None => JsonSet.empty
       }

--- a/bleep-core/src/main/scala/bleep/internal/Replacements.scala
+++ b/bleep-core/src/main/scala/bleep/internal/Replacements.scala
@@ -45,23 +45,4 @@ object Replacements {
         build.toString -> "${BUILD_DIR}"
       )
     )
-
-  def versions(scalaVersion: Option[Versions.Scala], platform: Option[String]): Replacements =
-    ofReplacements(
-      List(
-        scalaVersion match {
-          case Some(scalaVersion) =>
-            List(
-//              scalaVersion.epoch.toString -> "${SCALA_EPOCH}",
-              s"${scalaVersion.binVersion}" -> "${SCALA_BIN_VERSION}",
-              scalaVersion.scalaVersion -> "${SCALA_VERSION}"
-            )
-          case None => Nil
-        },
-        platform match {
-          case Some(platform) => List(s"$platform" -> "${PLATFORM}")
-          case None           => Nil
-        }
-      ).flatten
-    )
 }

--- a/snapshot-tests/converter/.bleep/.bloop/cli.json
+++ b/snapshot-tests/converter/.bleep/.bloop/cli.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/cli/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/cli/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/cli/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/cli/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/cli"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/core.json
+++ b/snapshot-tests/converter/.bleep/.bloop/core.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/core/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/core/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/core/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/core/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/core"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/import-scalajs-definitions.json
+++ b/snapshot-tests/converter/.bleep/.bloop/import-scalajs-definitions.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/import-scalajs-definitions/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/import-scalajs-definitions/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/import-scalajs-definitions/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/import-scalajs-definitions/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/import-scalajs-definitions"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/importer-portable.json
+++ b/snapshot-tests/converter/.bleep/.bloop/importer-portable.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer-portable/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer-portable/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer-portable/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/importer-portable/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/importer-portable"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/importer-test.json
+++ b/snapshot-tests/converter/.bleep/.bloop/importer-test.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/importer/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/importer-test"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/importer.json
+++ b/snapshot-tests/converter/.bleep/.bloop/importer.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/importer/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/importer/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/importer"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/logging.json
+++ b/snapshot-tests/converter/.bleep/.bloop/logging.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/logging/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/logging/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/logging/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/logging/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/logging"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/phases.json
+++ b/snapshot-tests/converter/.bleep/.bloop/phases.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/phases/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/phases/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/phases/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/phases/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/phases"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/sbt-converter.json
+++ b/snapshot-tests/converter/.bleep/.bloop/sbt-converter.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/sbt-converter/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/sbt-converter/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/sbt-converter/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/sbt-converter/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests-in/converter/sbt-converter/src/main/scala-sbt-1.0",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/sbt-converter"
     ],

--- a/snapshot-tests/converter/.bleep/.bloop/scalajs.json
+++ b/snapshot-tests/converter/.bleep/.bloop/scalajs.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/scalajs/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/scalajs/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/scalajs/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/scalajs/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/scalajs"
     ],
     "dependencies": [

--- a/snapshot-tests/converter/.bleep/.bloop/scripts.json
+++ b/snapshot-tests/converter/.bleep/.bloop/scripts.json
@@ -9,8 +9,7 @@
       "<BLEEP_GIT>/snapshot-tests/converter/scripts/src/java",
       "<BLEEP_GIT>/snapshot-tests/converter/scripts/src/scala",
       "<BLEEP_GIT>/snapshot-tests/converter/scripts/src/scala-2",
-      "<BLEEP_GIT>/snapshot-tests/converter/scripts/src/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests/converter/scripts/src/scala-2.13-"
+      "<BLEEP_GIT>/snapshot-tests/converter/scripts/src/scala-2.12"
     ],
     "dependencies": [
       

--- a/snapshot-tests/converter/.bleep/.bloop/ts.json
+++ b/snapshot-tests/converter/.bleep/.bloop/ts.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/converter/ts/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/converter/ts/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/converter/ts/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/converter/ts/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/converter/.bleep/generated-sources/ts"
     ],
     "dependencies": [

--- a/snapshot-tests/create-new-build/.bleep/.bloop/myapp-test@js213.json
+++ b/snapshot-tests/create-new-build/.bleep/.bloop/myapp-test@js213.json
@@ -9,8 +9,7 @@
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/java",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2.13+"
+      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2.13"
     ],
     "dependencies": [
       "myapp@js213"

--- a/snapshot-tests/create-new-build/.bleep/.bloop/myapp-test@js3.json
+++ b/snapshot-tests/create-new-build/.bleep/.bloop/myapp-test@js3.json
@@ -8,7 +8,6 @@
       "<BLEEP_GIT>/snapshot-tests/create-new-build/.bleep/generated-sources/myapp-test@js3",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/java",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-3"
     ],
     "dependencies": [

--- a/snapshot-tests/create-new-build/.bleep/.bloop/myapp-test@jvm213.json
+++ b/snapshot-tests/create-new-build/.bleep/.bloop/myapp-test@jvm213.json
@@ -9,8 +9,7 @@
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/java",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2.13+"
+      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2.13"
     ],
     "dependencies": [
       "myapp@jvm213"

--- a/snapshot-tests/create-new-build/.bleep/.bloop/myapp-test@jvm3.json
+++ b/snapshot-tests/create-new-build/.bleep/.bloop/myapp-test@jvm3.json
@@ -8,7 +8,6 @@
       "<BLEEP_GIT>/snapshot-tests/create-new-build/.bleep/generated-sources/myapp-test@jvm3",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/java",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp-test/src/scala-3"
     ],
     "dependencies": [

--- a/snapshot-tests/create-new-build/.bleep/.bloop/myapp@js213.json
+++ b/snapshot-tests/create-new-build/.bleep/.bloop/myapp@js213.json
@@ -9,8 +9,7 @@
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/java",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2.13+"
+      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2.13"
     ],
     "dependencies": [
       

--- a/snapshot-tests/create-new-build/.bleep/.bloop/myapp@js3.json
+++ b/snapshot-tests/create-new-build/.bleep/.bloop/myapp@js3.json
@@ -8,7 +8,6 @@
       "<BLEEP_GIT>/snapshot-tests/create-new-build/.bleep/generated-sources/myapp@js3",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/java",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-3"
     ],
     "dependencies": [

--- a/snapshot-tests/create-new-build/.bleep/.bloop/myapp@jvm213.json
+++ b/snapshot-tests/create-new-build/.bleep/.bloop/myapp@jvm213.json
@@ -9,8 +9,7 @@
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/java",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2.13+"
+      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2.13"
     ],
     "dependencies": [
       

--- a/snapshot-tests/create-new-build/.bleep/.bloop/myapp@jvm3.json
+++ b/snapshot-tests/create-new-build/.bleep/.bloop/myapp@jvm3.json
@@ -8,7 +8,6 @@
       "<BLEEP_GIT>/snapshot-tests/create-new-build/.bleep/generated-sources/myapp@jvm3",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/java",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala",
-      "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/create-new-build/myapp/src/scala-3"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/bench@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/bench@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/bench@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/bench@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/bench@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/bench@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/bench@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/bench@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/bench/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/bench@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/core-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/core-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/core-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/core-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/core-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/core-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/core-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/core-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/core/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/core-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/example-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/example-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/example-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/example-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/example-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/example-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/example@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/example@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/example@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/example@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/example@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/example@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/example@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/example@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/example/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/example@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/free@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/free@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/free@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/free@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/free@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/free@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/free@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/free@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/free/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/free@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-circe-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-circe-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-circe-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-circe-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-circe-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-circe-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-circe-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-circe-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-circe-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-circe@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-circe@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-circe@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-circe@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-circe@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-circe@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-circe@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-circe@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2-circe/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-circe@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/h2-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/h2@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/h2@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/h2@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/h2@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/h2/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/h2@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/hikari-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/hikari-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/hikari-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/hikari-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/hikari-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/hikari-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/hikari-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/hikari-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/hikari-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/hikari@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/hikari@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/hikari@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/hikari@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/hikari@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/hikari@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/hikari@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/hikari@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/hikari/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/hikari@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/munit-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/munit-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/munit-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/munit-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/munit-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/munit-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/munit-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/munit-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/munit-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/munit@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/munit@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/munit@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/munit@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/munit@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/munit@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/munit@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/munit@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/munit/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/munit@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-circe-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-circe-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-circe-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-circe-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-circe-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-circe-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-circe-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-circe-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-circe-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-circe@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-circe@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-circe@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-circe@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-circe@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-circe@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-circe@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-circe@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres-circe/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-circe@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/postgres@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/postgres@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/postgres/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/postgres@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/refined-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/refined-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/refined-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/refined-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/refined-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/refined-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/refined-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/refined-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/refined-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/refined@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/refined@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/refined@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/refined@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/refined@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/refined@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/refined@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/refined@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/refined/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/refined@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/scalatest-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/scalatest-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/scalatest-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/scalatest-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/scalatest-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/scalatest-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/scalatest-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/scalatest-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/scalatest-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/scalatest@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/scalatest@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/scalatest@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/scalatest@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/scalatest@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/scalatest@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/scalatest@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/scalatest@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/scalatest/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/scalatest@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/specs2-test@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/specs2-test@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/specs2-test@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/specs2-test@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/specs2-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/specs2-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/specs2-test@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/specs2-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/specs2-test@jvm3"
     ],

--- a/snapshot-tests/doobie/.bleep/.bloop/specs2@jvm212.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/specs2@jvm212.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala-2.12",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala-2.13-",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/specs2@jvm212"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/specs2@jvm213.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/specs2@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/specs2@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/doobie/.bleep/.bloop/specs2@jvm3.json
+++ b/snapshot-tests/doobie/.bleep/.bloop/specs2@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/doobie/modules/specs2/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/doobie/.bleep/generated-sources/specs2@jvm3"
     ],

--- a/snapshot-tests/doobie/bleep.yaml
+++ b/snapshot-tests/doobie/bleep.yaml
@@ -17,8 +17,12 @@ projects:
     cross:
       jvm212:
         dependencies: com.chuusai::shapeless:2.3.7
+        sources: ./src/main/scala-2.13-
       jvm213:
         dependencies: com.chuusai::shapeless:2.3.7
+        sources: ./src/main/scala-2.13+
+      jvm3:
+        sources: ./src/main/scala-2.13+
     dependencies: org.tpolecat::typename:1.0.0
     dependsOn: free
     extends:

--- a/snapshot-tests/http4s/.bleep/.bloop/async-http-client-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/async-http-client-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/async-http-client-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/async-http-client-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/async-http-client-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/async-http-client-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/async-http-client@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/async-http-client@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/async-http-client@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/async-http-client@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/async-http-client@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/async-http-client/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/async-http-client@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/bench@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/bench@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/bench/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/bench/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/bench/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/bench/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/bench@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/bench@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/bench@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/bench/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/bench/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/bench/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/bench/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/bench@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-client-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-client-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-client-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-client-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-client-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-client-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-client@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-client@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-client@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-client@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-client@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-client/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-client@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-core-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-core-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-core-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-core-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-core-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-core-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-core@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-core@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-core@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-core@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-core@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-core/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-core@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-server-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-server-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-server-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-server-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-server-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-server-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-server@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-server@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-server@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/blaze-server@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/blaze-server@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/blaze-server/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/blaze-server@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/boopickle-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/boopickle-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/boopickle-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/boopickle-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/boopickle-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/boopickle-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/boopickle-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/boopickle-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/boopickle-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/boopickle-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/boopickle-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/boopickle-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/boopickle@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/boopickle@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/boopickle@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/boopickle@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/boopickle@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/boopickle@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/boopickle@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/boopickle@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/boopickle@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/boopickle@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/boopickle@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/.jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/boopickle/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/boopickle@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/circe-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/circe-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/circe-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/circe-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/circe-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/circe-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/circe-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/circe-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/circe-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/circe-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/circe-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/circe-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/circe@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/circe@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/circe@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/circe@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/circe@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/circe@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/circe@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/circe@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/circe@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/circe@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/circe@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/.jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/circe/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/circe@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/client-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/client-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/client-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/client-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/client-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/client-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/client-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/client-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/client-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/client-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/client-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/client-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/client@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/client@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/client@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/client@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/client@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/client@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/client@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/client@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/client@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/client@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/client@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/client/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/client@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/core@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/core@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/core/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/core@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/core@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/core@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/core/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/core@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/core@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/core@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/core/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/core@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/core@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/core@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/core/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/core/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/core@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/dropwizard-metrics-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dropwizard-metrics-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dropwizard-metrics-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/dropwizard-metrics-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dropwizard-metrics-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dropwizard-metrics-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/dropwizard-metrics@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dropwizard-metrics@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dropwizard-metrics@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/dropwizard-metrics@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dropwizard-metrics@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dropwizard-metrics/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dropwizard-metrics@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/dsl-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dsl-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dsl-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/dsl-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dsl-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dsl-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/dsl-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dsl-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dsl-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/dsl-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dsl-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dsl-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/dsl@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dsl@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dsl@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/dsl@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dsl@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dsl@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/dsl@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dsl@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dsl@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/dsl@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/dsl@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/.jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/dsl/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/dsl@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-client-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-client-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-client-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-client-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-client-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-client-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-client-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-client-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-client-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-client-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-client-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-client-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-client@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-client@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-client@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-client@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-client@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-client@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-client@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-client@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-client@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-client@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-client@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-client/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-client@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-core-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-core-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-core-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-core-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-core-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-core-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-core-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-core-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-core-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-core-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-core-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-core-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-core@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-core@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-core@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-core@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-core@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-core@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-core@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-core@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-core@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-core@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-core@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-core/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-core@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-server-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-server-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-server-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-server-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-server-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-server-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-server-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-server-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-server-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-server-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-server-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-server-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-server@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-server@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-server@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-server@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-server@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-server@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-server@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-server@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-server@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/ember-server@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/ember-server@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/ember-server/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/ember-server@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-blaze@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-blaze@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/blaze/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/blaze/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/blaze/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/blaze/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-blaze@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-blaze@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-blaze@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/blaze/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/blaze/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/blaze/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/blaze/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-blaze@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-docker@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-docker@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/docker/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/docker/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/docker/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/docker/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-docker@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-docker@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-docker@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/docker/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/docker/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/docker/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/docker/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-docker@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-ember-client-h2@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-ember-client-h2@js213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-client-h2/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-client-h2/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-client-h2/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-client-h2/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-ember-client-h2@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-ember-client-h2@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-ember-client-h2@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-client-h2/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-client-h2/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-client-h2/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-client-h2/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-ember-client-h2@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-ember-server-h2@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-ember-server-h2@js213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-server-h2/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-server-h2/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-server-h2/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-server-h2/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-ember-server-h2@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-ember-server-h2@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-ember-server-h2@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-server-h2/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-server-h2/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-server-h2/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember-server-h2/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-ember-server-h2@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-ember@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-ember@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-ember@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-ember@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-ember@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/ember/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-ember@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-jetty@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-jetty@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/jetty/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/jetty/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/jetty/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/jetty/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-jetty@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-jetty@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-jetty@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/jetty/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/jetty/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/jetty/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/jetty/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-jetty@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-tomcat@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-tomcat@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/tomcat/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/tomcat/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/tomcat/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/tomcat/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-tomcat@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-tomcat@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-tomcat@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/tomcat/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/tomcat/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/tomcat/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/tomcat/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-tomcat@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-war@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-war@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/war/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/war/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/war/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/war/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-war@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples-war@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples-war@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/war/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/war/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/war/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/war/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples-war@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/examples@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/examples@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/examples@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/examples/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/examples@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/jawn-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jawn-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jawn-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/jawn-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jawn-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jawn-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/jawn-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jawn-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jawn-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/jawn-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jawn-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jawn-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/jawn@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jawn@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jawn@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/jawn@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jawn@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jawn@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/jawn@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jawn@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jawn@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/jawn@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jawn@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/.jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jawn/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jawn@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/jetty-client-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jetty-client-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jetty-client-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/jetty-client-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jetty-client-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jetty-client-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/jetty-client@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jetty-client@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jetty-client@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/jetty-client@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jetty-client@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-client/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jetty-client@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/jetty-server-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jetty-server-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jetty-server-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/jetty-server-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jetty-server-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jetty-server-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/jetty-server@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jetty-server@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jetty-server@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/jetty-server@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/jetty-server@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/jetty-server/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/jetty-server@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/laws@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/laws@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/laws@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/laws@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/laws@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/laws@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/laws@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/laws@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/laws@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/laws@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/laws@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/.jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/laws/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/laws@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/node-serverless@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/node-serverless@js213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/node-serverless/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/node-serverless/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/node-serverless/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/node-serverless/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/node-serverless@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/node-serverless@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/node-serverless@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/node-serverless/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/node-serverless/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/node-serverless/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/node-serverless/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/node-serverless@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/okhttp-client-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/okhttp-client-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/okhttp-client-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/okhttp-client-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/okhttp-client-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/okhttp-client-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/okhttp-client@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/okhttp-client@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/okhttp-client@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/okhttp-client@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/okhttp-client@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/okhttp-client/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/okhttp-client@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/play-json-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/play-json-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/play-json-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/play-json-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/play-json-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/play-json-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/play-json@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/play-json@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/play-json@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/play-json@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/play-json@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/play-json/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/play-json@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/prometheus-metrics-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/prometheus-metrics-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/prometheus-metrics-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/prometheus-metrics-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/prometheus-metrics-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/prometheus-metrics-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/prometheus-metrics@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/prometheus-metrics@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/prometheus-metrics@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/prometheus-metrics@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/prometheus-metrics@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/prometheus-metrics/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/prometheus-metrics@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/scala-xml-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scala-xml-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scala-xml-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/scala-xml-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scala-xml-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scala-xml-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/scala-xml@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scala-xml@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scala-xml@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/scala-xml@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scala-xml@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scala-xml/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scala-xml@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalInput@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalInput@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/input/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/input/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/input/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/input/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalafixInternalInput@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalInput@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalInput@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/input/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/input/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/input/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/input/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalafixInternalInput@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalOutput@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalOutput@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/output/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/output/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/output/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/output/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalafixInternalOutput@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalOutput@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalOutput@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/output/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/output/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/output/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/output/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalafixInternalOutput@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalRules.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalRules.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/rules/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/rules/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/rules/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/rules/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalafixInternalRules"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalTests-test.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalafixInternalTests-test.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/tests/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/tests/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/tests/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalafix-internal/tests/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalafixInternalTests-test"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/scalatags-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalatags-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalatags-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/scalatags-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalatags-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalatags-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/scalatags@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalatags@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalatags@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/scalatags@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/scalatags@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/scalatags/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/scalatags@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/server-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/server-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/server-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/server-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/server-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/server-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/server-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/server-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/server-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/server-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/server-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/server-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/server@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/server@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/server@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/server@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/server@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/js/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/server@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/server@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/server@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/server@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/server@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/server@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/jvm/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/server/shared/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/server@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/servlet-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/servlet-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/servlet-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/servlet-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/servlet-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/servlet-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/servlet@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/servlet@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/servlet@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/servlet@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/servlet@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/servlet/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/servlet@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/testing-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/testing-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/testing-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/testing-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/testing-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/testing-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/testing-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/testing-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/testing-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/testing-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/testing-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/testing/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/testing-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/tests-test@js213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/tests-test@js213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/js/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/js/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/js/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/tests-test@js213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/tests-test@js3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/tests-test@js3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/js/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/js/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/js/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/js/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/tests-test@js3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/tests-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/tests-test@jvm213.json
@@ -9,12 +9,10 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/jvm/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/jvm/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/jvm/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/tests-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/tests-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/tests-test@jvm3.json
@@ -7,11 +7,9 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/jvm/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/jvm/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/jvm/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/jvm/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tests/shared/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/tests-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/tomcat-server-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/tomcat-server-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/tomcat-server-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/tomcat-server-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/tomcat-server-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/tomcat-server-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/tomcat-server@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/tomcat-server@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/tomcat-server@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/tomcat-server@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/tomcat-server@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/tomcat-server/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/tomcat-server@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/twirl-test@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/twirl-test@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/test/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/test/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/test/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/twirl-test@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/twirl-test@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/twirl-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/twirl-test@jvm3"
     ],

--- a/snapshot-tests/http4s/.bleep/.bloop/twirl@jvm213.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/twirl@jvm213.json
@@ -9,7 +9,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/main/scala",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/main/scala-2",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/main/scala-2.13",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/twirl@jvm213"
     ],
     "dependencies": [

--- a/snapshot-tests/http4s/.bleep/.bloop/twirl@jvm3.json
+++ b/snapshot-tests/http4s/.bleep/.bloop/twirl@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/http4s/twirl/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests/http4s/.bleep/generated-sources/twirl@jvm3"
     ],

--- a/snapshot-tests/http4s/bleep.yaml
+++ b/snapshot-tests/http4s/bleep.yaml
@@ -757,7 +757,7 @@ templates:
   template-scala-2-js:
     extends: template-js
     scala:
-      options: -P:scala${PLATFORM}:mapSourceURI:file:${BUILD_DIR}/->https://raw.githubusercontent.com/http4s/http4s/bc0662792fd0c4d8462c247f634c01fee0dd5712/
+      options: -P:scalajs:mapSourceURI:file:${BUILD_DIR}/->https://raw.githubusercontent.com/http4s/http4s/bc0662792fd0c4d8462c247f634c01fee0dd5712/
   template-scala-2.13-js:
     extends:
     - template-scala-2
@@ -768,14 +768,14 @@ templates:
     - template-scala-2
   template-scala-3:
     scala:
-      options: -Ykind-projector -language:implicitConversions -source:${SCALA_BIN_VERSION}.0-migration
+      options: -Ykind-projector -language:implicitConversions -source:3.0-migration
       version: 3.1.1
   template-scala-3-js:
     extends:
     - template-js
     - template-scala-3
     scala:
-      options: -scala${PLATFORM} -scala${PLATFORM}-mapSourceURI:file:${BUILD_DIR}/->https://raw.githubusercontent.com/http4s/http4s/bc0662792fd0c4d8462c247f6${SCALA_BIN_VERSION}4c01fee0dd5712/
+      options: -scalajs -scalajs-mapSourceURI:file:${BUILD_DIR}/->https://raw.githubusercontent.com/http4s/http4s/bc0662792fd0c4d8462c247f634c01fee0dd5712/
   template-scala-3-jvm:
     extends:
     - template-jvm

--- a/snapshot-tests/tapir/.bleep/.bloop/apispecDocs@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/apispecDocs@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/apispec-docs/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/apispec-docs/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/apispec-docs/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/apispec-docs/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/apispec-docs/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/apispec-docs/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/apispecModel@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/apispecModel@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/apispec-model/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/apispec-model/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/apispec-model/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/apispec-model/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/apispec-model/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/apispec-model/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/asyncapiCirce@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/asyncapiCirce@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/asyncapiCirceYaml@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/asyncapiCirceYaml@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe-yaml/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe-yaml/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe-yaml/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe-yaml/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe-yaml/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-circe-yaml/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/asyncapiModel@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/asyncapiModel@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-model/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-model/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-model/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-model/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-model/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/asyncapi-model/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/awsLambda-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/awsLambda-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/awsLambda@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/awsLambda@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/lambda/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/awsSam-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/awsSam-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/awsSam@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/awsSam@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/serverless/aws/sam/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/cats-test@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/cats-test@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/cats-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/cats-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/cats@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/cats@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/cats@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/cats@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/cats/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/circeJson-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/circeJson-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/circeJson@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/circeJson@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/circeJson@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/circeJson@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/circe/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/clientTestServer@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/clientTestServer@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/testserver/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/testserver/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/testserver/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/testserver/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/testserver/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/testserver/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/clientTests@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/clientTests@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/clientTests@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/clientTests@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/tests/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/core-test@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/core-test@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/core-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/core-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/core@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/core@js3.json
@@ -8,7 +8,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/boilerplate-gen",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/core@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/core@jvm3.json
@@ -8,7 +8,6 @@
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/boilerplate-gen",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/core/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/http4sClient-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/http4sClient-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/http4sClient@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/http4sClient@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/http4s-client/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/http4sServer-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/http4sServer-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/http4sServer@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/http4sServer@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/http4s-server/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/nettyServer-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/nettyServer-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/nettyServer@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/nettyServer@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/netty-server/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/openapiCirce@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/openapiCirce@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/openapiCirceYaml@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/openapiCirceYaml@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe-yaml/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe-yaml/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe-yaml/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe-yaml/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe-yaml/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-circe-yaml/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/openapiDocs-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/openapiDocs-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/openapiDocs@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/openapiDocs@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/openapi-docs/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/openapiModel-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/openapiModel-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/openapiModel@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/openapiModel@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/apispec/openapi-model/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/opentelemetryMetrics-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/opentelemetryMetrics-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/opentelemetryMetrics@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/opentelemetryMetrics@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/opentelemetry-metrics/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/prometheusMetrics-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/prometheusMetrics-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/prometheusMetrics@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/prometheusMetrics@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/metrics/prometheus-metrics/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/redoc@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/redoc@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/redocBundle@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/redocBundle@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc-bundle/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc-bundle/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc-bundle/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc-bundle/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc-bundle/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/redoc-bundle/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/serverTests@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/serverTests@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/tests/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/tests/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/tests/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/tests/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/tests/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/tests/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/sttpClient-test@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/sttpClient-test@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/sttpClient-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/sttpClient-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/sttpClient@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/sttpClient@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/sttpClient@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/sttpClient@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/client/sttp-client/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/sttpStubServer-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/sttpStubServer-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/sttpStubServer@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/sttpStubServer@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/sttp-stub-server/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/swaggerUi@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/swaggerUi@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/swaggerUiBundle-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/swaggerUiBundle-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/swaggerUiBundle@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/swaggerUiBundle@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/docs/swagger-ui-bundle/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/tests@js3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/tests@js3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scalajs",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scalajs-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/tests@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/tests@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/tests/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/vertxServer-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/vertxServer-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/vertxServer@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/vertxServer@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/vertx/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/zio-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/zio-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/zio@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/zio@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/integrations/zio/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/zioHttp4sServer-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/zioHttp4sServer-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/zioHttp4sServer@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/zioHttp4sServer@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http4s-server/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/zioHttpServer-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/zioHttpServer-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/zioHttpServer@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/zioHttpServer@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/server/zio-http-server/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/zioJson-test@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/zioJson-test@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/test/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/test/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/test/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/test/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/test/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/test/scalajvm-3",

--- a/snapshot-tests/tapir/.bleep/.bloop/zioJson@jvm3.json
+++ b/snapshot-tests/tapir/.bleep/.bloop/zioJson@jvm3.json
@@ -7,7 +7,6 @@
     "sources": [
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/main/java",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/main/scala",
-      "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/main/scala-2.13+",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/main/scala-3",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/main/scalajvm",
       "<BLEEP_GIT>/snapshot-tests-in/tapir/json/zio/src/main/scalajvm-3",

--- a/snapshot-tests/tapir/bleep.yaml
+++ b/snapshot-tests/tapir/bleep.yaml
@@ -2,6 +2,11 @@ $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
 $version: testing
 projects:
   akkaHttpServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - com.softwaremill.sttp.shared::akka:1.2.7
     - com.typesafe.akka::akka-http:10.2.7
@@ -12,6 +17,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/akka-http-server
   akkaHttpServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: com.softwaremill.sttp.client3::akka-http-backend:3.3.18
     dependsOn:
     - akkaHttpServer
@@ -21,6 +31,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/akka-http-server
   apispecDocs:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependsOn:
     - apispecModel
     - core
@@ -30,12 +45,22 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/docs/apispec-docs
   apispecModel:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     extends:
     - template-common-main
     - template-cross-jvm-212-213
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/apispec/apispec-model
   asyncapiCirce:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - io.circe::circe-core:0.14.1
     - io.circe::circe-generic:0.14.1
@@ -47,6 +72,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/apispec/asyncapi-circe
   asyncapiCirceYaml:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: io.circe::circe-yaml:0.14.1
     dependsOn: asyncapiCirce
     extends:
@@ -55,6 +85,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/apispec/asyncapi-circe-yaml
   asyncapiDocs:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependsOn:
     - apispecDocs
     - asyncapiModel
@@ -63,6 +98,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/docs/asyncapi-docs
   asyncapiDocs-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - com.softwaremill.sttp.shared::akka:1.2.7
     - com.typesafe.akka::akka-stream:2.6.17
@@ -75,6 +115,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/docs/asyncapi-docs
   asyncapiModel:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependsOn: apispecModel
     extends:
     - template-common-main
@@ -83,16 +128,22 @@ projects:
     folder: ./../../snapshot-tests-in/tapir/apispec/asyncapi-model
   awsExamples:
     cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
       jvm212:
         dependencies: com.amazonaws:aws-lambda-java-runtime-interface-client:2.0.0
         dependsOn:
         - awsSam
         - awsTerraform
+        sources: ./src/main/scala-2.13-
       jvm213:
         dependencies: com.amazonaws:aws-lambda-java-runtime-interface-client:2.0.0
         dependsOn:
         - awsSam
         - awsTerraform
+        sources: ./src/main/scala-2.13+
     dependencies: com.softwaremill.sttp.client3::cats:3.3.18
     dependsOn: awsLambda
     extends:
@@ -102,9 +153,17 @@ projects:
   awsLambda:
     cross:
       js212:
-        sources: ./src/main/scalajvm-2
+        sources:
+        - ./src/main/scala-2.13-
+        - ./src/main/scalajvm-2
       js213:
-        sources: ./src/main/scalajvm-2
+        sources:
+        - ./src/main/scala-2.13+
+        - ./src/main/scalajvm-2
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - ch.qos.logback:logback-classic:1.2.7
     - ch.qos.logback:logback-core:1.2.7
@@ -120,6 +179,11 @@ projects:
     - template-cross-jvm-all-js-212-213
     folder: ./../../snapshot-tests-in/tapir/serverless/aws/lambda
   awsLambda-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - awsLambda
     - tests
@@ -129,6 +193,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/serverless/aws/lambda
   awsLambdaTests:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: com.amazonaws:aws-lambda-java-runtime-interface-client:2.0.0
     dependsOn:
     - awsLambda
@@ -140,12 +209,22 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/serverless/aws/lambda-tests
   awsLambdaTests-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn: awsLambdaTests
     extends:
     - template-common-test
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/serverless/aws/lambda-tests
   awsSam:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - io.circe::circe-generic:0.14.1
     - io.circe::circe-yaml:0.14.1
@@ -156,6 +235,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/serverless/aws/sam
   awsSam-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - awsSam
     - tests
@@ -165,6 +249,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/serverless/aws/sam
   awsTerraform:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - io.circe::circe-generic:0.14.1
     - io.circe::circe-literal:0.14.1
@@ -176,6 +265,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/serverless/aws/terraform
   awsTerraform-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - awsTerraform
     - tests
@@ -184,6 +278,15 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/serverless/aws/terraform
   cats:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - org.typelevel::cats-core:2.7.0
     - org.typelevel::cats-effect:3.3.0
@@ -196,12 +299,18 @@ projects:
     cross:
       js212:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13-
       js213:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13+
       js3:
         dependencies:
         - io.github.cquiroz::scala-java-time:2.3.0
         - org.scala-js:scalajs-test-bridge_2.13:1.8.0
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - org.scalacheck::scalacheck:1.15.4
     - org.scalatest::scalatest:3.2.10
@@ -214,6 +323,15 @@ projects:
     - template-cross-all
     folder: ./../../snapshot-tests-in/tapir/integrations/cats
   circeJson:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - io.circe::circe-core:0.14.1
     - io.circe::circe-generic:0.14.1
@@ -224,6 +342,11 @@ projects:
     - template-cross-all
     folder: ./../../snapshot-tests-in/tapir/json/circe
   circeJson-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: circeJson
     extends:
@@ -232,6 +355,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/json/circe
   clientTestServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - ch.qos.logback:logback-classic:1.2.7
     - ch.qos.logback:logback-core:1.2.7
@@ -247,11 +375,19 @@ projects:
   clientTests:
     cross:
       js212:
-        sources: ./src/main/scalajvm-2
+        sources:
+        - ./src/main/scala-2.13-
+        - ./src/main/scalajvm-2
       js213:
-        sources: ./src/main/scalajvm-2
+        sources:
+        - ./src/main/scala-2.13+
+        - ./src/main/scalajvm-2
       js3:
-        sources: ./src/main/scalajvm-${SCALA_BIN_VERSION}
+        sources: ./src/main/scalajvm-3
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - forceJvm: true
       module: org.http4s::http4s-blaze-server:0.23.7
@@ -272,12 +408,14 @@ projects:
         - org.scala-js::scalajs-dom:2.0.0
         - configuration: provided
           module: org.scala-lang:scala-reflect:2.12.15
+        sources: ./src/main/scala-2.13-
       js213:
         dependencies:
         - com.propensive::magnolia:0.17.0
         - org.scala-js::scalajs-dom:2.0.0
         - configuration: provided
           module: org.scala-lang:scala-reflect:2.13.6
+        sources: ./src/main/scala-2.13+
       js3:
         dependencies:
         - com.softwaremill.magnolia1_3::magnolia:1.0.0-M7
@@ -287,11 +425,13 @@ projects:
         - com.propensive::magnolia:0.17.0
         - configuration: provided
           module: org.scala-lang:scala-reflect:2.12.15
+        sources: ./src/main/scala-2.13-
       jvm213:
         dependencies:
         - com.propensive::magnolia:0.17.0
         - configuration: provided
           module: org.scala-lang:scala-reflect:2.13.6
+        sources: ./src/main/scala-2.13+
       jvm3:
         dependencies: com.softwaremill.magnolia1_3::magnolia:1.0.0-M7
     dependencies:
@@ -312,6 +452,7 @@ projects:
         - io.github.cquiroz::scala-java-time:2.3.0
         - configuration: provided
           module: org.scala-lang:scala-reflect:2.12.15
+        sources: ./src/test/scala-2.13-
       js213:
         dependencies:
         - com.47deg::scalacheck-toolbox-datetime:0.6.0
@@ -319,6 +460,7 @@ projects:
         - io.github.cquiroz::scala-java-time:2.3.0
         - configuration: provided
           module: org.scala-lang:scala-reflect:2.13.6
+        sources: ./src/test/scala-2.13+
       js3:
         dependencies:
         - io.github.cquiroz::scala-java-time-tzdb:2.3.0
@@ -329,11 +471,13 @@ projects:
         - com.47deg::scalacheck-toolbox-datetime:0.6.0
         - configuration: provided
           module: org.scala-lang:scala-reflect:2.12.15
+        sources: ./src/test/scala-2.13-
       jvm213:
         dependencies:
         - com.47deg::scalacheck-toolbox-datetime:0.6.0
         - configuration: provided
           module: org.scala-lang:scala-reflect:2.13.6
+        sources: ./src/test/scala-2.13+
     dependencies:
     - org.scalacheck::scalacheck:1.15.4
     - org.scalatest::scalatest:3.2.10
@@ -351,12 +495,14 @@ projects:
           module: org.scala-lang:scala-reflect:2.12.15
         scala:
           compilerPlugins: org.scalamacros:::paradise:2.1.1
+        sources: ./src/main/scala-2.13-
       jvm213:
         dependencies:
           configuration: provided
           module: org.scala-lang:scala-reflect:2.13.6
         scala:
           options: -Ymacro-annotations
+        sources: ./src/main/scala-2.13+
     dependencies: tf.tofu::derevo-core:0.12.8
     dependsOn: newtype
     extends:
@@ -371,12 +517,14 @@ projects:
           module: org.scala-lang:scala-reflect:2.12.15
         scala:
           compilerPlugins: org.scalamacros:::paradise:2.1.1
+        sources: ./src/test/scala-2.13-
       jvm213:
         dependencies:
           configuration: provided
           module: org.scala-lang:scala-reflect:2.13.6
         scala:
           options: -Ymacro-annotations
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: derevo
     extends:
@@ -384,6 +532,15 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/integrations/derevo
   enumeratum:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: com.beachape::enumeratum:1.7.0
     dependsOn: core
     extends:
@@ -394,8 +551,14 @@ projects:
     cross:
       js212:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13-
       js213:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13+
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: enumeratum
     extends:
@@ -431,7 +594,13 @@ projects:
     - template-common-main
     - template-scala-2.13-jvm
     folder: ./../../snapshot-tests-in/tapir/examples
+    sources: ./src/main/scala-2.13+
   finatraServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - com.twitter::finatra-http:21.2.0
     - org.apache.httpcomponents:httpmime:4.5.13
@@ -441,6 +610,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/finatra-server
   finatraServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - module: com.twitter::finatra-http:21.2.0
       publication:
@@ -484,6 +658,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/finatra-server
   finatraServerCats:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: org.typelevel::cats-effect:3.3.0
     dependsOn: finatraServer
     extends:
@@ -491,6 +670,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/finatra-server/finatra-server-cats
   finatraServerCats-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - finatraServer-test
     - finatraServerCats
@@ -499,6 +683,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/finatra-server/finatra-server-cats
   http4sClient:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - configuration: optional
       module: com.softwaremill.sttp.shared::fs2:1.2.7
@@ -510,6 +699,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/client/http4s-client
   http4sClient-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - configuration: optional
       module: com.softwaremill.sttp.shared::fs2:1.2.7
@@ -523,6 +717,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/client/http4s-client
   http4sServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - com.softwaremill.sttp.shared::fs2:1.2.7
     - org.http4s::http4s-blaze-server:0.23.7
@@ -533,6 +732,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/http4s-server
   http4sServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - http4sServer
     - serverTests
@@ -542,6 +746,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/http4s-server
   json4s:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: org.json4s::json4s-core:4.0.3
     dependsOn: core
     extends:
@@ -549,6 +758,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/json/json4s
   json4s-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - org.json4s::json4s-jackson:4.0.3
     - org.scalatest::scalatest:3.2.10
@@ -558,6 +772,15 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/json/json4s
   jsoniterScala:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.12.0
     dependsOn: core
     extends:
@@ -565,6 +788,15 @@ projects:
     - template-cross-jvm-212-213-js-212-213
     folder: ./../../snapshot-tests-in/tapir/json/jsoniter
   jsoniterScala-test:
+    cross:
+      js212:
+        sources: ./src/test/scala-2.13-
+      js213:
+        sources: ./src/test/scala-2.13+
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.12.0
     - org.scalatest::scalatest:3.2.10
@@ -574,6 +806,11 @@ projects:
     - template-cross-jvm-212-213-js-212-213
     folder: ./../../snapshot-tests-in/tapir/json/jsoniter
   nettyServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - ch.qos.logback:logback-classic:1.2.7
     - ch.qos.logback:logback-core:1.2.7
@@ -588,6 +825,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/netty-server
   nettyServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
       configuration: optional
       module: com.softwaremill.sttp.shared::fs2:1.2.7
@@ -604,15 +846,19 @@ projects:
       js212:
         scala:
           compilerPlugins: org.scalamacros:::paradise:2.1.1
+        sources: ./src/main/scala-2.13-
       js213:
         scala:
           options: -Ymacro-annotations
+        sources: ./src/main/scala-2.13+
       jvm212:
         scala:
           compilerPlugins: org.scalamacros:::paradise:2.1.1
+        sources: ./src/main/scala-2.13-
       jvm213:
         scala:
           options: -Ymacro-annotations
+        sources: ./src/main/scala-2.13+
     dependencies: io.estatico::newtype:0.4.4
     dependsOn: core
     extends:
@@ -624,15 +870,19 @@ projects:
       js212:
         scala:
           compilerPlugins: org.scalamacros:::paradise:2.1.1
+        sources: ./src/test/scala-2.13-
       js213:
         scala:
           options: -Ymacro-annotations
+        sources: ./src/test/scala-2.13+
       jvm212:
         scala:
           compilerPlugins: org.scalamacros:::paradise:2.1.1
+        sources: ./src/test/scala-2.13-
       jvm213:
         scala:
           options: -Ymacro-annotations
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: newtype
     extends:
@@ -640,6 +890,11 @@ projects:
     - template-cross-jvm-212-213-js-212-213
     folder: ./../../snapshot-tests-in/tapir/integrations/newtype
   openapiCirce:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - io.circe::circe-core:0.14.1
     - io.circe::circe-generic:0.14.1
@@ -651,6 +906,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/apispec/openapi-circe
   openapiCirceYaml:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: io.circe::circe-yaml:0.14.1
     dependsOn: openapiCirce
     extends:
@@ -671,7 +931,9 @@ projects:
     folder: ./../../snapshot-tests-in/tapir/sbt/sbt-openapi-codegen
     scala:
       options: -Wconf:cat=unused-nowarn:s
-    sources: ./src/main/scala-sbt-1.0
+    sources:
+    - ./src/main/scala-2.13-
+    - ./src/main/scala-sbt-1.0
   openapiCodegen-test:
     dependencies:
     - com.47deg::scalacheck-toolbox-datetime:0.6.0
@@ -690,13 +952,17 @@ projects:
     folder: ./../../snapshot-tests-in/tapir/sbt/sbt-openapi-codegen
     scala:
       options: -Wconf:cat=unused-nowarn:s
-    sources: ./src/test/scala-sbt-1.0
+    sources:
+    - ./src/test/scala-2.13-
+    - ./src/test/scala-sbt-1.0
   openapiDocs:
     cross:
       jvm212:
         dependsOn: enumeratum
+        sources: ./src/main/scala-2.13-
       jvm213:
         dependsOn: enumeratum
+        sources: ./src/main/scala-2.13+
     dependsOn:
     - apispecDocs
     - openapiModel
@@ -706,6 +972,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/docs/openapi-docs
   openapiDocs-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - openapiCirceYaml
     - openapiDocs
@@ -716,6 +987,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/docs/openapi-docs
   openapiModel:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependsOn: apispecModel
     extends:
     - template-common-main
@@ -723,6 +999,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/apispec/openapi-model
   openapiModel-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: openapiModel
     extends:
@@ -731,6 +1012,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/apispec/openapi-model
   opentelemetryMetrics:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - io.opentelemetry:opentelemetry-api:1.9.1
     - io.opentelemetry:opentelemetry-sdk:1.9.1
@@ -741,6 +1027,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/metrics/opentelemetry-metrics
   opentelemetryMetrics-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: io.opentelemetry:opentelemetry-sdk-metrics:1.5.0-alpha
     dependsOn:
     - core-test
@@ -751,6 +1042,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/metrics/opentelemetry-metrics
   playClient:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - configuration: optional
       module: com.softwaremill.sttp.shared::akka:1.2.7
@@ -763,6 +1059,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/client/play-client
   playClient-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - configuration: optional
       module: com.softwaremill.sttp.shared::akka:1.2.7
@@ -776,6 +1077,15 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/client/play-client
   playJson:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: com.typesafe.play::play-json:2.9.2
     dependsOn: core
     extends:
@@ -786,8 +1096,14 @@ projects:
     cross:
       js212:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13-
       js213:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13+
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: playJson
     extends:
@@ -795,6 +1111,11 @@ projects:
     - template-cross-jvm-212-213-js-212-213
     folder: ./../../snapshot-tests-in/tapir/json/playjson
   playServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - com.softwaremill.sttp.shared::akka:1.2.7
     - com.typesafe.play::play-akka-http-server:2.8.7
@@ -806,6 +1127,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/play-server
   playServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - playServer
     - serverTests
@@ -814,6 +1140,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/play-server
   prometheusMetrics:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: io.prometheus:simpleclient_common:0.12.0
     dependsOn: core
     extends:
@@ -822,6 +1153,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/metrics/prometheus-metrics
   prometheusMetrics-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - core-test
     - prometheusMetrics
@@ -831,6 +1167,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/metrics/prometheus-metrics
   redoc:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependsOn: core
     extends:
     - template-common-main
@@ -838,6 +1179,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/docs/redoc
   redocBundle:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependsOn:
     - openapiCirceYaml
     - openapiDocs
@@ -848,6 +1194,15 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/docs/redoc-bundle
   refined:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: eu.timepit::refined:0.9.28
     dependsOn: core
     extends:
@@ -858,8 +1213,14 @@ projects:
     cross:
       js212:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13-
       js213:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13+
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - io.circe::circe-refined:0.14.1
     - org.scalatest::scalatest:3.2.10
@@ -871,6 +1232,11 @@ projects:
     - template-cross-jvm-212-213-js-212-213
     folder: ./../../snapshot-tests-in/tapir/integrations/refined
   serverTests:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: com.softwaremill.sttp.client3::httpclient-backend-fs2:3.3.18
     dependsOn: tests
     extends:
@@ -879,6 +1245,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/tests
   sprayJson:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: io.spray::spray-json:1.3.6
     dependsOn: core
     extends:
@@ -886,6 +1257,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/json/sprayjson
   sprayJson-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: sprayJson
     extends:
@@ -894,6 +1270,10 @@ projects:
     folder: ./../../snapshot-tests-in/tapir/json/sprayjson
   sttpClient:
     cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
       jvm212:
         dependencies:
         - configuration: optional
@@ -904,6 +1284,7 @@ projects:
           module: com.softwaremill.sttp.shared::zio:1.2.7
         - configuration: optional
           module: com.typesafe.akka::akka-stream:2.6.17
+        sources: ./src/main/scala-2.13-
       jvm213:
         dependencies:
         - configuration: optional
@@ -914,6 +1295,7 @@ projects:
           module: com.softwaremill.sttp.shared::zio:1.2.7
         - configuration: optional
           module: com.typesafe.akka::akka-stream:2.6.17
+        sources: ./src/main/scala-2.13+
       jvm3:
         dependencies:
         - configuration: optional
@@ -930,8 +1312,10 @@ projects:
     cross:
       js212:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13-
       js213:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13+
       js3:
         dependencies:
         - io.github.cquiroz::scala-java-time:2.3.0
@@ -950,6 +1334,7 @@ projects:
           module: com.softwaremill.sttp.shared::zio:1.2.7
         - configuration: optional
           module: com.typesafe.akka::akka-stream:2.6.17
+        sources: ./src/test/scala-2.13-
       jvm213:
         dependencies:
         - com.softwaremill.sttp.client3::akka-http-backend:3.3.18
@@ -964,6 +1349,7 @@ projects:
           module: com.softwaremill.sttp.shared::zio:1.2.7
         - configuration: optional
           module: com.typesafe.akka::akka-stream:2.6.17
+        sources: ./src/test/scala-2.13+
       jvm3:
         dependencies:
         - forceJvm: true
@@ -981,6 +1367,11 @@ projects:
     - template-cross-all
     folder: ./../../snapshot-tests-in/tapir/client/sttp-client
   sttpMockServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - io.circe::circe-core:0.14.1
     - io.circe::circe-generic:0.14.1
@@ -991,6 +1382,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/sttp-mock-server
   sttpMockServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: io.circe::circe-literal:0.14.1
     dependsOn:
     - serverTests
@@ -1000,6 +1396,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/server/sttp-mock-server
   sttpStubServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependsOn: sttpClient
     extends:
     - template-common-main
@@ -1007,6 +1408,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/sttp-stub-server
   sttpStubServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - serverTests
     - sttpStubServer
@@ -1016,6 +1422,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/sttp-stub-server
   swaggerUi:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: org.webjars:swagger-ui:4.1.3
     dependsOn: core
     extends:
@@ -1024,6 +1435,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/docs/swagger-ui
   swaggerUiBundle:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependsOn:
     - openapiCirceYaml
     - openapiDocs
@@ -1034,6 +1450,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/docs/swagger-ui-bundle
   swaggerUiBundle-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn:
     - http4sServer
@@ -1045,6 +1466,15 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/docs/swagger-ui-bundle
   tests:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - ch.qos.logback:logback-classic:1.2.7
     - ch.qos.logback:logback-core:1.2.7
@@ -1060,6 +1490,11 @@ projects:
     - template-cross-all
     folder: ./../../snapshot-tests-in/tapir/tests
   tethysJson:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - com.tethys-json::tethys-core:0.25.0
     - com.tethys-json::tethys-jackson:0.25.0
@@ -1069,6 +1504,11 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/json/tethys
   tethysJson-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - com.tethys-json::tethys-derivation:0.25.0
     - org.scalatest::scalatest:3.2.10
@@ -1078,6 +1518,15 @@ projects:
     - template-cross-jvm-212-213
     folder: ./../../snapshot-tests-in/tapir/json/tethys
   uPickleJson:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: com.lihaoyi::upickle:1.4.3
     dependsOn: core
     extends:
@@ -1088,8 +1537,14 @@ projects:
     cross:
       js212:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13-
       js213:
         dependencies: io.github.cquiroz::scala-java-time:2.3.0
+        sources: ./src/test/scala-2.13+
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: uPickleJson
     extends:
@@ -1097,6 +1552,11 @@ projects:
     - template-cross-jvm-212-213-js-212-213
     folder: ./../../snapshot-tests-in/tapir/json/upickle
   vertxServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - configuration: optional
       module: com.softwaremill.sttp.shared::fs2:1.2.7
@@ -1110,6 +1570,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/vertx
   vertxServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - configuration: optional
       module: com.softwaremill.sttp.shared::fs2:1.2.7
@@ -1125,6 +1590,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/vertx
   zio:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
     - com.softwaremill.sttp.shared::zio:1.2.7
     - dev.zio::zio-streams:1.0.12
@@ -1136,6 +1606,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/integrations/zio
   zio-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies:
     - dev.zio::zio-test-sbt:1.0.12
     - dev.zio::zio-test:1.0.12
@@ -1147,6 +1622,11 @@ projects:
     folder: ./../../snapshot-tests-in/tapir/integrations/zio
     testFrameworks: zio.test.sbt.ZTestFramework
   zioHttp4sServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: dev.zio::zio-interop-cats:3.2.9.0
     dependsOn:
     - http4sServer
@@ -1157,6 +1637,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/zio-http4s-server
   zioHttp4sServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependsOn:
     - serverTests
     - zioHttp4sServer
@@ -1166,6 +1651,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/zio-http4s-server
   zioHttpServer:
+    cross:
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies: io.d11::zhttp:1.0.0.0-RC17
     dependsOn: zio
     extends:
@@ -1174,6 +1664,11 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/zio-http-server
   zioHttpServer-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: dev.zio::zio-interop-cats:3.2.9.0
     dependsOn:
     - serverTests
@@ -1184,6 +1679,15 @@ projects:
     - template-cross-jvm-all
     folder: ./../../snapshot-tests-in/tapir/server/zio-http-server
   zioJson:
+    cross:
+      js212:
+        sources: ./src/main/scala-2.13-
+      js213:
+        sources: ./src/main/scala-2.13+
+      jvm212:
+        sources: ./src/main/scala-2.13-
+      jvm213:
+        sources: ./src/main/scala-2.13+
     dependencies:
       forceJvm: true
       module: dev.zio::zio-json:0.2.0-M3
@@ -1193,6 +1697,11 @@ projects:
     - template-cross-jvm-all-js-212-213
     folder: ./../../snapshot-tests-in/tapir/json/zio
   zioJson-test:
+    cross:
+      jvm212:
+        sources: ./src/test/scala-2.13-
+      jvm213:
+        sources: ./src/test/scala-2.13+
     dependencies: org.scalatest::scalatest:3.2.10
     dependsOn: zioJson
     extends:
@@ -1300,7 +1809,7 @@ templates:
     - template-js
     - template-scala-3
     scala:
-      options: -scala${PLATFORM}
+      options: -scalajs
   template-scala-3-jvm:
     extends:
     - template-jvm


### PR DESCRIPTION
- revert 8e9396bc (include include src/main/scala2.13[+\-] source dirs)
- remove version replacements. this was mostly used to understand sbt matrix source layouts