### PR TITLE
Speedup CI build somewhat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
         run: cs install --channel channel bleep --verbose
 
       - name: Run tests
+        env:
+          CI: true
         run: |
           bleep generate-resources
           bleep test
@@ -74,6 +76,8 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Test binary after build (non-windows)
+        env:
+          CI: true
         run: ./${{ matrix.file_name }} --ignore-version-in-build-file test --no-color jvm213
         if: runner.os != 'Windows'
 
@@ -93,6 +97,8 @@ jobs:
 
       - name: Test binary after build (windows)
         shell: cmd
+        env:
+          CI: true
         # todo: fix tests on windows
         run: .\${{ matrix.file_name }} --ignore-version-in-build-file compile --no-color jvm213
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      # todo: this is only needed because it makes some windows development stuff available. figure out how bleep can download it itself
       - uses: graalvm/setup-graalvm@v1
+        if: runner.os == 'Windows'
         with:
           version: '22.1.0'
           java-version: '17'


### PR DESCRIPTION
the `ENV: CI` was lost at some point, and with it the sneaky coursier cache where the snapshot tests place resolving cache within the coursier folder. 

there is still more to be done here