### PR TITLE
logging: transfer log events from child processes as json. 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,43 @@
 [submodule "liberated/sbt-git-versioning"]
 	path = liberated/sbt-git-versioning
 	url = git@github.com:bleep-build/sbt-git-versioning.git
+    branch = main
+    update = rebase
 [submodule "liberated/sbt-native-image"]
 	path = liberated/sbt-native-image
 	url = git@github.com:bleep-build/sbt-native-image.git
+    branch = main
+    update = rebase
 [submodule "liberated/sbt-sonatype"]
 	path = liberated/sbt-sonatype
 	url = git@github.com:bleep-build/sbt-sonatype.git
+    branch = master
+    update = rebase
 [submodule "liberated/sbt-pgp"]
 	path = liberated/sbt-pgp
 	url = git@github.com:bleep-build/sbt-pgp.git
+    branch = develop
+    update = rebase
 [submodule "liberated/sbt-ci-release"]
 	path = liberated/sbt-ci-release
 	url = git@github.com:bleep-build/sbt-ci-release.git
+    branch = main
+    update = rebase
 [submodule "liberated/sbt-dynver"]
 	path = liberated/sbt-dynver
 	url = git@github.com:bleep-build/sbt-dynver.git
+    branch = master
+    update = rebase
+[submodule "liberated/mdoc"]
+	path = liberated/mdoc
+	url = git@github.com:bleep-build/mdoc.git
+	branch = main
+	update = rebase
+[submodule "liberated/sbt-tpolecat"]
+	path = liberated/sbt-tpolecat
+	url = git@github.com:bleep-build/sbt-tpolecat.git
+    branch = main
+    update = rebase
 [submodule "snapshot-tests-in/tapir"]
 	path = snapshot-tests-in/tapir
 	url = git@github.com:softwaremill/tapir.git
@@ -28,15 +50,9 @@
 [submodule "snapshot-tests-in/converter"]
 	path = snapshot-tests-in/converter
 	url = git@github.com:ScalablyTyped/Converter.git
-[submodule "liberated/mdoc"]
-	path = liberated/mdoc
-	url = git@github.com:bleep-build/mdoc.git
 [submodule "snapshot-tests-in/bloop"]
 	path = snapshot-tests-in/bloop
 	url = git@github.com:scalacenter/bloop.git
-[submodule "liberated/sbt-tpolecat"]
-	path = liberated/sbt-tpolecat
-	url = git@github.com:bleep-build/sbt-tpolecat.git
 [submodule "snapshot-tests-in/sbt"]
 	path = snapshot-tests-in/sbt
 	url = git@github.com:sbt/sbt.git

