### PR TITLE
Iterate on project selection

### DIFF
--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -3,7 +3,7 @@ package bleep
 import bleep.bsp.BspImpl
 import bleep.internal.{fatal, Os}
 import bleep.logging._
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.syntax.apply._
 import cats.syntax.foldable._
 import com.monovore.decline._
@@ -12,6 +12,7 @@ import coursier.jvm.{Execve, JvmIndex}
 import java.io.{BufferedWriter, PrintStream}
 import java.nio.file.{Path, Paths}
 import java.time.Instant
+import scala.collection.immutable.SortedMap
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Properties, Success, Try}
 
@@ -57,28 +58,39 @@ object Main {
       installTabCompletions(logger)
     ).foldK
 
-  def argumentFrom[A](defmeta: String, nameToValue: Option[Map[String, A]]): Argument[A] =
-    Argument.fromMap(defmeta, nameToValue.getOrElse(Map.empty))
+  def argumentFrom[A](defmeta: String, values: SortedMap[model.ProjectGlob, A]): Argument[A] =
+    new Argument[A] {
+      override def defaultMetavar: String = defmeta
+
+      override def read(string: String): ValidatedNel[String, A] =
+        values.get(model.ProjectGlob(string)) match {
+          case Some(t) => Validated.valid(t)
+          case None =>
+            Validated.invalidNel(
+              s"Unknown value: $string. Expected one of: ${values.iterator.map { case (model.ProjectGlob(str), _) => str }.mkString(", ")}."
+            )
+        }
+    }
 
   def hasBuildOpts(started: Started): Opts[BleepBuildCommand] = {
     val projectNamesNoCross: Opts[NonEmptyList[model.ProjectName]] =
       Opts
-        .arguments(metavars.projectNameNoCross)(argumentFrom(metavars.projectNameNoCross, Some(started.globs.projectNamesNoCrossMap)))
+        .arguments(metavars.projectNameNoCross)(argumentFrom(metavars.projectNameNoCross, started.globs.projectNamesNoCrossMap))
 
     val projectNames: Opts[Array[model.CrossProjectName]] =
       Opts
-        .arguments(metavars.projectName)(argumentFrom(metavars.projectName, Some(started.globs.projectNameMap)))
-        .map(_.toList.toArray.flatten)
+        .arguments(metavars.projectName)(argumentFrom(metavars.projectName, started.globs.projectNameMap))
+        .map(_.toList.toArray)
         .orNone
         .map(started.chosenProjects)
 
     val projectName: Opts[model.CrossProjectName] =
-      Opts.argument(metavars.projectNameExact)(argumentFrom(metavars.projectNameExact, Some(started.globs.exactProjectMap)))
+      Opts.argument(metavars.projectNameExact)(argumentFrom(metavars.projectNameExact, started.globs.exactProjectMap))
 
     val testProjectNames: Opts[Array[model.CrossProjectName]] =
       Opts
-        .arguments(metavars.testProjectName)(argumentFrom(metavars.testProjectName, Some(started.globs.testProjectNameMap)))
-        .map(_.toList.toArray.flatten)
+        .arguments(metavars.testProjectName)(argumentFrom(metavars.testProjectName, started.globs.testProjectNameMap))
+        .map(_.toList.toArray)
         .orNone
         .map(started.chosenTestProjects)
 
@@ -164,7 +176,7 @@ object Main {
               commands.Run(projectName, mainClass, arguments, raw = true, watch = watch)
             }
           ),
-          setupIdeCmd(started.buildPaths, started.logger, Some(started.globs.projectNameMap), started.executionContext),
+          setupIdeCmd(started.buildPaths, started.logger, started.globs.projectNameMap, started.executionContext),
           Opts.subcommand("clean", "clean")(
             projectNames.map(projectNames => commands.Clean(projectNames))
           ),
