### PR TITLE
Split script declarations in two, and add support for running shell scripts

### DIFF
--- a/bleep-cli/src/scala/bleep/sbtimport/generateBuild.scala
+++ b/bleep-cli/src/scala/bleep/sbtimport/generateBuild.scala
@@ -78,7 +78,7 @@ object generateBuild {
 
       val buildWithScript = buildFile1.copy(
         projects = buildFile1.projects.updated(scriptProjectName.name, scriptsProject),
-        scripts = buildFile1.scripts.updated(model.ScriptName("generate-resources"), model.JsonList(List(model.ScriptDef(scriptProjectName, className))))
+        scripts = buildFile1.scripts.updated(model.ScriptName("generate-resources"), model.JsonList(List(model.ScriptDef.Main(scriptProjectName, className))))
       )
 
       val scriptPath = destinationPaths.project(scriptProjectName, scriptsProject).dir / "src/scala/scripts/GenerateResources.scala"

--- a/bleep-core/src/scala/bleep/BleepCommandRemote.scala
+++ b/bleep-core/src/scala/bleep/BleepCommandRemote.scala
@@ -11,7 +11,7 @@ import scala.build.blooprifle.internal.Operations
 import scala.jdk.CollectionConverters._
 
 abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
-  def chosenProjects(started: Started): Array[model.CrossProjectName]
+  def watchableProjects(started: Started): Array[model.CrossProjectName]
 
   def buildTarget(buildPaths: BuildPaths, name: model.CrossProjectName): bsp4j.BuildTargetIdentifier =
     new bsp4j.BuildTargetIdentifier(buildPaths.buildVariantDir.toFile.toURI.toASCIIString.stripSuffix("/") + "/?id=" + name.value)
@@ -70,7 +70,7 @@ abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
 
         var currentStarted = started
 
-        val codeWatcher = BleepFileWatching.projects(currentStarted, chosenProjects(currentStarted)) { changedProjects =>
+        val codeWatcher = BleepFileWatching.projects(currentStarted, watchableProjects(currentStarted)) { changedProjects =>
           val patchedCmd = this match {
             case x: BleepCommandRemote.OnlyChanged => x.onlyChangedProjects(currentStarted, changedProjects)
             case other                             => other
@@ -87,7 +87,7 @@ abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
               codeWatcher.updateMapping(Map.empty)
             case Right(newStarted) =>
               currentStarted = newStarted
-              codeWatcher.updateMapping(BleepFileWatching.projectPathsMapping(currentStarted, chosenProjects(currentStarted)))
+              codeWatcher.updateMapping(BleepFileWatching.projectPathsMapping(currentStarted, watchableProjects(currentStarted)))
           }
         }
 

--- a/bleep-core/src/scala/bleep/commands/Compile.scala
+++ b/bleep-core/src/scala/bleep/commands/Compile.scala
@@ -9,7 +9,7 @@ import scala.build.bloop.BloopServer
 
 case class Compile(watch: Boolean, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) with BleepCommandRemote.OnlyChanged {
 
-  override def chosenProjects(started: Started): Array[model.CrossProjectName] = projects
+  override def watchableProjects(started: Started): Array[model.CrossProjectName] = projects
 
   override def onlyChangedProjects(started: Started, isChanged: model.CrossProjectName => Boolean): Compile = {
     val ps = projects.filter(p => isChanged(p) || started.build.transitiveDependenciesFor(p).keys.exists(isChanged))

--- a/bleep-core/src/scala/bleep/commands/Dist.scala
+++ b/bleep-core/src/scala/bleep/commands/Dist.scala
@@ -15,7 +15,7 @@ object Dist {
 }
 
 case class Dist(started: Started, watch: Boolean, options: Dist.Options) extends BleepCommandRemote(watch) {
-  override def chosenProjects(started: Started): Array[model.CrossProjectName] = Array(options.project)
+  override def watchableProjects(started: Started): Array[model.CrossProjectName] = Array(options.project)
 
   override def runWithServer(started: Started, bloop: BloopServer): Either[BleepException, Unit] =
     for {

--- a/bleep-core/src/scala/bleep/commands/PublishLocal.scala
+++ b/bleep-core/src/scala/bleep/commands/PublishLocal.scala
@@ -27,7 +27,7 @@ object PublishLocal {
 }
 
 case class PublishLocal(watch: Boolean, options: PublishLocal.Options) extends BleepCommandRemote(watch) with BleepCommandRemote.OnlyChanged {
-  override def chosenProjects(started: Started): Array[model.CrossProjectName] = options.projects
+  override def watchableProjects(started: Started): Array[model.CrossProjectName] = options.projects
 
   override def onlyChangedProjects(started: Started, isChanged: model.CrossProjectName => Boolean): PublishLocal = {
     val ps = options.projects.filter(p => isChanged(p) || started.build.transitiveDependenciesFor(p).keys.exists(isChanged))

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -25,7 +25,7 @@ case class Run(
     raw: Boolean,
     watch: Boolean
 ) extends BleepCommandRemote(watch) {
-  override def chosenProjects(started: Started): Array[model.CrossProjectName] = Array(project)
+  override def watchableProjects(started: Started): Array[model.CrossProjectName] = Array(project)
 
   override def runWithServer(started: Started, bloop: BloopServer): Either[BleepException, Unit] = {
     val maybeSpecifiedMain: Option[String] =

--- a/bleep-core/src/scala/bleep/commands/Script.scala
+++ b/bleep-core/src/scala/bleep/commands/Script.scala
@@ -3,17 +3,56 @@ package commands
 
 import bleep.BleepException
 import cats.syntax.traverse._
+import coursier.jvm.JvmIndex
 
 import scala.build.bloop.BloopServer
 
 case class Script(name: model.ScriptName, args: List[String], watch: Boolean) extends BleepCommandRemote(watch) {
-  override def chosenProjects(started: Started): Array[model.CrossProjectName] =
-    started.build.scripts(name).values.map(_.project).distinct.toArray
+  override def watchableProjects(started: Started): Array[model.CrossProjectName] =
+    started.build
+      .scripts(name)
+      .values
+      .map {
+        case model.ScriptDef.Main(project, _) => project
+        case model.ScriptDef.Shell(_, _)      => throw new BleepException.Text("cannot `--watch shell` scripts for now")
+      }
+      .distinct
+      .toArray
 
   override def runWithServer(started: Started, bloop: BloopServer): Either[BleepException, Unit] =
     started.build
       .scripts(name)
       .values
-      .traverse { case model.ScriptDef(project, main) => Run(project, Some(main), args = args, raw = false, watch = false).runWithServer(started, bloop) }
+      .traverse {
+        case model.ScriptDef.Main(project, main) =>
+          Run(project, Some(main), args = args, raw = false, watch = watch).runWithServer(started, bloop)
+        case model.ScriptDef.Shell(command, overridesForOs) =>
+          val os = JvmIndex.defaultOs()
+          val bareCommand: String = overridesForOs.flatMap(_.get(os)).orElse(command).getOrElse {
+            throw new BleepException.Text(s"no command found for os $os")
+          }
+
+          val cmd = os match {
+            case "windows" =>
+              List("cmd.exe", "/C", bareCommand)
+            case _ =>
+              val quote = '"'.toString
+              val quotedQuote = "\\\\"
+              List("bash", "-c", bareCommand.replace(quote, quotedQuote))
+          }
+          try {
+            cli(
+              action = s"script ${name.value}",
+              cwd = started.buildPaths.cwd,
+              cmd = cmd,
+              logger = started.logger,
+              out = cli.Out.ViaLogger(started.logger),
+              in = cli.In.Attach
+            )
+            Right(())
+          } catch {
+            case x: BleepException => Left(x)
+          }
+      }
       .map(_ => ())
 }

--- a/bleep-core/src/scala/bleep/commands/Test.scala
+++ b/bleep-core/src/scala/bleep/commands/Test.scala
@@ -9,7 +9,7 @@ import scala.build.bloop.BloopServer
 
 case class Test(watch: Boolean, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) with BleepCommandRemote.OnlyChanged {
 
-  override def chosenProjects(started: Started): Array[model.CrossProjectName] = projects
+  override def watchableProjects(started: Started): Array[model.CrossProjectName] = projects
 
   override def onlyChangedProjects(started: Started, isChanged: model.CrossProjectName => Boolean): BleepCommandRemote = {
     val ps = projects.filter(p => isChanged(p) || started.build.transitiveDependenciesFor(p).keys.exists(isChanged))

--- a/bleep-model/src/scala/bleep/model/ScriptDef.scala
+++ b/bleep-model/src/scala/bleep/model/ScriptDef.scala
@@ -1,21 +1,42 @@
 package bleep.model
 
-import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+import io.circe.generic.semiauto.deriveCodec
+import io.circe._
 
-case class ScriptDef(project: CrossProjectName, main: String)
+sealed trait ScriptDef
 
 object ScriptDef {
-  implicit val decodes: Decoder[ScriptDef] = Decoder.instance(c =>
-    c.as[String].flatMap { str =>
-      str.split("/") match {
-        case Array(projectName, main) =>
-          CrossProjectName.decodes.decodeJson(Json.fromString(projectName)).map(crossProjectName => ScriptDef(crossProjectName, main))
+  case class Main(project: CrossProjectName, main: String) extends ScriptDef
+  object Main {
+    implicit val codec: Codec.AsObject[Main] = deriveCodec
+  }
 
-        case _ =>
-          Left(DecodingFailure(s"$str needs to be on the form `projectName(@crossId)/fully.qualified.Main`", c.history))
+  case class Shell(command: Option[String], `override-os`: Option[Map[String, String]]) extends ScriptDef
+  object Shell {
+    implicit val codec: Codec.AsObject[Shell] = deriveCodec
+  }
+
+  val fromString: Decoder[ScriptDef] =
+    Decoder.instance { c =>
+      c.as[String].flatMap { str =>
+        str.split("/") match {
+          case Array(projectName, main) =>
+            CrossProjectName.decodes.decodeJson(Json.fromString(projectName)).map { crossProjectName =>
+              ScriptDef.Main(crossProjectName, main)
+            }
+
+          case _ =>
+            Left(DecodingFailure(s"$str needs to be on the form `projectName(@crossId)/fully.qualified.Main`", c.history))
+        }
       }
     }
-  )
+
+  implicit val decodes: Decoder[ScriptDef] =
+    fromString.or(Main.codec.map(x => x: ScriptDef)).or(Shell.codec.map(x => x: ScriptDef))
+
   implicit val encodes: Encoder[ScriptDef] =
-    Encoder.instance(sd => Json.fromString(s"${sd.project.value}/${sd.main}"))
+    Encoder.instance {
+      case x: Main  => Json.fromJsonObject(Main.codec.encodeObject(x))
+      case x: Shell => Json.fromJsonObject(Shell.codec.encodeObject(x))
+    }
 }

--- a/schema.json
+++ b/schema.json
@@ -421,6 +421,50 @@
           ]
         }
       }
+    },
+    "ScriptMain": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "string"
+        },
+        "main": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "project",
+        "main"
+      ]
+    },
+    "ScriptShell": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "shell script to run - it can be multi-line. You can also omit this if you specify `override-os` for all relevant operating systems",
+          "type": "string"
+        },
+        "override-os": {
+          "description": "Override shell script for an os. Provide (`windows`, `darwin`, `linux` as key, and the script as value)",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "type",
+        "command"
+      ]
+    },
+    "Script": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ScriptMain"
+        },
+        {
+          "$ref": "#/$defs/ScriptShell"
+        }
+      ]
     }
   },
   "properties": {
@@ -435,6 +479,12 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/Project"
+      }
+    },
+    "scripts": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/Script"
       }
     },
     "templates": {

--- a/snapshot-tests-rewrites/drop-feature-flag/bloop/bleep.yaml
+++ b/snapshot-tests-rewrites/drop-feature-flag/bloop/bleep.yaml
@@ -686,7 +686,9 @@ resolvers:
 - type: ivy
   uri: https://repo.typesafe.com/typesafe/ivy-releases/
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common-main:
     sbt-scope: main

--- a/snapshot-tests-rewrites/drop-feature-flag/converter/bleep.yaml
+++ b/snapshot-tests-rewrites/drop-feature-flag/converter/bleep.yaml
@@ -90,7 +90,9 @@ resolvers:
   type: ivy
   uri: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     platform:

--- a/snapshot-tests-rewrites/drop-feature-flag/doobie/bleep.yaml
+++ b/snapshot-tests-rewrites/drop-feature-flag/doobie/bleep.yaml
@@ -280,7 +280,9 @@ projects:
     scala:
       version: 3.2.0
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     platform:

--- a/snapshot-tests-rewrites/drop-feature-flag/http4s/bleep.yaml
+++ b/snapshot-tests-rewrites/drop-feature-flag/http4s/bleep.yaml
@@ -760,7 +760,9 @@ projects:
     scala:
       version: 3.2.0
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     java:

--- a/snapshot-tests-rewrites/drop-feature-flag/sbt/bleep.yaml
+++ b/snapshot-tests-rewrites/drop-feature-flag/sbt/bleep.yaml
@@ -636,7 +636,9 @@ projects:
     - template-cross-all
     folder: ../sbt-build/zinc-lm-integration
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     java:

--- a/snapshot-tests-rewrites/drop-feature-flag/scalameta/bleep.yaml
+++ b/snapshot-tests-rewrites/drop-feature-flag/scalameta/bleep.yaml
@@ -271,7 +271,9 @@ projects:
     - ../tokens/shared/src/${SCOPE}/scala
     - ../tokens/shared/src/${SCOPE}/scala-${SCALA_BIN_VERSION}
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     scala:

--- a/snapshot-tests-rewrites/drop-feature-flag/tapir/bleep.yaml
+++ b/snapshot-tests-rewrites/drop-feature-flag/tapir/bleep.yaml
@@ -1206,7 +1206,9 @@ projects:
     - template-cross-jvm-all
     folder: ../sbt-build/client/testserver
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     scala:

--- a/snapshot-tests-rewrites/keep-selected-projects/bloop/bleep.yaml
+++ b/snapshot-tests-rewrites/keep-selected-projects/bloop/bleep.yaml
@@ -142,7 +142,9 @@ resolvers:
 - type: ivy
   uri: https://repo.typesafe.com/typesafe/ivy-releases/
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common-main:
     sbt-scope: main

--- a/snapshot-tests-rewrites/keep-selected-projects/converter/bleep.yaml
+++ b/snapshot-tests-rewrites/keep-selected-projects/converter/bleep.yaml
@@ -5,7 +5,9 @@ resolvers:
   type: ivy
   uri: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     platform:

--- a/snapshot-tests-rewrites/keep-selected-projects/doobie/bleep.yaml
+++ b/snapshot-tests-rewrites/keep-selected-projects/doobie/bleep.yaml
@@ -261,7 +261,9 @@ projects:
     - template-cross-all
     folder: ../sbt-build/modules/example
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     platform:

--- a/snapshot-tests-rewrites/keep-selected-projects/http4s/bleep.yaml
+++ b/snapshot-tests-rewrites/keep-selected-projects/http4s/bleep.yaml
@@ -677,7 +677,9 @@ projects:
     - template-cross-jvm-all
     folder: ../sbt-build/scalafix-internal/tests
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     java:

--- a/snapshot-tests-rewrites/keep-selected-projects/sbt/bleep.yaml
+++ b/snapshot-tests-rewrites/keep-selected-projects/sbt/bleep.yaml
@@ -542,7 +542,9 @@ projects:
     - template-cross-all
     folder: ../sbt-build/zinc-lm-integration
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     java:

--- a/snapshot-tests-rewrites/keep-selected-projects/scalameta/bleep.yaml
+++ b/snapshot-tests-rewrites/keep-selected-projects/scalameta/bleep.yaml
@@ -231,7 +231,9 @@ projects:
     - ../tokens/shared/src/${SCOPE}/scala
     - ../tokens/shared/src/${SCOPE}/scala-${SCALA_BIN_VERSION}
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     scala:

--- a/snapshot-tests-rewrites/keep-selected-projects/tapir/bleep.yaml
+++ b/snapshot-tests-rewrites/keep-selected-projects/tapir/bleep.yaml
@@ -958,7 +958,9 @@ projects:
     - template-cross-jvm-212-213
     folder: ../sbt-build/client/testserver
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     scala:

--- a/snapshot-tests/bloop/imported/bleep.yaml
+++ b/snapshot-tests/bloop/imported/bleep.yaml
@@ -687,7 +687,9 @@ resolvers:
 - type: ivy
   uri: https://repo.typesafe.com/typesafe/ivy-releases/
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common-main:
     sbt-scope: main

--- a/snapshot-tests/converter/imported/bleep.yaml
+++ b/snapshot-tests/converter/imported/bleep.yaml
@@ -90,7 +90,9 @@ resolvers:
   type: ivy
   uri: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     platform:

--- a/snapshot-tests/doobie/imported/bleep.yaml
+++ b/snapshot-tests/doobie/imported/bleep.yaml
@@ -280,7 +280,9 @@ projects:
     scala:
       version: 3.2.0
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     platform:

--- a/snapshot-tests/http4s/imported/bleep.yaml
+++ b/snapshot-tests/http4s/imported/bleep.yaml
@@ -760,7 +760,9 @@ projects:
     scala:
       version: 3.2.0
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     java:

--- a/snapshot-tests/sbt/imported/bleep.yaml
+++ b/snapshot-tests/sbt/imported/bleep.yaml
@@ -636,7 +636,9 @@ projects:
     - template-cross-all
     folder: ../sbt-build/zinc-lm-integration
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     java:

--- a/snapshot-tests/scalameta/imported/bleep.yaml
+++ b/snapshot-tests/scalameta/imported/bleep.yaml
@@ -271,7 +271,9 @@ projects:
     - ../tokens/shared/src/${SCOPE}/scala
     - ../tokens/shared/src/${SCOPE}/scala-${SCALA_BIN_VERSION}
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     scala:

--- a/snapshot-tests/tapir/imported/bleep.yaml
+++ b/snapshot-tests/tapir/imported/bleep.yaml
@@ -1206,7 +1206,9 @@ projects:
     - template-cross-jvm-all
     folder: ../sbt-build/client/testserver
 scripts:
-  generate-resources: scripts/scripts.GenerateResources
+  generate-resources:
+    main: scripts.GenerateResources
+    project: scripts
 templates:
   template-common:
     scala:


### PR DESCRIPTION
Fixes #227 and #226

- in the shell script structure `command` and `override-os` are optional, but bleep will error out if you try to run a script on an os where you have neither. override-os takes precedence

## example


```yaml
scripts:
  generate-docs:
    main: bleep.scripts.GenDocumentation
    project: scripts
  generate-resources:
    main: bleep.scripts.GenerateResources
    project: scripts-init
  generate-videos:
    main: bleep.scripts.GenDemoVideos
    project: scripts
  it:
    main: bleep.scripts.It
    project: scripts
  ls:
    command: ls -lah
    override-os:
      darwin: |
        cd bleep-core
        echo `pwd`
        ls -lah
      windows: dir
```

in the structure `ls` provides both `command` and `override-os` are optional, but bleep will error out if you try to run a script on an os where you have neither. `override-os` takes precedence  