### PR TITLE
Schema: Allow RelPath to point to current directory

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -71,7 +71,7 @@
     },
     "RelPath": {
       "type": "string",
-      "pattern": "^\\.\\.?/.+$"
+      "pattern": "^\\.\\.?/.*$"
     },
     "Dependency": {
       "anyOf": [


### PR DESCRIPTION
This change allows using `./` as a relative path.

In a project I tried to convert, `bleep import` created a file with `templates.template-common.folder: ./`, which is correct, but was refused by the schema.
