### PR TITLE
Move implementation to BleepScriptRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ paths and so on.
 import bleep.{bootstrap, model}
 import bleep.tasks._
 
-object GenNativeImage extends App {
-  bootstrap.forScript("GenNativeImage") { started =>
+object GenNativeImage extends BleepScriptRunner("GenNativeImage") {
+  override def run(started: Started, commands: Commands, args: List[String]): Unit = {
     val projectName = model.ProjectName("myproject")
     val project = started.bloopFiles(projectName).forceGet
 

--- a/bleep-cli/src/scala/bleep/internal/GeneratedFilesScript.scala
+++ b/bleep-cli/src/scala/bleep/internal/GeneratedFilesScript.scala
@@ -130,8 +130,8 @@ package scripts
 
 import java.nio.file.Files
 
-object GenerateResources extends App {
-  bleep.bootstrap.forScript("GenerateResources") { (started, commands) =>
+object GenerateResources extends BleepScriptRunner("GenerateResources") {
+  def run(started: Started, commands: Commands, args: List[String]): Unit = {
     started.logger.error("This script is a placeholder! You'll need to replace the contents with code which actually generates the files you want")
 
     ${copies.mkString("\n\n")}

--- a/bleep-tasks/src/scala/bleep/BleepScript.scala
+++ b/bleep-tasks/src/scala/bleep/BleepScript.scala
@@ -1,8 +1,6 @@
 package bleep
 
-abstract class BleepScript(val scriptName: String) {
-  def main(args: Array[String]): Unit =
-    bootstrap.forScript(scriptName)((started, commands) => run(started, commands, args.toList))
-
+trait BleepScript {
+  def scriptName: String
   def run(started: Started, commands: Commands, args: List[String]): Unit
 }

--- a/bleep-tasks/src/scala/bleep/BleepScriptRunner.scala
+++ b/bleep-tasks/src/scala/bleep/BleepScriptRunner.scala
@@ -1,0 +1,8 @@
+package bleep
+
+abstract class BleepScriptRunner(val scriptName: String) extends BleepScript {
+  def main(args: Array[String]): Unit =
+    bootstrap.forScript(scriptName)((started, commands) => run(started, commands, args.toList))
+
+  def run(started: Started, commands: Commands, args: List[String]): Unit
+}

--- a/scripts/src/scala/bleep/scripts/GenNativeImage.scala
+++ b/scripts/src/scala/bleep/scripts/GenNativeImage.scala
@@ -3,7 +3,7 @@ package scripts
 
 import bleep.tasks._
 
-object GenNativeImage extends BleepScript("GenNativeImage") {
+object GenNativeImage extends BleepScriptRunner("GenNativeImage") {
   def run(started: Started, commands: Commands, args: List[String]): Unit = {
     val projectName = model.CrossProjectName(model.ProjectName("bleep-cli"), crossId = None)
     val project = started.bloopProjects(projectName)

--- a/scripts/src/scala/bleep/scripts/Publish.scala
+++ b/scripts/src/scala/bleep/scripts/Publish.scala
@@ -8,7 +8,7 @@ import nosbt.InteractionService
 
 import scala.collection.immutable.SortedMap
 
-object Publish extends BleepScript("Publish") {
+object Publish extends BleepScriptRunner("Publish") {
   val groupId = "build.bleep"
 
   def run(started: Started, commands: Commands, args: List[String]): Unit = {

--- a/scripts/src/scala/bleep/scripts/PublishLocal.scala
+++ b/scripts/src/scala/bleep/scripts/PublishLocal.scala
@@ -5,7 +5,7 @@ import bleep.tasks.publishing._
 
 import scala.collection.immutable.SortedMap
 
-object PublishLocal extends BleepScript("PublishLocal") {
+object PublishLocal extends BleepScriptRunner("PublishLocal") {
   val groupId = "build.bleep"
 
   def run(started: Started, commands: Commands, args: List[String]): Unit = {


### PR DESCRIPTION
I see that you have refactored [`BleepScript` to just one class](https://github.com/oyvindberg/bleep/commit/c1b0ddb425b5d5ba6a595f798e6f4a2dc83fb9bf). Feel free to close this PR if you're happy with the current design.

But if you entertain me for a sec, I'd like to present to you the rationale for having both `BleepScript` _and_ `BleepScriptRunner`: It seemed to me a better, more future-proof design to have
 * just an interface, _unburdened by any implementation_, so that we can have a way to refer to _all_ possible plugins, e.g. `List[BleepScript]`, or `Map[String, BleepScript]`, and
 * a class to make it easier for implementers to create Bloop scripts, hence `BleepScriptRunner`

Yes, it's two classes instead of one, but the additional complexity is _very_ small, so I think it's worth having it. The benefit being more clean and future-proof design.