--- a/bleep-cli-test/src/scala/bleep/TemplateTest.scala
+++ b/bleep-cli-test/src/scala/bleep/TemplateTest.scala
@@ -80,7 +80,7 @@ class TemplateTest extends SnapshotTest {
       ignoreWhenInferringTemplates: Set[model.ProjectName] = Set.empty
   ): model.BuildFile = {
     val pre = model.Build.Exploded(model.BleepVersion.dev, projects, model.JsonList.empty, None, Map.empty)
-    val logger = bleep.logging.stdout(LogPatterns.interface(Instant.now, None, noColor = false)).withContext(testName).untyped
+    val logger = bleep.logging.stdout(LogPatterns.interface(Instant.now, noColor = false)).withContext(testName).untyped
     val buildFile = templatesInfer(new BleepTemplateLogger(logger), pre, ignoreWhenInferringTemplates)
     writeAndCompareEarly(outFolder.resolve(testName), Map(outFolder.resolve(testName) -> buildFile.asJson.foldWith(ShortenAndSortJson(Nil)).spaces2))
 

--- a/bleep-core/src/scala/bleep/bootstrap.scala
+++ b/bleep-core/src/scala/bleep/bootstrap.scala
@@ -10,7 +10,13 @@ import scala.util.{Failure, Success, Try}
 
 object bootstrap {
   def forScript(scriptName: String)(f: (Started, Commands) => Unit): Unit = {
-    val logger = logging.stdout(LogPatterns.interface(Instant.now, Some(scriptName), noColor = false)).untyped
+    val logAsJson = sys.env.contains(constants.BleepChildProcess)
+
+    val logger = {
+      val base = if (logAsJson) logging.stdoutJson() else logging.stdout(LogPatterns.interface(Instant.now, noColor = false))
+      base.untyped.withPath(scriptName)
+    }
+
     val buildLoader = BuildLoader.find(Os.cwd)
     val buildPaths = BuildPaths(Os.cwd, buildLoader, Mode.Normal)
     val maybeStarted = for {

--- a/bleep-core/src/scala/bleep/bsp/BleepRifleLogger.scala
+++ b/bleep-core/src/scala/bleep/bsp/BleepRifleLogger.scala
@@ -1,28 +1,37 @@
 package bleep.bsp
 
-import bleep.logging.{Logger, LoggerFn}
+import bleep.logging.{jsonEvents, Logger, LoggerFn}
 
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 import scala.build.blooprifle.BloopRifleLogger
 
 class BleepRifleLogger(logger: Logger) extends BloopRifleLogger {
-  override def info(msg: => String): Unit = logger.info(s"bloop-rifle: $msg")
-  override def debug(msg: => String, throwable: Throwable): Unit =
-    Option(throwable) match {
-      case Some(th) => logger.debug(s"bloop-rifle: $msg", th)
-      case None     => logger.debug(s"bloop-rifle: $msg")
+  val bloopLogger = logger.withPath("bloop")
+  val bloopRifleLogger = logger.withPath("bloop-rifle")
+  val jsonConsumer = new jsonEvents.JsonConsumer(logger)
+
+  override def info(msg: => String): Unit =
+    io.circe.parser.decode[jsonEvents.JsonEvent](msg) match {
+      case Left(_)          => bloopRifleLogger.info(msg)
+      case Right(jsonEvent) => jsonConsumer.log(jsonEvent)
     }
 
-  override def error(msg: => String, ex: Throwable): Unit = logger.error(s"bloop-rifle: $msg")
+  override def debug(msg: => String, throwable: Throwable): Unit =
+    Option(throwable) match {
+      case Some(th) => bloopRifleLogger.debug(msg, th)
+      case None     => bloopRifleLogger.debug(msg)
+    }
+
+  override def error(msg: => String, ex: Throwable): Unit = bloopRifleLogger.error(msg)
   override val bloopCliInheritStdout: Boolean = false
   override val bloopCliInheritStderr: Boolean = false
-  override def bloopBspStdout: Option[OutputStream] = Some(new BleepRifleLogger.Log("bloop: ", logger))
-  override def bloopBspStderr: Option[OutputStream] = Some(new BleepRifleLogger.Log("bloop: ", logger))
+  override def bloopBspStdout: Option[OutputStream] = Some(new BleepRifleLogger.Stream(bloopLogger))
+  override def bloopBspStderr: Option[OutputStream] = Some(new BleepRifleLogger.Stream(bloopLogger))
 }
 
 object BleepRifleLogger {
-  private class Log(prefix: String, logger: LoggerFn) extends OutputStream {
+  private class Stream(logger: LoggerFn) extends OutputStream {
     val bs = Array.newBuilder[Byte]
     override def write(b: Int): Unit = {
       val NewLine = '\n'.toByte
@@ -31,11 +40,11 @@ object BleepRifleLogger {
           val line = new String(bs.result(), StandardCharsets.UTF_8)
 
           fansi.Str.Strip(line).plainText.splitAt(4) match {
-            case ("[E] ", rest) => logger.error(prefix + rest)
-            case ("[W] ", rest) => logger.warn(prefix + rest)
-            case ("[I] ", rest) => logger.info(prefix + rest)
-            case ("[D] ", rest) => logger.debug(prefix + rest)
-            case _              => logger.debug(prefix + line)
+            case ("[E] ", rest) => logger.error(rest)
+            case ("[W] ", rest) => logger.warn(rest)
+            case ("[I] ", rest) => logger.info(rest)
+            case ("[D] ", rest) => logger.debug(rest)
+            case _              => logger.debug(line)
           }
 
           bs.clear()

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -33,7 +33,7 @@ case class Run(
     maybeMain.flatMap { main =>
       val params = new RunParams(buildTarget(started.buildPaths, project))
       val mainClass = new ScalaMainClass(main, args.asJava, List(s"-Duser.dir=${started.prebootstrapped.buildPaths.cwd}").asJava)
-      val envs = sys.env.map { case (k, v) => s"$k=$v" }.toList.sorted.asJava
+      val envs = sys.env.updated(constants.BleepChildProcess, "true").map { case (k, v) => s"$k=$v" }.toList.sorted.asJava
       mainClass.setEnvironmentVariables(envs)
       params.setData(mainClass)
       params.setDataKind("scala-main-class")

--- a/bleep-core/src/scala/bleep/constants.scala
+++ b/bleep-core/src/scala/bleep/constants.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 
 object constants {
   val Node = "18.4.0"
-
+  val BleepChildProcess = "BLEEP_CHILD_PROCESS"
   private val ivyLocalUri =
     URI.create(LocalRepositories.ivy2Local.pattern.chunks.head.string)
 

--- a/bleep-core/src/scala/bleep/logging/Formatter.scala
+++ b/bleep-core/src/scala/bleep/logging/Formatter.scala
@@ -91,7 +91,7 @@ object Formatter {
       }
 
   implicit val StrFormatter: Formatter[Str] = x => x
-  implicit val StringFormatter: Formatter[String] = Str.Strip(_)
+  implicit val StringFormatter: Formatter[String] = Str(_)
   implicit val IntFormatter: Formatter[Int] = _.toString
   implicit val LongFormatter: Formatter[Long] = _.toString
   implicit val UnitFormatter: Formatter[Unit] = _ => ""

--- a/bleep-core/src/scala/bleep/logging/LogLevel.scala
+++ b/bleep-core/src/scala/bleep/logging/LogLevel.scala
@@ -9,4 +9,14 @@ object LogLevel {
   case object error extends LogLevel(5)
 
   implicit val LogLevelOrdering: Ordering[LogLevel] = (one, two) => one.level.compareTo(two.level)
+
+  val All = List(debug, info, warn, error)
+
+  def unsafeFrom(level: Int): LogLevel =
+    if (level == debug.level) debug
+    else if (level == info.level) info
+    else if (level == warn.level) warn
+    else if (level == error.level) error
+    else sys.error(s"unexpected logLevel $level")
+
 }

--- a/bleep-core/src/scala/bleep/logging/LoggerFn.scala
+++ b/bleep-core/src/scala/bleep/logging/LoggerFn.scala
@@ -43,7 +43,7 @@ object LoggerFn {
     @inline def error[T: Formatter](t: => Text[T], th: Throwable)(implicit l: Line, f: File, e: Enclosing): Unit =
       apply(LogLevel.error, t, Some(th))
 
-    @inline def and(other: LoggerFn): LoggerFn =
+    def and(other: LoggerFn): LoggerFn =
       new LoggerFn {
         override def log[T: Formatter](text: => Text[T], throwable: Option[Throwable], metadata: Metadata): Unit = {
           fn.log(text, throwable, metadata)

--- a/bleep-core/src/scala/bleep/logging/Pattern.scala
+++ b/bleep-core/src/scala/bleep/logging/Pattern.scala
@@ -4,5 +4,5 @@ import fansi.Str
 import sourcecode.Text
 
 trait Pattern {
-  def apply[T: Formatter](t: => Text[T], throwable: Option[Throwable], metadata: Metadata, ctx: Ctx): Str
+  def apply[T: Formatter](t: => Text[T], throwable: Option[Throwable], metadata: Metadata, ctx: Ctx, path: List[String]): Str
 }

--- a/bleep-core/src/scala/bleep/logging/jsonEvents.scala
+++ b/bleep-core/src/scala/bleep/logging/jsonEvents.scala
@@ -1,0 +1,94 @@
+package bleep.logging
+
+import fansi.Str
+import io.circe.generic.semiauto
+import io.circe.{Codec, Decoder, Encoder}
+import sourcecode.{Enclosing, File, Line, Text}
+
+import java.io.{PrintStream, PrintWriter}
+import java.time.Instant
+import scala.util.control.NoStackTrace
+
+object jsonEvents {
+
+  /** Meant for transferring log events between processes */
+  case class JsonEvent(sourceCode: String, formatted: Str, throwable: Option[Th], metadata: Metadata, ctx: Ctx, path: List[String])
+
+  object JsonEvent {
+    implicit val strCodec: Codec[Str] =
+      Codec.forProduct2[Str, Array[Char], Array[Long]]("chars", "colors") { case (chars, colors) => Str.fromArrays(chars, colors) } { str =>
+        (str.getChars, str.getColors)
+      }
+
+    implicit val metadataCodec: Codec.AsObject[Metadata] =
+      Codec.forProduct5[Metadata, Instant, Int, Int, String, String]("instant", "logLevel", "line", "file", "enclosing") {
+        case (instant, logLevel, line, file, enclosing) =>
+          new Metadata(instant, LogLevel.unsafeFrom(logLevel), new Line(line), new File(file), new Enclosing(enclosing))
+      }(m => (m.instant, m.logLevel.level, m.line.value, m.file.value, m.enclosing.value))
+
+    implicit val codec: Codec[JsonEvent] = semiauto.deriveCodec
+
+    def from[T: Formatter](t: Text[T], throwable: Option[Throwable], metadata: Metadata, ctx: Ctx, path: List[String]): JsonEvent =
+      JsonEvent(t.source, Formatter[T](t.value), throwable.map(Th.from), metadata, ctx, path)
+  }
+
+  /** For used in called program, so it outputs all log events in json
+    */
+  final class JsonProducer[U <: Appendable](val underlying: U, val context: Ctx, val path: List[String]) extends TypedLogger[U] {
+    import io.circe.syntax._
+
+    override def log[T: Formatter](t: => Text[T], throwable: Option[Throwable], metadata: Metadata): Unit = {
+      val json = JsonEvent.from(t, throwable, metadata, context, path).asJson
+      underlying.append(json.noSpaces + "\n")
+      ()
+    }
+
+    override def withContext[T: Formatter](key: String, value: T): JsonProducer[U] =
+      new JsonProducer(underlying, context + (key -> Formatter(value)), path)
+
+    override def progressMonitor: Option[LoggerFn] = None
+
+    override def withPath(fragment: String): TypedLogger[U] =
+      new JsonProducer[U](underlying, context, fragment :: path)
+  }
+
+  /** For use in calling program, which receives json events
+    */
+  final class JsonConsumer(val underlying: Logger) {
+    def log(logEvent: JsonEvent): Unit = {
+      val underlying1 = logEvent.path.foldRight(underlying) { case (fragment, acc) => acc.withPath(fragment) }
+      val underlying2 = logEvent.ctx.foldRight(underlying1) { case ((k, v), acc) => acc.withContext(k, v) }
+
+      underlying2(
+        logEvent.metadata.logLevel,
+        Text(logEvent.formatted, logEvent.sourceCode),
+        logEvent.throwable.map(DeserializedThrowable.apply),
+        logEvent.metadata.instant
+      )(Formatter.StrFormatter, logEvent.metadata.line, logEvent.metadata.file, logEvent.metadata.enclosing)
+    }
+  }
+
+  case class DeserializedThrowable(th: Th) extends Throwable with NoStackTrace {
+    override def printStackTrace(s: PrintStream): Unit = s.println(th.stackTrace)
+    override def printStackTrace(s: PrintWriter): Unit = s.println(th.stackTrace)
+    override def getMessage: String = th.message.getOrElse("")
+  }
+
+  /** Wrap exceptions in something which is easier to transfer
+    */
+  case class Th(className: String, message: Option[String], cause: Option[Th], stackTrace: String, suppressed: Array[Th]) extends Throwable()
+
+  object Th {
+    implicit val encoder: Encoder[Th] = semiauto.deriveEncoder
+    implicit val decoder: Decoder[Th] = semiauto.deriveDecoder
+
+    def from(th: Throwable): Th =
+      Th(
+        className = th.getClass.getName,
+        message = Option(th.getMessage),
+        cause = Option(th.getCause).map(from),
+        stackTrace = formatThrowable(th),
+        suppressed = th.getSuppressed.map(from)
+      )
+  }
+}

--- a/bleep-core/src/scala/bleep/logging/package.scala
+++ b/bleep-core/src/scala/bleep/logging/package.scala
@@ -2,11 +2,11 @@ package bleep
 
 import fansi.Str
 
-import java.io.{BufferedWriter, PrintStream, StringWriter}
+import java.io.{BufferedWriter, PrintStream, PrintWriter, StringWriter}
 import java.nio.file.{Files, Path, StandardOpenOption}
 
 package object logging {
-  type Ctx = Map[Str, Str]
+  type Ctx = Map[String, Str]
   type Logger = TypedLogger[Unit]
   val Logger = TypedLogger
   type LoggerResource = TypedLoggerResource[Unit]
@@ -15,10 +15,13 @@ package object logging {
   private[logging] val emptyContext: Ctx = Map.empty
 
   def stdout(pattern: Pattern, ctx: Ctx = emptyContext): TypedLogger[PrintStream] =
-    new TypedLogger.ConsoleLogger(System.out, pattern, ctx)
+    new TypedLogger.ConsoleLogger(System.out, pattern, ctx, Nil)
 
   def stderr(pattern: Pattern, ctx: Ctx = emptyContext): TypedLogger[PrintStream] =
-    new TypedLogger.ConsoleLogger(System.err, pattern, ctx)
+    new TypedLogger.ConsoleLogger(System.err, pattern, ctx, Nil)
+
+  def stdoutJson(ctx: Ctx = emptyContext): TypedLogger[PrintStream] =
+    new jsonEvents.JsonProducer(System.out, ctx, Nil)
 
   def path(logFile: Path, pattern: Pattern, ctx: Ctx = emptyContext): TypedLoggerResource[BufferedWriter] =
     new TypedLoggerResource[BufferedWriter] {
@@ -35,11 +38,18 @@ package object logging {
       pattern: Pattern,
       ctx: Ctx = emptyContext
   ): TypedLogger[A] =
-    new TypedLogger.AppendableLogger(appendable, pattern, ctx)
+    new TypedLogger.AppendableLogger(appendable, pattern, ctx, Nil)
 
   def stringWriter(pattern: Pattern, ctx: Ctx = emptyContext): TypedLogger[StringWriter] =
     appendable(new StringWriter, pattern, ctx)
 
   def storing(ctx: Ctx = emptyContext): TypedLogger[Array[TypedLogger.Stored]] =
-    new TypedLogger.StoringLogger(new TypedLogger.Store, ctx)
+    new TypedLogger.StoringLogger(new TypedLogger.Store, ctx, Nil)
+
+  def formatThrowable(th: Throwable): String = {
+    val sw = new StringWriter()
+    val pw = new PrintWriter(sw)
+    th.printStackTrace(pw)
+    sw.toString
+  }
 }


### PR DESCRIPTION
Add `path` as a structured thing to replace string concatenation which was used before

This way output looks decent, filtering works and so on.

before:
<img width="1716" alt="Screenshot 2022-10-25 at 21 23 36" src="https://user-images.githubusercontent.com/247937/197863675-d3691f2f-3337-4464-9491-e9c7c51f58f0.png">

after:
<img width="1633" alt="Screenshot 2022-10-25 at 21 23 09" src="https://user-images.githubusercontent.com/247937/197863696-1a944438-b901-4b4e-8a83-fcdd70177bdb.png">
