### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             file_name: bleep
             artifact_name: bleep-x86_64-pc-linux
           - os: macos-latest
@@ -132,7 +132,7 @@ jobs:
 
   release:
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ build, build-native-image ]
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
@@ -153,7 +153,7 @@ jobs:
         run: find artifacts
       - name: Release
         run: |
-          chmod +x ./artifacts/bleep-x86_64-pc-linux/bleep
+          chmod +x ./artifacts/bleep-x86_64-pc-linux/bleep 
           ./artifacts/bleep-x86_64-pc-linux/bleep --dev generate-resources
           ./artifacts/bleep-x86_64-pc-linux/bleep --dev publish
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         if: runner.os == 'Windows'
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: '22.3.0'
           java-version: '17'
           components: 'native-image'
@@ -126,6 +127,7 @@ jobs:
       - name: Temporarily save package
         uses: actions/upload-artifact@v2
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.file_name }}
           retention-days: 1


### PR DESCRIPTION
## Revert "Pin gha ubuntu version to 20.04 (#236)"
Let's get it working again first, then find a way to downgrade ubuntu

## Find a solution for this problem, which suddenly appeared:
```
 Error: API rate limit exceeded for 52.226.31.96. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
 ```

Some googling left me with the impression that adding 
```
with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
```
should help.

