### PR TITLE
Amend coursier channel so that cs finds aarch64-apple-darwin

### DIFF
--- a/coursier-channel.json
+++ b/coursier-channel.json
@@ -12,7 +12,7 @@
       "x86_64-pc-linux": "tgz+https://github.com/oyvindberg/bleep/releases/download/v${version}/bleep-${platform}.tar.gz!bleep",
       "x86_64-pc-win32": "zip+https://github.com/oyvindberg/bleep/releases/download/v${version}/bleep-${platform}.zip!bleep.exe",
       "x86_64-apple-darwin": "tgz+https://github.com/oyvindberg/bleep/releases/download/v${version}/bleep-${platform}.tar.gz!bleep",
-      "arm64-apple-darwin": "tgz+https://github.com/oyvindberg/bleep/releases/download/v${version}/bleep-${platform}.tar.gz!bleep"
+      "aarch64-apple-darwin": "tgz+https://github.com/oyvindberg/bleep/releases/download/v${version}/bleep-arm64-apple-darwin.tar.gz!bleep"
     },
     "versionOverrides": [
       {


### PR DESCRIPTION
Closes https://github.com/oyvindberg/bleep/issues/267

* Coursier is set to standardise on `aarch64` (see https://github.com/coursier/coursier/pull/2651/files) 
* I'm using an M1 and `sys.props("os.arch")` gives me `aarch64`, so I assume it's gonna be the same for all macs with an arm64 architecture, even in the current state without that coursier PR merged 

The fix was tried locally via the following command : 

``` 
cs install --channel file:///fully/qualified/path/to/coursier-channel.json bleep
```

which happens to work 