### PR TITLE
Add `--watch` (`-w`) to  `compile`, `test`, `dist`, `publish-local`, `run`, `script`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,7 @@ jobs:
           CI: true
         run: |
           ./${{ matrix.file_name }} --dev test --no-color jvm213
+          ./${{ matrix.file_name }} selftest
         if: runner.os != 'Windows'
 
         # as is normal, everything involving windows is terrible.
@@ -116,12 +117,20 @@ jobs:
         shell: cmd
         if: runner.os == 'Windows'
 
-      - name: Test binary after build (windows)
+      - name: Test binary after build 1 (windows)
         shell: cmd
         env:
           CI: true
         # todo: fix tests on windows
         run: .\${{ matrix.file_name }} --dev compile --no-color jvm213
+        if: runner.os == 'Windows'
+
+      - name: Test binary after build 2 (windows)
+        shell: cmd
+        env:
+          CI: true
+        # todo: fix tests on windows
+        run: .\${{ matrix.file_name }} selftest
         if: runner.os == 'Windows'
 
       - name: Temporarily save package

--- a/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/jni-config.json
+++ b/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/jni-config.json
@@ -1,0 +1,25 @@
+[
+  {
+    "name": "com.swoval.files.apple.FileEvent",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.swoval.files.apple.FileEventMonitorImpl$WrappedConsumer",
+    "methods": [
+      {
+        "name": "accept",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      }
+    ]
+  }
+]

--- a/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/resource-config.json
+++ b/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/resource-config.json
@@ -1,0 +1,11 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qnative/x86_64/libswoval-files0.dylib\\E"
+      }
+    ]
+  },
+  "bundles": [
+  ]
+}

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -385,6 +385,11 @@ object Main {
 
         completions.value.foreach(c => println(c.value))
 
+      case "selftest" :: Nil =>
+        // checks that JNI libraries are successfully loaded
+        FileWatching(Logger.DevNull, Map(Os.cwd -> List(())))(println(_)).run(FileWatching.StopWhen.Immediately)
+        println("OK")
+
       case "bsp" :: args =>
         val (commonOpts, _) = CommonOpts.parse(args)
         val cwd = cwdFor(commonOpts)

--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -66,8 +66,8 @@ object BspImpl {
               }
             ).flatten
 
-            pre.fresh.flatMap { pre =>
-              bootstrap.from(pre, GenBloopFiles.SyncToDisk, bspRewrites, Lazy(bleepConfig), CoursierResolver.Factory.default)
+            pre.reloaded.flatMap { pre =>
+              bootstrap.from(pre, GenBloopFiles.SyncToDisk, bspRewrites, Lazy(bleepConfig), CoursierResolver.Factory.default, ExecutionContext.global)
             }
           }
 

--- a/bleep-cli/src/scala/bleep/commands/BuildCreateDirectories.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildCreateDirectories.scala
@@ -5,8 +5,8 @@ import bleep.internal.FileUtils
 
 import java.nio.file.{Files, Path}
 
