### PR TITLE
Direct users to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # A bleeping fast scala build tool!
 
-See documentation at [https://bleep.build](https://bleep.build)
+See documentation at [https://bleep.build](https://bleep.build/docs/)


### PR DESCRIPTION
Maybe it's better to direct users straight to the documentation section of the website. At least for the time being. The website https://bleep.build/ itself still has the default Docusaurus content.