@@ -269,13 +281,15 @@ object Main {
   def setupIdeCmd(
       buildPaths: BuildPaths,
       logger: Logger,
-      projectNameMap: Option[Map[String, Array[model.CrossProjectName]]],
+      projectNameMap: SortedMap[model.ProjectGlob, model.ProjectSelection],
       ec: ExecutionContext
   ): Opts[BleepCommand] = {
-    val projectNamesNoExpand: Opts[Option[List[String]]] =
+    val projectNamesNoExpand: Opts[Option[Array[model.ProjectGlob]]] =
       Opts
-        .arguments(metavars.projectName)(argumentFrom(metavars.projectName, projectNameMap.map(_.map { case (s, _) => (s, s) })))
-        .map(_.toList)
+        .arguments(metavars.projectName)(
+          argumentFrom(metavars.projectName, projectNameMap.map { case (s, _) => (s, s) })
+        )
+        .map(_.toList.toArray)
         .orNone
 
     Opts.subcommand("setup-ide", "generate ./bsp/bleep.json so IDEs can import build")(
@@ -356,9 +370,9 @@ object Main {
         val completions = buildLoader match {
           case noBuild: BuildLoader.NonExisting =>
             val completer = new Completer({
-              case metavars.platformName => model.PlatformId.All.map(_.value)
-              case metavars.scalaVersion => possibleScalaVersions.keys.toList
-              case _                     => Nil
+              case metavars.platformName => model.PlatformId.All.map(_.value).toArray
+              case metavars.scalaVersion => possibleScalaVersions.keys.toArray
+              case _                     => Array.empty
             })
             completer.completeOpts(restArgs)(noBuildOpts(logger, buildPaths, noBuild, userPaths))
           case existing: BuildLoader.Existing =>
@@ -370,14 +384,19 @@ object Main {
               case Left(th) => fatal("couldn't load build", logger, th)
 
               case Right(started) =>
+                def from[V](m: SortedMap[model.ProjectGlob, V]): Array[String] = {
+                  val b = Array.newBuilder[String]
+                  m.foreach { case (glob, _) => b += glob.value }
+                  b.result()
+                }
                 val completer = new Completer({
-                  case metavars.platformName       => model.PlatformId.All.map(_.value)
-                  case metavars.scalaVersion       => possibleScalaVersions.keys.toList
-                  case metavars.projectNameExact   => started.globs.exactProjectMap.keys.toList
-                  case metavars.projectNameNoCross => started.globs.projectNamesNoCrossMap.keys.toList
-                  case metavars.projectName        => started.globs.projectNameMap.keys.toList
-                  case metavars.testProjectName    => started.globs.testProjectNameMap.keys.toList
-                  case _                           => Nil
+                  case metavars.platformName       => model.PlatformId.All.map(_.value).toArray
+                  case metavars.scalaVersion       => possibleScalaVersions.keys.toArray
+                  case metavars.projectNameExact   => from(started.globs.exactProjectMap)
+                  case metavars.projectNameNoCross => from(started.globs.projectNamesNoCrossMap)
+                  case metavars.projectName        => from(started.globs.projectNameMap)
+                  case metavars.testProjectName    => from(started.globs.testProjectNameMap)
+                  case _                           => Array.empty
                 })
                 completer.completeOpts(restArgs)(hasBuildOpts(started))
             }

--- a/bleep-cli/src/scala/bleep/commands/SetupIde.scala
+++ b/bleep-cli/src/scala/bleep/commands/SetupIde.scala
@@ -13,7 +13,8 @@ import java.util
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
-case class SetupIde(buildPaths: BuildPaths, logger: Logger, maybeSelectedProjects: Option[List[String]], ec: ExecutionContext) extends BleepCommand {
+case class SetupIde(buildPaths: BuildPaths, logger: Logger, maybeSelectedProjects: Option[Array[model.ProjectGlob]], ec: ExecutionContext)
+    extends BleepCommand {
   implicit def encodesUtilList[T: Encoder]: Encoder[util.List[T]] = Encoder[List[T]].contramap(_.asScala.toList)
   implicit val encoder: Encoder[bsp4j.BspConnectionDetails] =
     Encoder.forProduct5[bsp4j.BspConnectionDetails, String, util.List[String], String, String, util.List[String]](

--- a/bleep-core/src/scala/bleep/Started.scala
+++ b/bleep-core/src/scala/bleep/Started.scala
@@ -40,9 +40,9 @@ case class Started(
     FetchJvm(Some(userPaths.resolveJvmCacheDir), new BleepCacheLogger(logger), jvm, executionContext)
   }
 
-  def chosenProjects(maybeFromCommandLine: Option[Array[model.CrossProjectName]]): Array[model.CrossProjectName] =
+  def chosenProjects(maybeFromCommandLine: Option[Array[model.ProjectSelection]]): Array[model.CrossProjectName] =
     maybeFromCommandLine match {
-      case Some(fromCommandLine) => fromCommandLine.sorted
+      case Some(fromCommandLine) => fromCommandLine.selection
       case None =>
         activeProjectsFromPath match {
           case None           => build.explodedProjects.keys.toArray.sorted
@@ -50,7 +50,7 @@ case class Started(
         }
     }
 
-  def chosenTestProjects(maybeFromCommandLine: Option[Array[model.CrossProjectName]]): Array[model.CrossProjectName] =
+  def chosenTestProjects(maybeFromCommandLine: Option[Array[model.ProjectSelection]]): Array[model.CrossProjectName] =
     chosenProjects(maybeFromCommandLine).filter(projectName => build.explodedProjects(projectName).isTestProject.getOrElse(false))
 
   def reloadFromDisk(rewrites: List[BuildRewrite]): Either[BleepException, Started] =

--- a/bleep-core/src/scala/bleep/bsp/BspProjectSelection.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspProjectSelection.scala
@@ -8,7 +8,7 @@ import java.nio.file.{Files, Path}
 object BspProjectSelection {
   def file(buildPaths: BuildPaths): Path = buildPaths.buildsDir / "bsp" / "project-selection.yaml"
 
-  def store(buildPaths: BuildPaths, maybeSelectedProjectGlobs: Option[List[String]]): Unit =
+  def store(buildPaths: BuildPaths, maybeSelectedProjectGlobs: Option[Array[model.ProjectGlob]]): Unit =
     maybeSelectedProjectGlobs match {
       case Some(selectedProjectGlobs) =>
         yaml.writeShortened(selectedProjectGlobs, file(buildPaths))
@@ -17,9 +17,9 @@ object BspProjectSelection {
         ()
     }
 
-  def load(buildPaths: BuildPaths): Either[BleepException, Option[List[String]]] =
+  def load(buildPaths: BuildPaths): Either[BleepException, Option[Array[model.ProjectGlob]]] =
     if (FileUtils.exists(file(buildPaths))) {
-      yaml.decode[List[String]](Files.readString(file(buildPaths))) match {
+      yaml.decode[Array[model.ProjectGlob]](Files.readString(file(buildPaths))) match {
         case Left(err)       => Left(new BleepException.InvalidJson(file(buildPaths), err))
         case Right(selected) => Right(Some(selected))
       }

--- a/bleep-model/src/scala/bleep/model/ProjectGlob.scala
+++ b/bleep-model/src/scala/bleep/model/ProjectGlob.scala
@@ -1,0 +1,10 @@
+package bleep.model
+
+import io.circe.{Codec, Decoder, Encoder}
+
+case class ProjectGlob(value: String) extends AnyVal
+
+object ProjectGlob {
+  implicit val codec: Codec[ProjectGlob] = Codec.from(Decoder[String].map(apply), Encoder[String].contramap(_.value))
+  implicit val ordering: Ordering[ProjectGlob] = Ordering[String].on(_.value)
+}

--- a/bleep-model/src/scala/bleep/model/ProjectGlobs.scala
+++ b/bleep-model/src/scala/bleep/model/ProjectGlobs.scala
@@ -1,43 +1,24 @@
 package bleep.model
 
+import scala.collection.immutable.SortedMap
+import scala.collection.mutable
+
 /** Represents named groups of projects based on scala version and platforms
   */
 class ProjectGlobs(activeProjectsFromPath: Option[Array[CrossProjectName]], explodedProjects: Map[CrossProjectName, Project]) {
-  def projectCompletions(projects: Array[CrossProjectName]): Map[String, Array[CrossProjectName]] = {
-    val crossNames: Map[String, Array[CrossProjectName]] =
-      projects.map(projectName => projectName.value -> Array(projectName)).toMap
-    val projectNames: Map[String, Array[CrossProjectName]] =
-      projects.groupBy { case CrossProjectName(name, _) => name.value }
-    val crossIds: Map[String, Array[CrossProjectName]] =
-      projects
-        .groupBy { case name @ CrossProjectName(_, crossId) =>
-          crossId.orElse {
-            val p = explodedProjects(name)
-            CrossId.defaultFrom(
-              p.scala.flatMap(_.version),
-              p.platform.flatMap(_.name),
-              isFull = false // todo: represent in project
-            )
-          }
-        }
-        .collect { case (Some(crossId), names) => (crossId.value, names) }
+  lazy val exactProjectMap: SortedMap[ProjectGlob, CrossProjectName] =
+    SortedMap.empty[ProjectGlob, CrossProjectName] ++ explodedProjects.map { case (crossName, _) => ProjectGlob(crossName.value) -> crossName }
 
-    crossIds ++ projectNames ++ crossNames
-  }
-
-  def exactProjectMap: Map[String, CrossProjectName] =
-    explodedProjects.map { case (crossName, _) => crossName.value -> crossName }
-
-  def projectNameMap: Map[String, Array[CrossProjectName]] = {
+  lazy val projectNameMap: SortedMap[ProjectGlob, ProjectSelection] = {
     val projects: Array[CrossProjectName] =
       activeProjectsFromPath match {
         case None           => explodedProjects.keys.toArray
         case Some(nonEmpty) => nonEmpty
       }
-    projectCompletions(projects)
+    ProjectGlobs.make(explodedProjects, projects)
   }
 
-  def testProjectNameMap: Map[String, Array[CrossProjectName]] = {
+  lazy val testProjectNameMap: SortedMap[ProjectGlob, ProjectSelection] = {
     val projects: Array[CrossProjectName] =
       activeProjectsFromPath match {
         case None           => explodedProjects.keys.toArray
@@ -46,15 +27,66 @@ class ProjectGlobs(activeProjectsFromPath: Option[Array[CrossProjectName]], expl
 
     val testProjects = projects.filter(projectName => explodedProjects(projectName).isTestProject.getOrElse(false))
 
-    projectCompletions(testProjects)
+    ProjectGlobs.make(explodedProjects, testProjects)
   }
 
-  def projectNamesNoCrossMap: Map[String, ProjectName] = {
+  lazy val projectNamesNoCrossMap: SortedMap[ProjectGlob, ProjectName] = {
     val projects: Iterable[CrossProjectName] =
       activeProjectsFromPath match {
         case None           => explodedProjects.keys
         case Some(nonEmpty) => nonEmpty
       }
-    projects.map(p => (p.name.value, p.name)).toMap
+    SortedMap.empty[ProjectGlob, ProjectName] ++ projects.map(p => (ProjectGlob(p.name.value), p.name)).toMap
+  }
+}
+object ProjectGlobs {
+  def make(explodedProjects: Map[CrossProjectName, Project], projects: Array[CrossProjectName]): SortedMap[ProjectGlob, ProjectSelection] = {
+    val includes = mutable.Map.empty[ProjectGlob, mutable.ArrayBuilder[CrossProjectName]]
+    val excludes = mutable.Map.empty[ProjectGlob, mutable.ArrayBuilder[CrossProjectName]]
+
+    def addInclude(group: String, name: CrossProjectName): Unit =
+      includes.getOrElseUpdate(ProjectGlob(group), mutable.ArrayBuilder.make[CrossProjectName]) += name
+
+    def addExclude(group: String, name: CrossProjectName): Unit =
+      excludes.getOrElseUpdate(ProjectGlob(s"~$group"), mutable.ArrayBuilder.make[CrossProjectName]) += name
+
+    def addBoth(group: String, name: CrossProjectName): Unit = {
+      addInclude(group, name)
+      addExclude(group, name)
+    }
+
+    projects.foreach { name =>
+      val p = explodedProjects(name)
+      val isTest = p.isTestProject.getOrElse(false)
+
+      addInclude(name.value, name)
+      addBoth(if (isTest) "@test" else "@main", name)
+      if (name.crossId.isDefined) addInclude(name.name.value + "@*", name)
+
+      val crossId = name.crossId.orElse {
+        val p = explodedProjects(name)
+        CrossId.defaultFrom(
+          p.scala.flatMap(_.version),
+          p.platform.flatMap(_.name),
+          isFull = false // todo: represent in project
+        )
+      }
+
+      crossId.foreach { crossId =>
+        addBoth(s"@${crossId.value}", name)
+      }
+      p.platform.flatMap(_.name).foreach { platformId =>
+        addBoth(s"@${platformId.value}", name)
+      }
+      p.scala.flatMap(_.version).foreach { scalaVersion =>
+        addBoth(s"@${scalaVersion.binVersion.filter(_.isDigit)}", name)
+        addBoth(s"@${scalaVersion.epoch.toString}", name)
+      }
+    }
+
+    SortedMap.empty[ProjectGlob, ProjectSelection] ++ (
+      includes.iterator.map { case (group, b) => (group, ProjectSelection.Include(b.result())) } ++
+        excludes.iterator.map { case (group, b) => (group, ProjectSelection.Exclude(b.result())) }
+    )
   }
 }

--- a/bleep-model/src/scala/bleep/model/ProjectSelection.scala
+++ b/bleep-model/src/scala/bleep/model/ProjectSelection.scala
@@ -1,0 +1,26 @@
+package bleep.model
+
+import scala.collection.mutable
+
+sealed trait ProjectSelection
+
+object ProjectSelection {
+  case object None extends ProjectSelection
+
+  case class Include(projectNames: Array[CrossProjectName]) extends ProjectSelection
+
+  case class Exclude(projectNames: Array[CrossProjectName]) extends ProjectSelection
+
+  implicit class SelectionOps(private val selections: Array[ProjectSelection]) extends AnyVal {
+    def selection: Array[CrossProjectName] = {
+      val ret = mutable.Set.empty[CrossProjectName]
+      selections.iterator.foreach {
+        case ProjectSelection.None                  => ()
+        case ProjectSelection.Include(projectNames) => ret ++= projectNames
+        case ProjectSelection.Exclude(projectNames) => ret --= projectNames
+      }
+      ret.toArray
+    }
+
+  }
+}

--- a/bleep-model/src/scala/bleep/rewrites/keepSelectedProjects.scala
+++ b/bleep-model/src/scala/bleep/rewrites/keepSelectedProjects.scala
@@ -1,10 +1,10 @@
 package bleep
 package rewrites
 
-case class keepSelectedProjects(selectedProjectGlobs: List[String]) extends BuildRewrite {
+case class keepSelectedProjects(selectedProjectGlobs: Array[model.ProjectGlob]) extends BuildRewrite {
   override val name = model.BuildRewriteName("keep-selected-projects")
 
-  def selectedPlusTransitiveDeps(selectedProjectNames: List[model.CrossProjectName], build: model.Build): Set[model.CrossProjectName] = {
+  def selectedPlusTransitiveDeps(selectedProjectNames: Array[model.CrossProjectName], build: model.Build): Set[model.CrossProjectName] = {
     val b = Set.newBuilder[model.CrossProjectName]
     selectedProjectNames.foreach { name =>
       b += name
@@ -14,7 +14,7 @@ case class keepSelectedProjects(selectedProjectGlobs: List[String]) extends Buil
   }
   protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] = {
     val globs = new model.ProjectGlobs(None, oldBuild.explodedProjects)
-    val selectedProjectNames = selectedProjectGlobs.flatMap(str => globs.projectNameMap.getOrElse(str, Array.empty[model.CrossProjectName]))
+    val selectedProjectNames = selectedProjectGlobs.flatMap(globs.projectNameMap.get).selection
     val withTransitive = selectedPlusTransitiveDeps(selectedProjectNames, oldBuild)
 
     val chosen = oldBuild.explodedProjects.filter { case (name, _) => withTransitive(name) }

--- a/bleep-tests/src/scala/bleep/RewriteSnapshotTest.scala
+++ b/bleep-tests/src/scala/bleep/RewriteSnapshotTest.scala
@@ -25,7 +25,7 @@ class RewriteSnapshotTest extends SnapshotTest {
 
   val rewrites: List[BuildRewrite] = List(
     DropFeatureFlag,
-    keepSelectedProjects(List("jvm213"))
+    keepSelectedProjects(Array(model.ProjectGlob("@jvm213")))
   )
 
   private val foundBuilds: List[BuildLoader.Existing] =

--- a/bleep-tests/src/scala/com/monovore/decline/CompleterTest.scala
+++ b/bleep-tests/src/scala/com/monovore/decline/CompleterTest.scala
@@ -11,7 +11,7 @@ class CompleterTest extends AnyFunSuite with TypeCheckedTripleEquals {
   case class Number(str: String)
   object Number {
     val metavar: String = "number"
-    val valids = List("one", "two", "three")
+    val valids = Array("one", "two", "three")
 
     implicit val argument: Argument[Number] =
       Argument.fromMap(metavar, valids.map(x => (x, Number(x))).toMap)
@@ -47,7 +47,7 @@ class CompleterTest extends AnyFunSuite with TypeCheckedTripleEquals {
 
   test("works") {
     val completer = new Completer({
-      case Project.metavar => List("common", "core", "test")
+      case Project.metavar => Array("common", "core", "test")
       case Number.metavar  => Number.valids
       case metavar         => sys.error(s"specify how to complete metavar $metavar")
     })
@@ -68,14 +68,14 @@ class CompleterTest extends AnyFunSuite with TypeCheckedTripleEquals {
 
     val opts = subCommands.foldK
 
-    assert(completer.completeOpts(Nil)(opts).value === List(compile, compose, testCmd))
-    assert(completer.completeOpts(List("co"))(opts).value === List(compile, compose))
-    assert(completer.completeOpts(List("te"))(opts).value === List(testCmd))
-    assert(completer.completeOpts(List("compile", "co"))(opts).value === List(common, core))
-    assert(completer.completeOpts(List("compile", "core", "te"))(opts).value === List(testProj))
-    assert(completer.completeOpts(List("compile", ""))(opts).value === List(foobar, f, bar, b, common, core, testProj))
-    assert(completer.completeOpts(List("compile", "--bar", ""))(opts).value === List(one, two, three))
-    assert(completer.completeOpts(List("compile", "--bar", "t"))(opts).value === List(two, three))
+    assert(completer.completeOpts(Nil)(opts).value === Array(compile, compose, testCmd))
+    assert(completer.completeOpts(List("co"))(opts).value === Array(compile, compose))
+    assert(completer.completeOpts(List("te"))(opts).value === Array(testCmd))
+    assert(completer.completeOpts(List("compile", "co"))(opts).value === Array(common, core))
+    assert(completer.completeOpts(List("compile", "core", "te"))(opts).value === Array(testProj))
+    assert(completer.completeOpts(List("compile", ""))(opts).value === Array(foobar, f, bar, b, common, core, testProj))
+    assert(completer.completeOpts(List("compile", "--bar", ""))(opts).value === Array(one, two, three))
+    assert(completer.completeOpts(List("compile", "--bar", "t"))(opts).value === Array(two, three))
   }
 
   test("repeated options") {
@@ -102,33 +102,33 @@ class CompleterTest extends AnyFunSuite with TypeCheckedTripleEquals {
       )
 
     val completer = new Completer({
-      case `platformMetavar` => platforms.keys.toList
-      case `fooMetavar`      => foos.keys.toList
-      case _                 => Nil
+      case `platformMetavar` => platforms.keys.toArray
+      case `fooMetavar`      => foos.keys.toArray
+      case _                 => Array.empty
     })
 
-    assert(completer.completeOpts(List("cmd1", "cmd2", "--p"))(opts).value === List(Completion("--platform", Some(platformHelp))))
-    assert(completer.completeOpts(List("cmd1", "cmd2", "-p"))(opts).value === Nil)
+    assert(completer.completeOpts(List("cmd1", "cmd2", "--p"))(opts).value === Array(Completion("--platform", Some(platformHelp))))
+    assert(completer.completeOpts(List("cmd1", "cmd2", "-p"))(opts).value === Array.empty[Completion])
     assert(
-      completer.completeOpts(List("cmd1", "cmd2", "-p", ""))(opts).value === List(
+      completer.completeOpts(List("cmd1", "cmd2", "-p", ""))(opts).value === Array(
         Completion("jvm", Some(platformMetavar)),
         Completion("js", Some(platformMetavar)),
         Completion("native", Some(platformMetavar))
       )
     )
     assert(
-      completer.completeOpts(List("cmd1", "cmd2", "-p", "j"))(opts).value === List(
+      completer.completeOpts(List("cmd1", "cmd2", "-p", "j"))(opts).value === Array(
         Completion("jvm", Some(platformMetavar)),
         Completion("js", Some(platformMetavar))
       )
     )
     assert(
-      completer.completeOpts(List("cmd1", "cmd2", "-p", "jvm", "-p", "n"))(opts).value === List(
+      completer.completeOpts(List("cmd1", "cmd2", "-p", "jvm", "-p", "n"))(opts).value === Array(
         Completion("native", Some(platformMetavar))
       )
     )
     assert(
-      completer.completeOpts(List("cmd1", "cmd2", "-p", "jvm", "-f", "o"))(opts).value === List(
+      completer.completeOpts(List("cmd1", "cmd2", "-p", "jvm", "-f", "o"))(opts).value === Array(
         Completion("one", Some(fooMetavar))
       )
     )


### PR DESCRIPTION
## Can now choose projects by:
- `@2` or `@3` for epoch scala versions
- `@213` for scala binary versions
- `@native`, `@js`, `@jvm` for platform
- `main`/`test` to account for `isTestProject`
- `@jvm213` still works like before

## Can also subtract projects from selection by prefixing `~` `@2 ~@jvm` will choose all projects for for instance 2.12 and 2.13 except those for jvm platform