### PR TITLE
config/logging: Use config file to enable timing in log messages. Add…

### DIFF
--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -33,17 +33,17 @@ object BspImpl {
 
       val localClient = new BspForwardClient(Some(launcher.getRemoteProxy))
 
-      val bleepConfig = BleepConfigOps.loadOrDefault(pre.userPaths).orThrow
+      val config = BleepConfigOps.loadOrDefault(pre.userPaths).orThrow
       val build = pre.existingBuild.buildFile.forceGet.orThrow
       val bleepRifleLogger = new BleepRifleLogger(pre.logger)
 
       val bloopRifleConfig =
         SetupBloopRifle(
-          compileServerMode = bleepConfig.compileServerMode,
+          compileServerMode = config.compileServerModeOrDefault,
           jvm = jvmOrSystem(build.jvm, pre.logger),
           logger = pre.logger,
           userPaths = pre.userPaths,
-          resolver = Lazy(CoursierResolver.Factory.default(pre, bleepConfig, build)),
+          resolver = CoursierResolver.Factory.default(pre, config, build),
           bleepRifleLogger = bleepRifleLogger,
           executionContext = ExecutionContext.fromExecutor(threads.prepareBuildExecutor)
         )
@@ -67,7 +67,7 @@ object BspImpl {
             ).flatten
 
             pre.reloadFromDisk().flatMap { pre =>
-              bootstrap.from(pre, GenBloopFiles.SyncToDisk, bspRewrites, Lazy(bleepConfig), CoursierResolver.Factory.default, ExecutionContext.global)
+              bootstrap.from(pre, GenBloopFiles.SyncToDisk, bspRewrites, config, CoursierResolver.Factory.default, ExecutionContext.global)
             }
           }
 

--- a/bleep-cli/src/scala/bleep/commands/BuildDiffBloop.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildDiffBloop.scala
@@ -43,8 +43,8 @@ case class BuildDiffBloop(opts: BuildDiff.Options, projects: Array[model.CrossPr
         ),
         genBloopFiles = GenBloopFiles.InMemory,
         rewrites = Nil,
-        lazyConfig = started.lazyConfig,
-        resolver = (_, _, _) => started.resolver.forceGet,
+        config = started.config,
+        resolverFactory = (_, _, _) => started.resolver,
         executionContext = started.executionContext
       )
       .orThrow