-case class BuildCreateDirectories(started: Started, projects: Array[model.CrossProjectName]) extends BleepCommand {
-  override def run(): Either[BleepException, Unit] = {
+case class BuildCreateDirectories(projects: Array[model.CrossProjectName]) extends BleepBuildCommand {
+  override def run(started: Started): Either[BleepException, Unit] = {
     val dirsWithProject: Map[Path, Array[model.CrossProjectName]] =
       projects
         .flatMap { crossName =>

--- a/bleep-cli/src/scala/bleep/commands/BuildCreateNew.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildCreateNew.scala
@@ -8,6 +8,7 @@ import bleep.{constants, model, BleepException}
 import cats.data.NonEmptyList
 
 import java.nio.file.{Files, Path}
+import scala.concurrent.ExecutionContext
 
 case class BuildCreateNew(
     logger: Logger,
@@ -17,7 +18,7 @@ case class BuildCreateNew(
     name: String,
     bleepVersion: model.BleepVersion,
     coursierResolver: CoursierResolver.Factory
-) extends BleepCommand {
+) extends BleepNoBuildCommand {
 
   override def run(): Either[BleepException, Unit] = {
     val buildLoader = BuildLoader.inDirectory(cwd)
@@ -35,7 +36,7 @@ case class BuildCreateNew(
     val pre = Prebootstrapped(buildPaths, logger, BuildLoader.Existing(buildPaths.bleepYamlFile))
     val bleepConfig = BleepConfigOps.lazyForceLoad(pre.userPaths)
 
-    bootstrap.from(pre, GenBloopFiles.SyncToDisk, rewrites = Nil, bleepConfig, coursierResolver) map { started =>
+    bootstrap.from(pre, GenBloopFiles.SyncToDisk, rewrites = Nil, bleepConfig, coursierResolver, ExecutionContext.global) map { started =>
       val projects = started.bloopProjectsList
       logger.info(s"Created ${projects.length} projects for build")
       val sourceDirs = projects.flatMap(_.sources).distinct

--- a/bleep-cli/src/scala/bleep/commands/BuildDiff.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildDiff.scala
@@ -7,8 +7,8 @@ import com.monovore.decline.Opts
 import scala.collection.immutable.SortedSet
 import scala.util.control.NonFatal
 
-case class BuildDiff(started: Started, opts: BuildDiff.Options, projects: Array[model.CrossProjectName]) extends BleepCommand {
-  override def run(): Either[BleepException, Unit] = {
+case class BuildDiff(opts: BuildDiff.Options, projects: Array[model.CrossProjectName]) extends BleepBuildCommand {
+  override def run(started: Started): Either[BleepException, Unit] = {
     val revision = opts.revision.getOrElse("HEAD")
 
     val oldBuildStr: Lazy[Either[BleepException, String]] = Lazy {

--- a/bleep-cli/src/scala/bleep/commands/BuildDiffBloop.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildDiffBloop.scala
@@ -18,11 +18,11 @@ import io.circe._
 import scala.collection.immutable.SortedSet
 import scala.util.control.NonFatal
 
-case class BuildDiffBloop(started: Started, opts: BuildDiff.Options, projects: Array[model.CrossProjectName]) extends BleepCommand {
+case class BuildDiffBloop(opts: BuildDiff.Options, projects: Array[model.CrossProjectName]) extends BleepBuildCommand {
   implicit val lcs: Patience[Json] = new Patience
   implicit val showStr: Show[Str] = _.toString()
 
-  override def run(): Either[BleepException, Unit] = {
+  override def run(started: Started): Either[BleepException, Unit] = {
     val revision = opts.revision.getOrElse("HEAD")
 
     val oldBuildStr: Lazy[Either[BleepException, String]] = Lazy {
@@ -44,7 +44,8 @@ case class BuildDiffBloop(started: Started, opts: BuildDiff.Options, projects: A
         genBloopFiles = GenBloopFiles.InMemory,
         rewrites = Nil,
         lazyConfig = started.lazyConfig,
-        resolver = (_, _, _) => started.resolver.forceGet
+        resolver = (_, _, _) => started.resolver.forceGet,
+        executionContext = started.executionContext
       )
       .orThrow
 

--- a/bleep-cli/src/scala/bleep/commands/BuildMoveFilesIntoBleepLayout.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildMoveFilesIntoBleepLayout.scala
@@ -10,16 +10,14 @@ import java.nio.file.{Files, Path}
 import scala.collection.immutable.SortedMap
 import scala.sys.process.Process
 
-case class BuildMoveFilesIntoBleepLayout(started: Started) extends BleepCommand {
-  override def run(): Either[BleepException, Unit] = {
+object BuildMoveFilesIntoBleepLayout extends BleepBuildCommand {
+  override def run(started: Started): Either[BleepException, Unit] = {
     val build = started.build.requireFileBacked(ctx = "command move-files-into-bleep-layout")
-    val (rewrittenBuild, filesToMove) = BuildMoveFilesIntoBleepLayout.newBuildAndFilesToMove(build, started.buildPaths)
-    BuildMoveFilesIntoBleepLayout.commit(started.logger, started.buildPaths, filesToMove, rewrittenBuild.file)
+    val (rewrittenBuild, filesToMove) = newBuildAndFilesToMove(build, started.buildPaths)
+    commit(started.logger, started.buildPaths, filesToMove, rewrittenBuild.file)
     Right(())
   }
-}
 
-object BuildMoveFilesIntoBleepLayout {
   def newBuildAndFilesToMove(build: model.Build.FileBacked, buildPaths: BuildPaths): (model.Build.FileBacked, SortedMap[Path, Path]) = {
 
     val moves = collection.mutable.Map.empty[Path, Path]

--- a/bleep-cli/src/scala/bleep/commands/BuildNormalize.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildNormalize.scala
@@ -3,8 +3,8 @@ package commands
 
 import bleep.rewrites.normalizeBuild
 
-case class BuildNormalize(started: Started) extends BleepCommand {
-  override def run(): Either[BleepException, Unit] = {
+object BuildNormalize extends BleepBuildCommand {
+  override def run(started: Started): Either[BleepException, Unit] = {
     val build = started.build.requireFileBacked(ctx = "command normalize")
     val build1 = normalizeBuild(build)
     yaml.writeShortened(build1.file, started.buildPaths.bleepYamlFile)

--- a/bleep-cli/src/scala/bleep/commands/BuildReapplyTemplates.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildReapplyTemplates.scala
@@ -4,8 +4,8 @@ package commands
 import bleep.rewrites.normalizeBuild
 import bleep.templates.templatesReapply
 
-case class BuildReapplyTemplates(started: Started) extends BleepCommand {
-  override def run(): Either[BleepException, Unit] = {
+object BuildReapplyTemplates extends BleepBuildCommand {
+  override def run(started: Started): Either[BleepException, Unit] = {
     val build = started.build.requireFileBacked(ctx = "command templates-reapply")
     val build1 = normalizeBuild(build)
     val build2 = templatesReapply(build1)

--- a/bleep-cli/src/scala/bleep/commands/BuildReinferTemplates.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildReinferTemplates.scala
@@ -5,8 +5,8 @@ import bleep.internal.BleepTemplateLogger
 import bleep.rewrites.{normalizeBuild, Defaults}
 import bleep.templates.templatesInfer
 
-case class BuildReinferTemplates(started: Started, ignoreWhenInferringTemplates: Set[model.ProjectName]) extends BleepCommand {
-  override def run(): Either[BleepException, Unit] = {
+case class BuildReinferTemplates(ignoreWhenInferringTemplates: Set[model.ProjectName]) extends BleepBuildCommand {
+  override def run(started: Started): Either[BleepException, Unit] = {
     // require that the build is from file, which means it may have templates
     val build0 = started.build.requireFileBacked(ctx = "command templates-generate-new")
 

--- a/bleep-cli/src/scala/bleep/commands/BuildShow.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildShow.scala
@@ -6,8 +6,8 @@ import bloop.config.ConfigCodecs
 import cats.data.NonEmptyList
 
 object BuildShow {
-  case class Short(started: Started, projects: NonEmptyList[model.ProjectName]) extends BleepCommand {
-    override def run(): Either[BleepException, Unit] = {
+  case class Short(projects: NonEmptyList[model.ProjectName]) extends BleepBuildCommand {
+    override def run(started: Started): Either[BleepException, Unit] = {
       val build = started.build.requireFileBacked("command build show short")
       projects.toList.foreach { projectName =>
         val p = build.file.projects.value(projectName)
@@ -18,8 +18,8 @@ object BuildShow {
       Right(())
     }
   }
-  case class Exploded(started: Started, projects: Array[model.CrossProjectName]) extends BleepCommand {
-    override def run(): Either[BleepException, Unit] = {
+  case class Exploded(projects: Array[model.CrossProjectName]) extends BleepBuildCommand {
+    override def run(started: Started): Either[BleepException, Unit] = {
       projects.foreach { crossProjectName =>
         val p0 = started.build.explodedProjects(crossProjectName)
         // we don't currently do these cleanups to be able to go back to short version
@@ -32,8 +32,8 @@ object BuildShow {
     }
   }
 
-  case class Bloop(started: Started, projects: Array[model.CrossProjectName]) extends BleepCommand {
-    override def run(): Either[BleepException, Unit] = {
+  case class Bloop(projects: Array[model.CrossProjectName]) extends BleepBuildCommand {
+    override def run(started: Started): Either[BleepException, Unit] = {
       projects.foreach { crossProjectName =>
         val f = started.bloopFiles(crossProjectName).forceGet
         println(fansi.Color.Red(crossProjectName.value))

--- a/bleep-cli/src/scala/bleep/commands/Import.scala
+++ b/bleep-cli/src/scala/bleep/commands/Import.scala
@@ -12,7 +12,7 @@ case class Import(
     logger: Logger,
     options: sbtimport.ImportOptions,
     bleepVersion: model.BleepVersion
-) extends BleepCommand {
+) extends BleepNoBuildCommand {
   override def run(): Either[BleepException, Unit] = {
     if (!options.skipSbt) {
       sbtimport.runSbt(logger, sbtBuildDir, destinationPaths)

--- a/bleep-cli/src/scala/bleep/commands/Scalafmt.scala
+++ b/bleep-cli/src/scala/bleep/commands/Scalafmt.scala
@@ -20,8 +20,8 @@ object Scalafmt {
       .toScala(List)
       .collectFirst { case Array("version", version) => version.stripPrefix("\"").stripSuffix("\"") }
 }
-class Scalafmt(started: Started, check: Boolean) extends BleepCommand {
-  override def run(): Either[BleepException, Unit] = {
+case class Scalafmt(check: Boolean) extends BleepBuildCommand {
+  override def run(started: Started): Either[BleepException, Unit] = {
     val configPath = started.buildPaths.buildDir / ".scalafmt.conf"
 
     val configStr: String =

--- a/bleep-core/src/scala/bleep/BleepCommand.scala
+++ b/bleep-core/src/scala/bleep/BleepCommand.scala
@@ -1,5 +1,13 @@
 package bleep
 
-trait BleepCommand {
+trait BleepNoBuildCommand {
   def run(): Either[BleepException, Unit]
+}
+
+trait BleepBuildCommand {
+  def run(started: Started): Either[BleepException, Unit]
+}
+
+trait BleepCommand extends BleepNoBuildCommand with BleepBuildCommand {
+  final def run(started: Started): Either[BleepException, Unit] = run()
 }

--- a/bleep-core/src/scala/bleep/BleepCommandRemote.scala
+++ b/bleep-core/src/scala/bleep/BleepCommandRemote.scala
@@ -1,7 +1,7 @@
 package bleep
 
 import bleep.bsp.{BleepRifleLogger, BspCommandFailed, SetupBloopRifle}
-import bleep.internal.{jvmOrSystem, BspClientDisplayProgress}
+import bleep.internal.{fatal, jvmOrSystem, BspClientDisplayProgress}
 import ch.epfl.scala.bsp4j
 
 import java.util
@@ -10,11 +10,13 @@ import scala.build.blooprifle.BloopRifleConfig
 import scala.build.blooprifle.internal.Operations
 import scala.jdk.CollectionConverters._
 
-abstract class BleepCommandRemote(started: Started, watch: Boolean, projects: Array[model.CrossProjectName]) extends BleepCommand {
+abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
+  def chosenProjects(started: Started): Array[model.CrossProjectName]
+
   def buildTarget(buildPaths: BuildPaths, name: model.CrossProjectName): bsp4j.BuildTargetIdentifier =
     new bsp4j.BuildTargetIdentifier(buildPaths.buildVariantDir.toFile.toURI.toASCIIString.stripSuffix("/") + "/?id=" + name.value)
 
-  def projectFromBuildTarget(name: bsp4j.BuildTargetIdentifier): model.CrossProjectName = {
+  def projectFromBuildTarget(started: Started)(name: bsp4j.BuildTargetIdentifier): model.CrossProjectName = {
     val id = name.getUri.split("=").last
     started.build.explodedProjects.keys.find(_.value == id).getOrElse(sys.error(s"Couldn't find project for $name"))
   }
@@ -22,9 +24,9 @@ abstract class BleepCommandRemote(started: Started, watch: Boolean, projects: Ar
   def buildTargets(buildPaths: BuildPaths, projects: Array[model.CrossProjectName]): util.List[bsp4j.BuildTargetIdentifier] =
     util.List.of(projects.map(p => buildTarget(buildPaths, p)): _*)
 
-  def runWithServer(bloop: BloopServer): Either[BleepException, Unit]
+  def runWithServer(started: Started, bloop: BloopServer): Either[BleepException, Unit]
 
-  override final def run(): Either[BleepException, Unit] = {
+  override final def run(started: Started): Either[BleepException, Unit] = {
     val bleepConfig = started.lazyConfig.forceGet
 
     bleepConfig.compileServerMode match {
@@ -63,24 +65,44 @@ abstract class BleepCommandRemote(started: Started, watch: Boolean, projects: Ar
 
     try
       if (watch) {
-        runWithServer(server)
+        // run once initially
+        runWithServer(started, server)
 
-        FileWatching.projects(started, projects) { projects =>
+        var currentStarted = started
+
+        val codeWatcher = BleepFileWatching.projects(currentStarted, chosenProjects(currentStarted)) { changedProjects =>
           val patchedCmd = this match {
-            case x: BleepCommandRemote.OnlyChanged => x.onlyChangedProjects(projects)
+            case x: BleepCommandRemote.OnlyChanged => x.onlyChangedProjects(currentStarted, changedProjects)
             case other                             => other
           }
 
-          patchedCmd.runWithServer(server)
+          patchedCmd.runWithServer(currentStarted, server)
+          ()
         }
+
+        val buildWatcher = BleepFileWatching.build(started.logger, started.prebootstrapped.existingBuild) { case () =>
+          started.reloaded match {
+            case Left(bleepException) =>
+              fatal.log("build changed, but it didn't work :(", started.logger, bleepException)
+              codeWatcher.updateMapping(Map.empty)
+            case Right(newStarted) =>
+              currentStarted = newStarted
+              codeWatcher.updateMapping(BleepFileWatching.projectPathsMapping(currentStarted, chosenProjects(currentStarted)))
+          }
+        }
+
+        started.logger.info("Running in watch mode")
+
+        codeWatcher.combine(buildWatcher).run(FileWatching.StopWhen.OnStdInput)
+
         Right(())
 
       } else
-        runWithServer(server).flatMap { case () =>
+        runWithServer(started, server).flatMap { case () =>
           buildClient.failed match {
             case empty if empty.isEmpty => Right(())
             case failed =>
-              Left(new BspCommandFailed("Failed", failed.map(projectFromBuildTarget).toArray, BspCommandFailed.NoDetails))
+              Left(new BspCommandFailed("Failed", failed.map(projectFromBuildTarget(started)).toArray, BspCommandFailed.NoDetails))
           }
         }
     finally
@@ -94,7 +116,7 @@ abstract class BleepCommandRemote(started: Started, watch: Boolean, projects: Ar
       }
   }
 
-  def discoverMain(bloop: BloopServer, project: model.CrossProjectName): Either[BleepException, String] = {
+  def discoverMain(started: Started, bloop: BloopServer, project: model.CrossProjectName): Either[BleepException, String] = {
     val req = new bsp4j.ScalaMainClassesParams(util.List.of[bsp4j.BuildTargetIdentifier](buildTarget(started.buildPaths, project)))
     started.logger.debug(req.toString)
 
@@ -114,7 +136,7 @@ abstract class BleepCommandRemote(started: Started, watch: Boolean, projects: Ar
 object BleepCommandRemote {
   trait OnlyChanged {
     self: BleepCommandRemote =>
-    def onlyChangedProjects(isChanged: model.CrossProjectName => Boolean): BleepCommandRemote
+    def onlyChangedProjects(started: Started, isChanged: model.CrossProjectName => Boolean): BleepCommandRemote
   }
 
   case class AmbiguousMain(mainClasses: Seq[String])

--- a/bleep-core/src/scala/bleep/BleepFileWatching.scala
+++ b/bleep-core/src/scala/bleep/BleepFileWatching.scala
@@ -1,0 +1,29 @@
+package bleep
+
+import bleep.logging.Logger
+
+import java.nio.file.Path
+import scala.collection.compat._
+
+object BleepFileWatching {
+  def projectPathsMapping(started: Started, projects: Array[model.CrossProjectName]): Map[Path, Seq[model.CrossProjectName]] = {
+    val withTransitiveDeps: Array[model.CrossProjectName] =
+      (projects ++ projects.flatMap(x => started.build.transitiveDependenciesFor(x).keys)).distinct
+
+    val sourceProjectPairs: Array[(Path, model.CrossProjectName)] =
+      withTransitiveDeps.flatMap { name =>
+        val bloopProject = started.bloopProjects(name)
+        (bloopProject.sources ++ bloopProject.resources.getOrElse(Nil)).map(path => (path, name))
+      }
+
+    sourceProjectPairs.toSeq.groupMap { case (p, _) => p } { case (_, name) => name }
+  }
+
+  def projects(started: Started, projects: Array[model.CrossProjectName])(
+      onChange: Set[model.CrossProjectName] => Unit
+  ): FileWatching.TypedWatcher[model.CrossProjectName] =
+    FileWatching(started.logger, projectPathsMapping(started, projects))(onChange)
+
+  def build(logger: Logger, existingBuild: BuildLoader.Existing)(onChange: () => Unit): FileWatching.Watcher =
+    FileWatching(logger, Map(existingBuild.bleepYaml -> List(())))(_ => onChange())
+}

--- a/bleep-core/src/scala/bleep/Commands.scala
+++ b/bleep-core/src/scala/bleep/Commands.scala
@@ -3,14 +3,14 @@ package bleep
 import bleep.commands.PublishLocal
 
 class Commands(started: Started) {
-  private def force(cmd: BleepCommand): Unit =
-    cmd.run().orThrow
+  private def force(cmd: BleepBuildCommand): Unit =
+    cmd.run(started).orThrow
 
   def clean(projects: List[model.CrossProjectName]): Unit =
-    force(commands.Clean(started, projects.toArray))
+    force(commands.Clean(projects.toArray))
 
   def compile(projects: List[model.CrossProjectName], watch: Boolean = false): Unit =
-    force(commands.Compile(started, watch, projects.toArray))
+    force(commands.Compile(watch, projects.toArray))
 
   def run(
       project: model.CrossProjectName,
@@ -19,14 +19,14 @@ class Commands(started: Started) {
       raw: Boolean = false,
       watch: Boolean = false
   ): Unit =
-    force(commands.Run(started, project, maybeOverriddenMain, args, raw, watch))
+    force(commands.Run(project, maybeOverriddenMain, args, raw, watch))
 
   def test(projects: List[model.CrossProjectName], watch: Boolean = false): Unit =
-    force(commands.Test(started, watch, projects.toArray))
+    force(commands.Test(watch, projects.toArray))
 
   def script(name: model.ScriptName, args: List[String], watch: Boolean = false): Unit =
-    force(commands.Script(started, name, args, watch))
+    force(commands.Script(name, args, watch))
 
   def publishLocal(options: PublishLocal.Options, watch: Boolean = false): Unit =
-    force(commands.PublishLocal(started, watch, options))
+    force(commands.PublishLocal(watch, options))
 }

--- a/bleep-core/src/scala/bleep/Commands.scala
+++ b/bleep-core/src/scala/bleep/Commands.scala
@@ -9,18 +9,24 @@ class Commands(started: Started) {
   def clean(projects: List[model.CrossProjectName]): Unit =
     force(commands.Clean(started, projects.toArray))
 
-  def compile(projects: List[model.CrossProjectName]): Unit =
-    force(commands.Compile(started, projects.toArray))
+  def compile(projects: List[model.CrossProjectName], watch: Boolean = false): Unit =
+    force(commands.Compile(started, watch, projects.toArray))
 
-  def run(project: model.CrossProjectName, maybeOverriddenMain: Option[String] = None, args: List[String] = Nil, raw: Boolean = false): Unit =
-    force(commands.Run(started, project, maybeOverriddenMain, args, raw))
+  def run(
+      project: model.CrossProjectName,
+      maybeOverriddenMain: Option[String] = None,
+      args: List[String] = Nil,
+      raw: Boolean = false,
+      watch: Boolean = false
+  ): Unit =
+    force(commands.Run(started, project, maybeOverriddenMain, args, raw, watch))
 
-  def test(projects: List[model.CrossProjectName]): Unit =
-    force(commands.Test(started, projects.toArray))
+  def test(projects: List[model.CrossProjectName], watch: Boolean = false): Unit =
+    force(commands.Test(started, watch, projects.toArray))
 
-  def script(name: model.ScriptName, args: List[String]): Unit =
-    force(commands.Script(started, name, args))
+  def script(name: model.ScriptName, args: List[String], watch: Boolean = false): Unit =
+    force(commands.Script(started, name, args, watch))
 
-  def publishLocal(options: PublishLocal.Options): Unit =
-    force(commands.PublishLocal(started, options))
+  def publishLocal(options: PublishLocal.Options, watch: Boolean = false): Unit =
+    force(commands.PublishLocal(started, watch, options))
 }

--- a/bleep-core/src/scala/bleep/FileWatching.scala
+++ b/bleep-core/src/scala/bleep/FileWatching.scala
@@ -1,0 +1,113 @@
+package bleep
+
+import bleep.logging.Logger
+import com.swoval.files.FileTreeViews.Observer
+import com.swoval.files.{PathWatcher, PathWatchers}
+import com.swoval.functional.Either
+
+import java.nio.file.{Files, Path}
+import scala.collection.compat._
+import scala.collection.mutable
+
+object FileWatching {
+  def projects(started: Started, projects: Array[model.CrossProjectName])(onChange: Set[model.CrossProjectName] => Unit): Unit = {
+    val bySourceFolder: Map[Path, Seq[model.CrossProjectName]] = {
+      val withTransitiveDeps: Array[model.CrossProjectName] =
+        (projects ++ projects.flatMap(x => started.build.transitiveDependenciesFor(x).keys)).distinct
+
+      val sourceProjectPairs: Array[(Path, model.CrossProjectName)] =
+        withTransitiveDeps.flatMap { name =>
+          val bloopProject = started.bloopProjects(name)
+          (bloopProject.sources ++ bloopProject.resources.getOrElse(Nil)).map(path => (path, name))
+        }
+
+      sourceProjectPairs.toSeq.groupMap { case (p, _) => p } { case (_, name) => name }
+    }
+
+    FileWatching[model.CrossProjectName](started.logger, bySourceFolder)(onChange)
+  }
+
+  def apply[K](logger: Logger, mapping: Map[Path, Seq[K]])(onChange: Set[K] => Unit): Unit = {
+    val w = new State[K](logger, onChange)
+    // setup initial paths
+    w.updateMapping(mapping)
+    logger.info("Running in watch mode")
+    while (!Console.in.ready() && !w.isShutdown) {
+      w.step()
+      Thread.sleep(10)
+    }
+    w.close()
+  }
+
+  private class State[K](logger: Logger, onChange: Set[K] => Unit) {
+    val watcher: PathWatcher[PathWatchers.Event] = PathWatchers.get( /* followLinks = */ true)
+    val changedKeys = mutable.Set.empty[K]
+    var isShutdown = false
+    var mapping: Map[Path, Seq[K]] = Map.empty
+
+    watcher.addObserver {
+      new Observer[PathWatchers.Event] {
+        def onError(t: Throwable): Unit = {
+          logger.error(s"Got error while listening watching files", t)
+          close()
+        }
+
+        def onNext(event: PathWatchers.Event): Unit = {
+          val path = event.getTypedPath.getPath
+          if (path.getFileName.toString.endsWith("~")) {
+            logger.withContext(path).debug("Ignoring change in temporary file")
+          } else {
+            logger.debug(event.toString)
+            var registeredPath = path
+            while (!mapping.contains(registeredPath)) registeredPath = registeredPath.getParent
+            val keys = mapping(registeredPath)
+            synchronized(changedKeys ++= keys)
+          }
+        }
+      }
+    }
+
+    def step(): Unit = {
+      val changes = consumeChanges()
+      changes match {
+        case empty if empty.isEmpty => ()
+        case nonEmpty               => onChange(nonEmpty)
+      }
+    }
+
+    def consumeChanges(): Set[K] = {
+      val changes = synchronized {
+        val res = changedKeys.toSet
+        changedKeys.clear()
+        res
+      }
+      if (changes.nonEmpty) logger.info(s"Changed: $changes")
+      changes
+    }
+
+    def updateMapping(newMapping0: Map[Path, Seq[K]]): Unit = {
+      val newMapping = newMapping0.filter { case (path, _) => Files.exists(path) }
+      // unregister removed paths
+      (mapping.keys.toSet -- newMapping.keys).foreach(watcher.unregister)
+
+      newMapping.foreach { case (path, keys) =>
+        val maybeRegistered = watcher.register(path, Int.MaxValue)
+
+        if (maybeRegistered.isLeft) {
+          val th = Either.leftProjection(maybeRegistered).getValue
+          throw new BleepException.Cause(th, s"Couldn't register $path for $keys for file watching ")
+        } else {
+          if (maybeRegistered.get()) {
+            logger.withContext(path).debug("registered")
+          }
+        }
+      }
+      mapping = newMapping
+    }
+
+    def close(): Unit = {
+      isShutdown = true
+      watcher.close()
+    }
+  }
+}

--- a/bleep-core/src/scala/bleep/FileWatching.scala
+++ b/bleep-core/src/scala/bleep/FileWatching.scala
@@ -20,6 +20,9 @@ object FileWatching {
     case object Never extends StopWhen {
       override def shouldContinue(): Boolean = true
     }
+    case object Immediately extends StopWhen {
+      override def shouldContinue(): Boolean = false
+    }
   }
 
   def apply[K](logger: Logger, mapping: Map[Path, Seq[K]])(onChange: Set[K] => Unit): TypedWatcher[K] = {

--- a/bleep-core/src/scala/bleep/Prebootstrapped.scala
+++ b/bleep-core/src/scala/bleep/Prebootstrapped.scala
@@ -5,7 +5,7 @@ import bleep.logging.Logger
 /** At this point we assert that we *have* a build. it's not necessarily loaded yet
   */
 case class Prebootstrapped(logger: Logger, userPaths: UserPaths, buildPaths: BuildPaths, existingBuild: BuildLoader.Existing) {
-  def fresh: Either[BleepException, Prebootstrapped] =
+  def reloaded: Either[BleepException, Prebootstrapped] =
     BuildLoader
       .inDirectory(existingBuild.buildDirectory)
       .existing

--- a/bleep-core/src/scala/bleep/Started.scala
+++ b/bleep-core/src/scala/bleep/Started.scala
@@ -52,4 +52,16 @@ case class Started(
 
   def chosenTestProjects(maybeFromCommandLine: Option[Array[model.CrossProjectName]]): Array[model.CrossProjectName] =
     chosenProjects(maybeFromCommandLine).filter(projectName => build.explodedProjects(projectName).isTestProject.getOrElse(false))
+
+  def reloaded: Either[BleepException, Started] =
+    prebootstrapped.reloaded.flatMap { pre =>
+      bootstrap.from(
+        pre,
+        GenBloopFiles.SyncToDisk,
+        rewrites,
+        BleepConfigOps.lazyForceLoad(pre.userPaths),
+        CoursierResolver.Factory.default,
+        executionContext
+      )
+    }
 }

--- a/bleep-core/src/scala/bleep/commands/Clean.scala
+++ b/bleep-core/src/scala/bleep/commands/Clean.scala
@@ -7,8 +7,8 @@ import bleep.internal.FileUtils
 import java.nio.file.{Files, Path}
 import scala.util.Properties
 
-case class Clean(started: Started, projects: Array[model.CrossProjectName]) extends BleepCommand {
-  override def run(): Either[BleepException, Unit] = {
+case class Clean(projects: Array[model.CrossProjectName]) extends BleepBuildCommand {
+  override def run(started: Started): Either[BleepException, Unit] = {
     val outDirectories: Array[Path] =
       projects.map(projectName => started.bloopFiles(projectName).forceGet.project.out).filter(Files.exists(_))
 

--- a/bleep-core/src/scala/bleep/commands/Compile.scala
+++ b/bleep-core/src/scala/bleep/commands/Compile.scala
@@ -7,16 +7,16 @@ import ch.epfl.scala.bsp4j
 
 import scala.build.bloop.BloopServer
 
-case class Compile(started: Started, watch: Boolean, projects: Array[model.CrossProjectName])
-    extends BleepCommandRemote(started, watch, projects)
-    with BleepCommandRemote.OnlyChanged {
+case class Compile(watch: Boolean, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) with BleepCommandRemote.OnlyChanged {
 
-  override def onlyChangedProjects(isChanged: model.CrossProjectName => Boolean): Compile = {
+  override def chosenProjects(started: Started): Array[model.CrossProjectName] = projects
+
+  override def onlyChangedProjects(started: Started, isChanged: model.CrossProjectName => Boolean): Compile = {
     val ps = projects.filter(p => isChanged(p) || started.build.transitiveDependenciesFor(p).keys.exists(isChanged))
     copy(projects = ps)
   }
 
-  override def runWithServer(bloop: BloopServer): Either[BleepException, Unit] = {
+  override def runWithServer(started: Started, bloop: BloopServer): Either[BleepException, Unit] = {
     val targets = buildTargets(started.buildPaths, projects)
 
     val result = bloop.server.buildTargetCompile(new bsp4j.CompileParams(targets)).get()
@@ -26,4 +26,5 @@ case class Compile(started: Started, watch: Boolean, projects: Array[model.Cross
       case other               => Left(new BspCommandFailed(s"compile", projects, BspCommandFailed.StatusCode(other)))
     }
   }
+
 }

--- a/bleep-core/src/scala/bleep/commands/Compile.scala
+++ b/bleep-core/src/scala/bleep/commands/Compile.scala
@@ -7,9 +7,18 @@ import ch.epfl.scala.bsp4j
 
 import scala.build.bloop.BloopServer
 
-case class Compile(started: Started, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(started) {
+case class Compile(started: Started, watch: Boolean, projects: Array[model.CrossProjectName])
+    extends BleepCommandRemote(started, watch, projects)
+    with BleepCommandRemote.OnlyChanged {
+
+  override def onlyChangedProjects(isChanged: model.CrossProjectName => Boolean): Compile = {
+    val ps = projects.filter(p => isChanged(p) || started.build.transitiveDependenciesFor(p).keys.exists(isChanged))
+    copy(projects = ps)
+  }
+
   override def runWithServer(bloop: BloopServer): Either[BleepException, Unit] = {
     val targets = buildTargets(started.buildPaths, projects)
+
     val result = bloop.server.buildTargetCompile(new bsp4j.CompileParams(targets)).get()
 
     result.getStatusCode match {

--- a/bleep-core/src/scala/bleep/commands/Dist.scala
+++ b/bleep-core/src/scala/bleep/commands/Dist.scala
@@ -14,10 +14,10 @@ object Dist {
   )
 }
 
-case class Dist(started: Started, options: Dist.Options) extends BleepCommandRemote(started) {
+case class Dist(started: Started, watch: Boolean, options: Dist.Options) extends BleepCommandRemote(started, watch, Array(options.project)) {
   override def runWithServer(bloop: BloopServer): Either[BleepException, Unit] =
     for {
-      _ <- Compile(started, Array(options.project)).runWithServer(bloop)
+      _ <- Compile(started, watch = false, Array(options.project)).runWithServer(bloop)
       mainClass <- options.overrideMain match {
         case Some(x) => Right(x)
         case None =>

--- a/bleep-core/src/scala/bleep/commands/PublishLocal.scala
+++ b/bleep-core/src/scala/bleep/commands/PublishLocal.scala
@@ -19,16 +19,23 @@ object PublishLocal {
   }
 
   case class CustomMaven(mavenRepo: model.Repository.MavenFolder) extends PublishTarget {
-    val path = mavenRepo.path
+    val path: Path = mavenRepo.path
     override val publishLayout: PublishLayout = PublishLayout.Maven()
   }
 
-  case class Options(groupId: String, version: String, publishTarget: PublishLocal.PublishTarget, projects: List[model.CrossProjectName])
+  case class Options(groupId: String, version: String, publishTarget: PublishLocal.PublishTarget, projects: Array[model.CrossProjectName])
 }
 
-case class PublishLocal(started: Started, options: PublishLocal.Options) extends BleepCommandRemote(started) {
+case class PublishLocal(started: Started, watch: Boolean, options: PublishLocal.Options)
+    extends BleepCommandRemote(started, watch, options.projects)
+    with BleepCommandRemote.OnlyChanged {
+  override def onlyChangedProjects(isChanged: model.CrossProjectName => Boolean): PublishLocal = {
+    val ps = options.projects.filter(p => isChanged(p) || started.build.transitiveDependenciesFor(p).keys.exists(isChanged))
+    copy(options = options.copy(projects = ps))
+  }
+
   override def runWithServer(bloop: BloopServer): Either[BleepException, Unit] =
-    Compile(started, options.projects.toArray).runWithServer(bloop).map { case () =>
+    Compile(started, watch = false, options.projects).runWithServer(bloop).map { case () =>
       val packagedLibraries: SortedMap[model.CrossProjectName, PackagedLibrary] =
         packageLibraries(
           started,

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -19,14 +19,15 @@ import scala.util.{Failure, Success, Try}
   *   use raw stdin and stdout and avoid the logger
   */
 case class Run(
-    started: Started,
     project: model.CrossProjectName,
     maybeOverriddenMain: Option[String],
     args: List[String],
     raw: Boolean,
     watch: Boolean
-) extends BleepCommandRemote(started, watch, projects = Array(project)) {
-  override def runWithServer(bloop: BloopServer): Either[BleepException, Unit] = {
+) extends BleepCommandRemote(watch) {
+  override def chosenProjects(started: Started): Array[model.CrossProjectName] = Array(project)
+
+  override def runWithServer(started: Started, bloop: BloopServer): Either[BleepException, Unit] = {
     val maybeSpecifiedMain: Option[String] =
       maybeOverriddenMain.orElse(started.build.explodedProjects(project).platform.flatMap(_.mainClass))
 
@@ -35,22 +36,22 @@ case class Run(
         case Some(mainClass) => Right(mainClass)
         case None =>
           started.logger.info("No main class specified in build or command line. discovering...")
-          discoverMain(bloop, project)
+          discoverMain(started, bloop, project)
       }
 
     maybeMain.flatMap { main =>
       // we could definitely run js/native projects in "raw" mode as well, it just needs to be implemented
       started.build.explodedProjects(project).platform.flatMap(_.name) match {
         case Some(model.PlatformId.Jvm) | None if raw =>
-          rawRun(bloop, main)
+          rawRun(started, bloop, main)
         case _ =>
-          bspRun(bloop, main)
+          bspRun(started, bloop, main)
       }
     }
   }
 
-  def rawRun(bloop: BloopServer, main: String): Either[BleepException, Unit] =
-    Compile(started, watch = false, Array(project)).runWithServer(bloop).map { case () =>
+  def rawRun(started: Started, bloop: BloopServer, main: String): Either[BleepException, Unit] =
+    Compile(watch = false, Array(project)).runWithServer(started, bloop).map { case () =>
       val bloopProject = started.bloopProjects(project)
       val cp = fixedClasspath(bloopProject)
       cli(
@@ -70,9 +71,10 @@ case class Run(
         in = cli.In.Attach,
         env = sys.env.toList
       )
+      ()
     }
 
-  def bspRun(bloop: BloopServer, main: String): Either[BspCommandFailed, Unit] = {
+  def bspRun(started: Started, bloop: BloopServer, main: String): Either[BspCommandFailed, Unit] = {
     val params = new bsp4j.RunParams(buildTarget(started.buildPaths, project))
     val mainClass = new bsp4j.ScalaMainClass(main, args.asJava, List(s"-Duser.dir=${started.prebootstrapped.buildPaths.cwd}").asJava)
     val envs = sys.env.updated(jsonEvents.CallerProcessAcceptsJsonEvents, "true").map { case (k, v) => s"$k=$v" }.toList.sorted.asJava

--- a/bleep-core/src/scala/bleep/commands/Script.scala
+++ b/bleep-core/src/scala/bleep/commands/Script.scala
@@ -6,11 +6,12 @@ import cats.syntax.traverse._
 
 import scala.build.bloop.BloopServer
 
-case class Script(started: Started, name: model.ScriptName, args: List[String]) extends BleepCommandRemote(started) {
+case class Script(started: Started, name: model.ScriptName, args: List[String], watch: Boolean)
+    extends BleepCommandRemote(started, watch, started.build.scripts(name).values.map(_.project).distinct.toArray) {
   override def runWithServer(bloop: BloopServer): Either[BleepException, Unit] =
     started.build
       .scripts(name)
       .values
-      .traverse { case model.ScriptDef(project, main) => Run(started, project, Some(main), args = args, raw = false).runWithServer(bloop) }
+      .traverse { case model.ScriptDef(project, main) => Run(started, project, Some(main), args = args, raw = false, watch = false).runWithServer(bloop) }
       .map(_ => ())
 }

--- a/bleep-core/src/scala/bleep/commands/Test.scala
+++ b/bleep-core/src/scala/bleep/commands/Test.scala
@@ -4,15 +4,20 @@ package commands
 import bleep.BleepException
 import bleep.bsp.BspCommandFailed
 import ch.epfl.scala.bsp4j
-import ch.epfl.scala.bsp4j.CompileParams
 
 import scala.build.bloop.BloopServer
 
-case class Test(started: Started, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(started) {
+case class Test(started: Started, watch: Boolean, projects: Array[model.CrossProjectName])
+    extends BleepCommandRemote(started, watch, projects)
+    with BleepCommandRemote.OnlyChanged {
+
+  override def onlyChangedProjects(isChanged: model.CrossProjectName => Boolean): BleepCommandRemote = {
+    val ps = projects.filter(p => isChanged(p) || started.build.transitiveDependenciesFor(p).keys.exists(isChanged))
+    copy(projects = ps)
+  }
+
   override def runWithServer(bloop: BloopServer): Either[BleepException, Unit] = {
     val targets = buildTargets(started.buildPaths, projects)
-    // workaround for https://github.com/scalacenter/bloop/pull/1839
-    bloop.server.buildTargetCompile(new CompileParams(targets)).get()
     val result = bloop.server.buildTargetTest(new bsp4j.TestParams(targets)).get()
 
     result.getStatusCode match {

--- a/bleep-core/src/scala/bleep/internal/fatal.scala
+++ b/bleep-core/src/scala/bleep/internal/fatal.scala
@@ -6,6 +6,11 @@ import bleep.logging.Logger
 
 object fatal {
   def apply(context: String, logger: Logger, throwable: Throwable): Nothing = {
+    log(context, logger, throwable)
+    sys.exit(1)
+  }
+
+  def log(context: String, logger: Logger, throwable: Throwable): Unit =
     throwable match {
       case buildException: BleepException =>
         logger.debug(context, buildException)
@@ -13,7 +18,4 @@ object fatal {
       case unexpected =>
         logger.error(context, unexpected)
     }
-    sys.exit(1)
-  }
-
 }

--- a/bleep-tests/src/scala/bleep/CreateNewSnapshotTests.scala
+++ b/bleep-tests/src/scala/bleep/CreateNewSnapshotTests.scala
@@ -6,6 +6,7 @@ import bleep.testing.SnapshotTest
 import cats.data.NonEmptyList
 
 import java.nio.file.Path
+import scala.concurrent.ExecutionContext
 
 class CreateNewSnapshotTests extends SnapshotTest {
   test("create-new-build") {
@@ -37,7 +38,8 @@ class CreateNewSnapshotTests extends SnapshotTest {
           GenBloopFiles.InMemory,
           Nil,
           Lazy(model.BleepConfig.default),
-          testResolver
+          testResolver,
+          ExecutionContext.global
         )
 
       val generatedBloopFiles: Map[Path, String] =

--- a/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
@@ -9,6 +9,7 @@ import org.scalatest.Assertion
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 class IntegrationSnapshotTests extends SnapshotTest {
@@ -123,7 +124,8 @@ class IntegrationSnapshotTests extends SnapshotTest {
           GenBloopFiles.InMemory,
           rewrites = Nil,
           Lazy(model.BleepConfig.default),
-          testResolver
+          testResolver,
+          ExecutionContext.global
         )
         .orThrow
 

--- a/scripts/src/scala/bleep/scripts/PublishLocal.scala
+++ b/scripts/src/scala/bleep/scripts/PublishLocal.scala
@@ -6,7 +6,7 @@ import bleep.plugin.dynver.DynVerPlugin
 object PublishLocal extends BleepScript("PublishLocal") {
   def run(started: Started, commands: Commands, args: List[String]): Unit = {
     val dynVer = new DynVerPlugin(baseDirectory = started.buildPaths.buildDir.toFile, dynverSonatypeSnapshots = true)
-    val projects = started.build.explodedProjects.keys.toList.filter(projectsToPublish.include)
+    val projects = started.build.explodedProjects.keys.toArray.filter(projectsToPublish.include)
 
     commands.publishLocal(
       bleep.commands.PublishLocal.Options(


### PR DESCRIPTION
Fixes #221

- Use [swowal](https://github.com/swoval/swoval) to detect file changes
- ignore changes in files ending in `~` (temp files)
- include all source and resource directories for all chosen projects
- the `compile`, `test` and `publish-local` commands can rerun only changed projects (as opposed to everything). For now the semantics are that downstream projects will also be rerun, as long as they are among the projects you chose in the first place. I think that's the best way. Upstream dependencies will in any case be recompiled by Bloop as necessary.

https://user-images.githubusercontent.com/247937/208799772-1a09da3a-589b-4555-9f49-280086614e92.mp4