--- a/bleep-cli/src/scala/bleep/commands/BuildUpdateDeps.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildUpdateDeps.scala
@@ -23,8 +23,7 @@ case object BuildUpdateDeps extends BleepBuildCommand {
     val allDeps: Map[UpgradeDependencies.ContextualDep, Dependency] =
       instantiateAllDependencies(build)
 
-    val config = started.lazyConfig.forceGet
-    val repos = CoursierResolver.coursierRepos(build.resolvers.values, config.authentications).filter(_.repr.contains("http"))
+    val repos = CoursierResolver.coursierRepos(build.resolvers.values, started.config.authentications).filter(_.repr.contains("http"))
     val fileCache = FileCache[Task]().withLogger(new BleepCacheLogger(started.logger))
 
     val foundByDep: Map[UpgradeDependencies.ContextualDep, (Dependency, Versions)] = {

--- a/bleep-cli/src/scala/bleep/commands/CompileServerSetMode.scala
+++ b/bleep-cli/src/scala/bleep/commands/CompileServerSetMode.scala
@@ -6,5 +6,5 @@ import bleep.logging.Logger
 
 case class CompileServerSetMode(logger: Logger, userPaths: UserPaths, mode: model.CompileServerMode) extends BleepCommand {
   override def run(): Either[BleepException, Unit] =
-    BleepConfigOps.rewritePersisted(logger, userPaths)(_.copy(compileServerMode = mode)).map(_ => ())
+    BleepConfigOps.rewritePersisted(logger, userPaths)(_.copy(compileServerMode = Some(mode))).map(_ => ())
 }

--- a/bleep-core/src/scala/bleep/BleepCommandRemote.scala
+++ b/bleep-core/src/scala/bleep/BleepCommandRemote.scala
@@ -28,11 +28,9 @@ abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
   def runWithServer(started: Started, bloop: BloopServer): Either[BleepException, Unit]
 
   override final def run(started: Started): Either[BleepException, Unit] = {
-    val bleepConfig = started.lazyConfig.forceGet
-
-    bleepConfig.compileServerMode match {
+    started.config.compileServerModeOrDefault match {
       case model.CompileServerMode.NewEachInvocation =>
-        started.logger.warn("TIP: run `bleep compile-server auto-shutdown-disable` so you'll get a warm/fast compile server")
+        started.logger.warn("TIP: run `bleep config compile-server auto-shutdown-disable` so you'll get a warm/fast compile server")
       case model.CompileServerMode.Shared => ()
     }
 
@@ -41,7 +39,7 @@ abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
     val bleepRifleLogger = new BleepRifleLogger(started.logger)
     val bloopRifleConfig: BloopRifleConfig =
       SetupBloopRifle(
-        bleepConfig.compileServerMode,
+        started.config.compileServerModeOrDefault,
         bloopJvm,
         started.logger,
         started.pre.userPaths,
@@ -118,7 +116,7 @@ abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
           }
         }
     finally
-      bleepConfig.compileServerMode match {
+      started.config.compileServerModeOrDefault match {
         case model.CompileServerMode.NewEachInvocation =>
           server.shutdown()
           Operations.exit(bloopRifleConfig.address, started.buildPaths.dotBleepDir, System.out, System.err, bleepRifleLogger)

--- a/bleep-core/src/scala/bleep/GenBloopFiles.scala
+++ b/bleep-core/src/scala/bleep/GenBloopFiles.scala
@@ -19,7 +19,7 @@ trait GenBloopFiles {
   def apply(
       logger: Logger,
       buildPaths: BuildPaths,
-      lazyResolver: Lazy[CoursierResolver],
+      resolver: CoursierResolver,
       build: model.Build,
       fetchNode: FetchNode
   ): GenBloopFiles.Files
@@ -28,10 +28,10 @@ trait GenBloopFiles {
 object GenBloopFiles {
   type Files = SortedMap[model.CrossProjectName, Lazy[Config.File]]
 
-  val InMemory: GenBloopFiles = (_, buildPaths, lazyResolver, build, fetchNode) =>
+  val InMemory: GenBloopFiles = (_, buildPaths, resolver, build, fetchNode) =>
     rewriteDependentData(build.explodedProjects).apply { (crossName, project, eval) =>
       translateProject(
-        lazyResolver.forceGet,
+        resolver,
         buildPaths,
         crossName,
         project,

--- a/bleep-core/src/scala/bleep/Prebootstrapped.scala
+++ b/bleep-core/src/scala/bleep/Prebootstrapped.scala
@@ -11,10 +11,3 @@ case class Prebootstrapped(logger: Logger, userPaths: UserPaths, buildPaths: Bui
       .existing
       .map(newExisting => copy(existingBuild = newExisting))
 }
-
-object Prebootstrapped {
-  def apply(buildPaths: BuildPaths, logger: Logger, existing: BuildLoader.Existing): Prebootstrapped = {
-    val userPaths = UserPaths.fromAppDirs
-    Prebootstrapped(logger, userPaths, buildPaths, existing)
-  }
-}

--- a/bleep-core/src/scala/bleep/Started.scala
+++ b/bleep-core/src/scala/bleep/Started.scala
@@ -15,10 +15,10 @@ case class Started(
     build: model.Build,
     bloopFiles: GenBloopFiles.Files,
     activeProjectsFromPath: Option[Array[model.CrossProjectName]],
-    lazyConfig: Lazy[model.BleepConfig],
-    resolver: Lazy[CoursierResolver],
+    config: model.BleepConfig,
+    resolver: CoursierResolver,
     executionContext: ExecutionContext
-)(reloadUsing: (Prebootstrapped, Lazy[model.BleepConfig], List[BuildRewrite]) => Either[BleepException, Started]) {
+)(reloadUsing: (Prebootstrapped, model.BleepConfig, List[BuildRewrite]) => Either[BleepException, Started]) {
   def buildPaths: BuildPaths = pre.buildPaths
   def userPaths: UserPaths = pre.userPaths
   def logger: Logger = pre.logger
@@ -56,8 +56,8 @@ case class Started(
   def reloadFromDisk(rewrites: List[BuildRewrite]): Either[BleepException, Started] =
     for {
       pre <- pre.reloadFromDisk()
-      lazyConfig = BleepConfigOps.lazyForceLoad(userPaths)
-      reloaded <- reloadUsing(pre, lazyConfig, rewrites)
+      config <- BleepConfigOps.loadOrDefault(userPaths)
+      reloaded <- reloadUsing(pre, config, rewrites)
     } yield reloaded
 
   def reloadFromDisk(): Either[BleepException, Started] =

--- a/bleep-core/src/scala/bleep/bsp/BleepBspServer.scala
+++ b/bleep-core/src/scala/bleep/bsp/BleepBspServer.scala
@@ -34,7 +34,7 @@ class BleepBspServer(
 
     // wait random bit before shutting down server to reduce risk of multiple bleep instances starting bloop at the same time
     val timeout = Random.nextInt(400)
-    TimeUnit.MILLISECONDS.sleep(100 + timeout)
+    TimeUnit.MILLISECONDS.sleep(100L + timeout)
     sys.exit(1)
   }
 
@@ -47,7 +47,6 @@ class BleepBspServer(
           val methodContext = s"bloop bsp server, method: $methodName"
           val context = if (params.isEmpty) methodContext else params.mkString(s"$methodContext, with params: ", ", ", "")
           onFatalError(error, context)
-          throw error
       }
 
   private def capabilities: bsp4j.BuildServerCapabilities = {

--- a/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
@@ -19,7 +19,7 @@ object SetupBloopRifle {
       jvm: model.Jvm,
       logger: Logger,
       userPaths: UserPaths,
-      resolver: Lazy[CoursierResolver],
+      resolver: CoursierResolver,
       bleepRifleLogger: BleepRifleLogger,
       executionContext: ExecutionContext
   ): BloopRifleConfig = {
@@ -38,12 +38,12 @@ object SetupBloopRifle {
       )
   }
 
-  def bloopClassPath(resolver: Lazy[CoursierResolver])(bloopVersion: String): Either[BleepException, (Seq[File], Boolean)] =
+  def bloopClassPath(resolver: CoursierResolver)(bloopVersion: String): Either[BleepException, (Seq[File], Boolean)] =
     ModuleParser.module(BloopRifleConfig.defaultModule, BloopRifleConfig.defaultScalaVersion) match {
       case Left(msg) => Left(new BleepException.ModuleFormatError(BloopRifleConfig.defaultModule, msg))
       case Right(mod) =>
         val dep = model.Dep.JavaDependency(mod.organization, mod.name, bloopVersion)
-        resolver.forceGet.resolve(Set(dep), model.VersionCombo.Java) match {
+        resolver.resolve(Set(dep), model.VersionCombo.Java) match {
           case Left(coursierError) =>
             Left(new BleepException.ResolveError(coursierError, "installing bloop"))
           case Right(value) =>

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -4,7 +4,6 @@ package commands
 import bleep.BleepException
 import bleep.bsp.BspCommandFailed
 import bleep.logging.jsonEvents
-import bloop.config.Config
 import ch.epfl.scala.bsp4j
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError

--- a/bleep-core/src/scala/bleep/logging/LogLevel.scala
+++ b/bleep-core/src/scala/bleep/logging/LogLevel.scala
@@ -1,7 +1,7 @@
 package bleep.logging
 
 sealed abstract class LogLevel(val level: Int)(implicit val name: sourcecode.Name) {
-  val bracketName = s"[${name.value}]"
+  val bracketName = s"[${name.value.padTo(5, ' ')}]"
 }
 
 object LogLevel {

--- a/bleep-model/src/scala/bleep/model/BleepConfig.scala
+++ b/bleep-model/src/scala/bleep/model/BleepConfig.scala
@@ -4,14 +4,18 @@ import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 
 case class BleepConfig(
-    compileServerMode: CompileServerMode,
-    authentications: Option[Authentications]
-)
+    compileServerMode: Option[CompileServerMode],
+    authentications: Option[Authentications],
+    logTiming: Option[Boolean]
+) {
+  def compileServerModeOrDefault: CompileServerMode = compileServerMode.getOrElse(CompileServerMode.Shared)
+}
 
 object BleepConfig {
   val default = BleepConfig(
-    compileServerMode = CompileServerMode.Shared,
-    authentications = None
+    compileServerMode = None,
+    authentications = None,
+    logTiming = None
   )
 
   implicit val decoder: Decoder[BleepConfig] = deriveDecoder

--- a/bleep-site-in/usage/compile-servers.mdx
+++ b/bleep-site-in/usage/compile-servers.mdx
@@ -8,14 +8,14 @@ Roughly there are two modes of operation:
 
 This is the default behaviour, but if you need to change back this is the command:
 ```
-$ bleep compile-server auto-shutdown-disable
+$ bleep config compile-server auto-shutdown-disable
 ```
 
 Note that since projects can specify the exact JVM they will be compiled with, and Bloop run the Scala compiler on the JVM it is started with, more than one compile servers may be started if necessary.
 
 If you want to stop all running Bloop servers started by Bleep, this is the command:
 ```
-$ bleep compile-server stop-all
+$ bleep config compile-server stop-all
 ```
 
 ## 2) Bleep will start a compile-server for each invocation
@@ -25,5 +25,5 @@ This is slower, but will conserve memory.
 To enable this mode run this command:
 
 ```
-$ bleep compile-server auto-shutdown-enable
+$ bleep config compile-server auto-shutdown-enable
 ```

--- a/bleep-tests/src/scala/bleep/CreateNewSnapshotTests.scala
+++ b/bleep-tests/src/scala/bleep/CreateNewSnapshotTests.scala
@@ -14,11 +14,13 @@ class CreateNewSnapshotTests extends SnapshotTest {
     val testFolder = outFolder / "create-new-build"
     val buildLoader = BuildLoader.inDirectory(testFolder / "build")
     val buildPaths = BuildPaths(cwd = FileUtils.TempDir, buildLoader, model.BuildVariant.Normal)
+    val userPaths = UserPaths.fromAppDirs
 
     TestResolver.withFactory(isCi, testFolder, absolutePaths) { testResolver =>
       val generatedProjectFiles: Map[Path, String] =
         BuildCreateNew(
           logger,
+          userPaths,
           cwd = buildPaths.buildDir,
           platforms = NonEmptyList.of(model.PlatformId.Jvm, model.PlatformId.Js),
           scalas = NonEmptyList.of(model.VersionScala.Scala3, model.VersionScala.Scala213),
@@ -34,10 +36,10 @@ class CreateNewSnapshotTests extends SnapshotTest {
 
       val Right(started) =
         bootstrap.from(
-          Prebootstrapped(bootstrappedDestinationPaths, logger, BuildLoader.Existing(buildLoader.bleepYaml)),
+          Prebootstrapped(logger, userPaths, bootstrappedDestinationPaths, BuildLoader.Existing(buildLoader.bleepYaml)),
           GenBloopFiles.InMemory,
           Nil,
-          Lazy(model.BleepConfig.default),
+          model.BleepConfig.default,
           testResolver,
           ExecutionContext.global
         )

--- a/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
@@ -14,6 +14,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 class IntegrationSnapshotTests extends SnapshotTest {
   absolutePaths.sortedValues.foreach(println)
+  val userPaths = UserPaths.fromAppDirs
 
   test("tapir") {
     testIn("tapir", "https://github.com/softwaremill/tapir.git", "9057697")
@@ -120,10 +121,10 @@ class IntegrationSnapshotTests extends SnapshotTest {
     TestResolver.withFactory(isCi, testFolder, absolutePaths) { testResolver =>
       val started = bootstrap
         .from(
-          Prebootstrapped(bootstrappedDestinationPaths, logger, existingImportedBuildLoader),
+          Prebootstrapped(logger, userPaths, bootstrappedDestinationPaths, existingImportedBuildLoader),
           GenBloopFiles.InMemory,
           rewrites = Nil,
-          Lazy(model.BleepConfig.default),
+          model.BleepConfig.default,
           testResolver,
           ExecutionContext.global
         )

--- a/bleep-tests/src/scala/bleep/testing/SnapshotTest.scala
+++ b/bleep-tests/src/scala/bleep/testing/SnapshotTest.scala
@@ -12,7 +12,7 @@ import java.time.Instant
 import scala.util.Properties
 
 trait SnapshotTest extends AnyFunSuite with TripleEqualsSupport {
-  val logger0 = logging.stdout(LogPatterns.interface(Instant.now, noColor = false), disableProgress = true).untyped.minLogLevel(LogLevel.info)
+  val logger0 = logging.stdout(LogPatterns.interface(Some(Instant.now), noColor = false), disableProgress = true).untyped.minLogLevel(LogLevel.info)
 
   val isCi: Boolean =
     sys.env.contains("BUILD_NUMBER") || sys.env.contains("CI") // from sbt


### PR DESCRIPTION
… `bleep config` subcommand

- config is now read first thing at boot. removed some lazyness because of this
- all fields in config file are now optional
- show timing information earlier in log line (before path, not among context)
- add `bleep config file` subcommand to show location of config file
- add `bleep config log-timing-{disable|enable}` command to control log timing in log messages
- move `bleep compile-server` under `bleep config`

Fixes #256, #257