### PR TITLE
Revamp logging, `Main`, process exit a bit more, allow `bleep-setup-ide` to boot JVM

### DIFF
--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success, Try}
 
 object BspImpl {
-  def run(pre: Prebootstrapped): Unit = {
+  def run(pre: Prebootstrapped): ExitCode = {
 
     val bspBloopServer: BleepBspServer =
       new BleepBspServer(pre.logger, null, null, null)
@@ -87,6 +87,7 @@ object BspImpl {
         )(es)
 
         Await.result(doneFuture, Duration.Inf)
+        ExitCode.Success
       } finally {
         if (bloopServer != null)
           bloopServer.shutdown()

--- a/bleep-core/src/scala/bleep/ExitCode.scala
+++ b/bleep-core/src/scala/bleep/ExitCode.scala
@@ -1,0 +1,14 @@
+package bleep
+
+sealed abstract class ExitCode(val value: Int) {
+  final def andThen(f: => ExitCode): ExitCode =
+    this match {
+      case ExitCode.Success => f
+      case ExitCode.Failure => this
+    }
+}
+
+object ExitCode {
+  case object Success extends ExitCode(0)
+  case object Failure extends ExitCode(1)
+}

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -3,8 +3,7 @@ package commands
 
 import bleep.BleepException
 import bleep.bsp.BspCommandFailed
-import bleep.internal.jvmRunCommand
-import bleep.logging.jsonEvents
+import bleep.internal.{bleepLoggers, jvmRunCommand}
 import ch.epfl.scala.bsp4j
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
@@ -65,7 +64,7 @@ case class Run(
   def bspRun(started: Started, bloop: BloopServer, main: String): Either[BspCommandFailed, Unit] = {
     val params = new bsp4j.RunParams(buildTarget(started.buildPaths, project))
     val mainClass = new bsp4j.ScalaMainClass(main, args.asJava, List(s"-Duser.dir=${started.pre.buildPaths.cwd}").asJava)
-    val envs = sys.env.updated(jsonEvents.CallerProcessAcceptsJsonEvents, "true").map { case (k, v) => s"$k=$v" }.toList.sorted.asJava
+    val envs = sys.env.updated(bleepLoggers.CallerProcessAcceptsJsonEvents, "true").map { case (k, v) => s"$k=$v" }.toList.sorted.asJava
     mainClass.setEnvironmentVariables(envs)
     params.setData(mainClass)
     params.setDataKind("scala-main-class")

--- a/bleep-core/src/scala/bleep/internal/bleepLoggers.scala
+++ b/bleep-core/src/scala/bleep/internal/bleepLoggers.scala
@@ -1,0 +1,67 @@
+package bleep
+package internal
+
+import bleep.logging.{LogLevel, Loggers, TypedLogger, TypedLoggerResource}
+import bleep.model.BleepConfig
+
+import java.io.{BufferedWriter, PrintStream}
+import java.time.Instant
+
+object bleepLoggers {
+  /* Use this environment variable to communicate to subprocesses that parent accepts json events */
+  val CallerProcessAcceptsJsonEvents = "CALLER_PROCESS_ACCEPTS_JSON_EVENTS"
+
+  lazy val logAsJson = sys.env.contains(CallerProcessAcceptsJsonEvents)
+
+  def stdoutNoLogFile(bleepConfig: model.BleepConfig, commonOpts: CommonOpts): TypedLoggerResource[PrintStream] =
+    if (logAsJson) TypedLoggerResource.flushable(Loggers.printJsonStream(System.out))
+    else baseStdout(bleepConfig, commonOpts).map(Loggers.decodeJsonStream)
+
+  def stdoutAndFileLogging(
+      bleepConfig: BleepConfig,
+      commonOpts: CommonOpts,
+      buildPaths: BuildPaths
+  ): TypedLoggerResource[(PrintStream, Option[BufferedWriter])] =
+    if (logAsJson) TypedLoggerResource.pure(Loggers.printJsonStream(System.out)).maybeZipWith(None)
+    else {
+      baseStdout(bleepConfig, commonOpts)
+        .maybeZipWith(Some(Loggers.path(buildPaths.logFile, LogPatterns.logFile)))
+        // it's an optimization to perform this before both loggers so we don't need to do it twice
+        .map(Loggers.decodeJsonStream)
+    }
+
+  private def baseStdout(bleepConfig: BleepConfig, commonOpts: CommonOpts): TypedLoggerResource[PrintStream] =
+    Loggers
+      .stdout(
+        LogPatterns.interface(
+          startRun = if (bleepConfig.logTiming.getOrElse(false)) Some(Instant.now) else None,
+          noColor = commonOpts.noColor
+        ),
+        disableProgress = commonOpts.noBspProgress
+      )
+      .map(l => if (commonOpts.debug) l else l.minLogLevel(LogLevel.info))
+
+  // we need to use stderr in some situations
+  // 1) BSP where stdout is already used for BSP protocol
+  // 2) auto-complete, when stdout is used to communicate completions
+  // 3) early, right after boot if we haven't set up proper logging
+
+  lazy val stderrWarn: TypedLogger[PrintStream] =
+    if (logAsJson) Loggers.printJsonStream(System.err)
+    else Loggers.decodeJsonStream(Loggers.stderr(LogPatterns.logFile).minLogLevel(LogLevel.warn))
+
+  lazy val stderrAll: TypedLogger[PrintStream] =
+    if (logAsJson) Loggers.printJsonStream(System.err)
+    else Loggers.decodeJsonStream(Loggers.stderr(LogPatterns.logFile))
+
+  def stderrAndFileLogging(commonOpts: CommonOpts, buildPaths: BuildPaths): TypedLoggerResource[(PrintStream, Option[BufferedWriter])] =
+    if (logAsJson) TypedLoggerResource.pure(Loggers.printJsonStream(System.err)).maybeZipWith(None)
+    else {
+      TypedLoggerResource
+        .pure(Loggers.stderr(LogPatterns.logFile))
+        .map(l => if (commonOpts.debug) l else l.minLogLevel(LogLevel.info))
+        .maybeZipWith(Some(Loggers.path(buildPaths.logFile, LogPatterns.logFile)))
+        // it's an optimization to perform this before both loggers so we don't need to do it twice
+        .map(Loggers.decodeJsonStream)
+    }
+}

--- a/bleep-core/src/scala/bleep/internal/fatal.scala
+++ b/bleep-core/src/scala/bleep/internal/fatal.scala
@@ -5,14 +5,14 @@ import bleep.BleepException
 import bleep.logging.Logger
 
 object fatal {
-  def apply(context: String, logger: Logger, throwable: Throwable): Nothing = {
+  def apply(context: String, logger: Logger, throwable: Throwable): ExitCode.Failure.type = {
     log(context, logger, throwable)
-    sys.exit(1)
+    ExitCode.Failure
   }
 
-  def apply(context: String, logger: Logger): Nothing = {
+  def apply(context: String, logger: Logger): ExitCode.Failure.type = {
     logger.error(context)
-    sys.exit(1)
+    ExitCode.Failure
   }
 
   def log(context: String, logger: Logger, throwable: Throwable): Unit =

--- a/bleep-core/src/scala/bleep/internal/jvmRunCommand.scala
+++ b/bleep-core/src/scala/bleep/internal/jvmRunCommand.scala
@@ -4,6 +4,7 @@ package internal
 import bloop.config.Config
 
 import java.io.File
+import java.nio.file.Path
 
 object jvmRunCommand {
   def apply(
@@ -18,17 +19,19 @@ object jvmRunCommand {
         val cp = fixedClasspath(bloopProject)
         overrideMainClass.orElse(bloopProject.platform.flatMap(_.mainClass)) match {
           case Some(main) =>
-            Right(
-              List[List[String]](
-                List(started.jvmCommand.toString),
-                jvm.runtimeConfig.getOrElse(jvm.config).options,
-                List("-classpath", cp.mkString(File.pathSeparator), main),
-                args
-              ).flatten
-            )
+            val jvmOptions = jvm.runtimeConfig.getOrElse(jvm.config).options
+            Right(cmd(started.jvmCommand, jvmOptions, cp, main, args))
           case None => Left(new BleepException.Text(project, "No main found"))
         }
       case _ => Left(new BleepException.Text(project, "This codepath can only run JVM projects"))
     }
   }
+
+  def cmd(jvmCommand: Path, jvmOptions: List[String], cp: List[Path], main: String, args: List[String]): List[String] =
+    List[List[String]](
+      List(jvmCommand.toString),
+      jvmOptions,
+      List("-classpath", cp.mkString(File.pathSeparator), main),
+      args
+    ).flatten
 }

--- a/bleep-core/src/scala/bleep/logging/Loggers.scala
+++ b/bleep-core/src/scala/bleep/logging/Loggers.scala
@@ -1,0 +1,42 @@
+package bleep.logging
+
+import java.io.{BufferedWriter, Flushable, PrintStream, StringWriter}
+import java.nio.file.{Files, Path, StandardOpenOption}
+
+object Loggers {
+  private[logging] val emptyContext: Ctx = Map.empty
+
+  // this is a resource since we absolutely should flush it before we exit
+  def stdout(pattern: Pattern, disableProgress: Boolean, ctx: Ctx = emptyContext): TypedLoggerResource[PrintStream] =
+    TypedLoggerResource.flushable {
+      new TypedLogger.ConsoleLogger(System.out, pattern, ctx, Nil, disableProgress)
+    }
+
+  // this is unbuffered, so I don't think there is any reason to care further
+  def stderr(pattern: Pattern, ctx: Ctx = emptyContext): TypedLogger[PrintStream] =
+    new TypedLogger.ConsoleLogger(System.err, pattern, ctx, Nil, disableProgress = true)
+
+  // this is a resource since we absolutely should flush it before we exit
+  def path(logFile: Path, pattern: Pattern, ctx: Ctx = emptyContext): TypedLoggerResource[BufferedWriter] =
+    TypedLoggerResource.autoCloseable {
+      Files.createDirectories(logFile.getParent)
+      val writer = Files.newBufferedWriter(logFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+      appendable(writer, pattern, ctx)
+    }
+
+  // wrap in TypedLoggerResource if you need it flushed/closed
+  def appendable[A <: Appendable](appendable: A, pattern: Pattern, ctx: Ctx = emptyContext): TypedLogger[A] =
+    new TypedLogger.AppendableLogger(appendable, pattern, ctx, Nil)
+
+  def stringWriter(pattern: Pattern, ctx: Ctx = emptyContext): TypedLogger[StringWriter] =
+    appendable(new StringWriter, pattern, ctx)
+
+  def storing(ctx: Ctx = emptyContext): TypedLogger[Array[TypedLogger.Stored]] =
+    new TypedLogger.StoringLogger(new TypedLogger.Store, ctx, Nil)
+
+  def printJsonStream[U <: Flushable with Appendable](to: U, ctx: Ctx = emptyContext): TypedLogger[U] =
+    new jsonEvents.SerializeLogEvents[U](to, ctx, Nil)
+
+  def decodeJsonStream[U](next: TypedLogger[U]): TypedLogger[U] =
+    jsonEvents.DeserializeLogEvents(next)
+}

--- a/bleep-core/src/scala/bleep/logging/TypedLoggerResource.scala
+++ b/bleep-core/src/scala/bleep/logging/TypedLoggerResource.scala
@@ -1,24 +1,43 @@
 package bleep.logging
 
+import java.io.Flushable
+
 trait TypedLoggerResource[U] {
   def use[T](f: TypedLogger[U] => T): T
+
+  final def unsafeGet(): TypedLogger[U] = {
+    var ret: TypedLogger[U] = null
+    use(ret = _)
+    ret
+  }
 }
 
 object TypedLoggerResource {
-  implicit class Ops[U1](private val one: TypedLoggerResource[U1]) extends AnyVal {
-    final def map[U2](transform: TypedLogger[U1] => TypedLogger[U2]): TypedLoggerResource[U2] =
+  final implicit class Ops[U1](private val one: TypedLoggerResource[U1]) extends AnyVal {
+    def map[U2](transform: TypedLogger[U1] => TypedLogger[U2]): TypedLoggerResource[U2] =
       new TypedLoggerResource[U2] {
         override def use[T](f: TypedLogger[U2] => T): T =
           one.use(logger => f(transform(logger)))
       }
 
-    final def zipWith[U2](other: TypedLoggerResource[U2]): TypedLoggerResource[(U1, U2)] =
+    def zipWith[U2](other: TypedLoggerResource[U2]): TypedLoggerResource[(U1, U2)] =
       new TypedLoggerResource[(U1, U2)] {
         override def use[T](f: TypedLogger[(U1, U2)] => T): T =
           one.use(oneLogger => other.use(otherLogger => f(oneLogger.zipWith(otherLogger))))
       }
 
-    final def untyped: LoggerResource = new TypedLoggerResource[Unit] {
+    def maybeZipWith[U2](other: Option[TypedLoggerResource[U2]]): TypedLoggerResource[(U1, Option[U2])] =
+      new TypedLoggerResource[(U1, Option[U2])] {
+        override def use[T](f: TypedLogger[(U1, Option[U2])] => T): T =
+          one.use { oneLogger =>
+            other match {
+              case Some(other) => other.use(otherLogger => f(oneLogger.maybeZipWith(Some(otherLogger))))
+              case None        => f(oneLogger.maybeZipWith(None))
+            }
+          }
+      }
+
+    def untyped: LoggerResource = new TypedLoggerResource[Unit] {
       override def use[T](f: TypedLogger[Unit] => T): T = one.use(l => f(l.untyped))
     }
   }
@@ -26,5 +45,27 @@ object TypedLoggerResource {
   def pure[U](logger: TypedLogger[U]): TypedLoggerResource[U] =
     new TypedLoggerResource[U] {
       override def use[T](f: TypedLogger[U] => T): T = f(logger)
+    }
+
+  def autoCloseable[U <: AutoCloseable](mkLogger: => TypedLogger[U]): TypedLoggerResource[U] =
+    new TypedLoggerResource[U] {
+      override def use[T](f: TypedLogger[U] => T): T = {
+        var inited: TypedLogger[U] = null
+        try {
+          inited = mkLogger
+          f(inited)
+        } finally if (inited != null) inited.underlying.close()
+      }
+    }
+
+  def flushable[U <: Flushable](mkLogger: => TypedLogger[U]): TypedLoggerResource[U] =
+    new TypedLoggerResource[U] {
+      override def use[T](f: TypedLogger[U] => T): T = {
+        var inited: TypedLogger[U] = null
+        try {
+          inited = mkLogger
+          f(inited)
+        } finally if (inited != null) inited.underlying.flush()
+      }
     }
 }

--- a/bleep-core/src/scala/bleep/logging/package.scala
+++ b/bleep-core/src/scala/bleep/logging/package.scala
@@ -2,8 +2,7 @@ package bleep
 
 import fansi.Str
 
-import java.io.{BufferedWriter, PrintStream, PrintWriter, StringWriter}
-import java.nio.file.{Files, Path, StandardOpenOption}
+import java.io.{PrintWriter, StringWriter}
 
 package object logging {
   type Ctx = Map[String, Str]
@@ -12,38 +11,7 @@ package object logging {
   type LoggerResource = TypedLoggerResource[Unit]
   val LoggerResource = TypedLoggerResource
 
-  private[logging] val emptyContext: Ctx = Map.empty
-
-  def stdout(pattern: Pattern, disableProgress: Boolean, ctx: Ctx = emptyContext): TypedLogger[PrintStream] =
-    new TypedLogger.ConsoleLogger(System.out, pattern, ctx, Nil, disableProgress)
-
-  def stderr(pattern: Pattern, ctx: Ctx = emptyContext): TypedLogger[PrintStream] =
-    new TypedLogger.ConsoleLogger(System.err, pattern, ctx, Nil, disableProgress = true)
-
-  def path(logFile: Path, pattern: Pattern, ctx: Ctx = emptyContext): TypedLoggerResource[BufferedWriter] =
-    new TypedLoggerResource[BufferedWriter] {
-      override def use[T](f: TypedLogger[BufferedWriter] => T): T = {
-        Files.createDirectories(logFile.getParent)
-        val writer: BufferedWriter = Files.newBufferedWriter(logFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
-        try f(appendable(writer, pattern, ctx))
-        finally writer.close()
-      }
-    }
-
-  def appendable[A <: Appendable](
-      appendable: A,
-      pattern: Pattern,
-      ctx: Ctx = emptyContext
-  ): TypedLogger[A] =
-    new TypedLogger.AppendableLogger(appendable, pattern, ctx, Nil)
-
-  def stringWriter(pattern: Pattern, ctx: Ctx = emptyContext): TypedLogger[StringWriter] =
-    appendable(new StringWriter, pattern, ctx)
-
-  def storing(ctx: Ctx = emptyContext): TypedLogger[Array[TypedLogger.Stored]] =
-    new TypedLogger.StoringLogger(new TypedLogger.Store, ctx, Nil)
-
-  def formatThrowable(th: Throwable): String = {
+  private[bleep] def formatThrowable(th: Throwable): String = {
     val sw = new StringWriter()
     val pw = new PrintWriter(sw)
     th.printStackTrace(pw)

--- a/bleep-tests/src/scala/bleep/IntegrationTests.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationTests.scala
@@ -1,8 +1,8 @@
 package bleep
 
 import bleep.internal.FileUtils
-import bleep.logging.{LogLevel, TypedLogger}
 import bleep.logging.TypedLogger.Stored
+import bleep.logging.{LogLevel, Loggers, TypedLogger}
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.Assertion
 import org.scalatest.funsuite.AnyFunSuite
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext
 
 class IntegrationTests extends AnyFunSuite with TripleEqualsSupport {
   val userPaths = UserPaths.fromAppDirs
-  val logger0 = logging.stdout(LogPatterns.interface(Some(Instant.now), noColor = false), disableProgress = true).untyped.minLogLevel(LogLevel.info)
+  val logger0 = Loggers.stdout(LogPatterns.interface(Some(Instant.now), noColor = false), disableProgress = true).untyped.unsafeGet().minLogLevel(LogLevel.info)
 
   val prelude =
     """$schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
@@ -25,7 +25,7 @@ class IntegrationTests extends AnyFunSuite with TripleEqualsSupport {
   // note: passing stored log messages is a hack for now. soon commands will return values, and `run` for instance will return printed lines
   def runTest(testName: String, yaml: String, files: Map[RelPath, String])(f: (Started, Commands, TypedLogger[Array[Stored]]) => Assertion): Unit =
     test(testName) {
-      val storingLogger = bleep.logging.storing()
+      val storingLogger = Loggers.storing()
       val stdLogger = logger0.withContext(testName)
       val testTempFolder = Files.createTempDirectory(s"bleep-test-$testName")
 

--- a/bleep-tests/src/scala/bleep/testing/SnapshotTest.scala
+++ b/bleep-tests/src/scala/bleep/testing/SnapshotTest.scala
@@ -1,7 +1,7 @@
 package bleep
 package testing
 
-import bleep.logging.{LogLevel, Logger}
+import bleep.logging.{LogLevel, Logger, Loggers}
 import coursier.paths.CoursierPaths
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.Assertion
@@ -12,7 +12,7 @@ import java.time.Instant
 import scala.util.Properties
 
 trait SnapshotTest extends AnyFunSuite with TripleEqualsSupport {
-  val logger0 = logging.stdout(LogPatterns.interface(Some(Instant.now), noColor = false), disableProgress = true).untyped.minLogLevel(LogLevel.info)
+  val logger0 = Loggers.stdout(LogPatterns.interface(Some(Instant.now), noColor = false), disableProgress = true).untyped.unsafeGet().minLogLevel(LogLevel.info)
 
   val isCi: Boolean =
     sys.env.contains("BUILD_NUMBER") || sys.env.contains("CI") // from sbt

--- a/scripts/src/scala/bleep/scripts/GenDemoVideos.scala
+++ b/scripts/src/scala/bleep/scripts/GenDemoVideos.scala
@@ -1,8 +1,8 @@
 package bleep
 package scripts
 
-import bleep.internal.FileUtils
-import bleep.logging.{jsonEvents, Logger}
+import bleep.internal.{bleepLoggers, FileUtils}
+import bleep.logging.Logger
 import bleep.plugin.nativeimage.NativeImagePlugin
 
 import java.nio.file.attribute.PosixFilePermissions
@@ -30,7 +30,7 @@ object GenDemoVideos extends BleepScript("GenVideos") {
 
     val env = sys.env
       .updated("BAT_PAGER", "")
-      .removed(jsonEvents.CallerProcessAcceptsJsonEvents)
+      .removed(bleepLoggers.CallerProcessAcceptsJsonEvents)
       .updated(
         "PATH", {
           // this whole exercise is really to make "bleep-cli" look like "bleep" in the videos


### PR DESCRIPTION
- recover lost log messages, fallout from 35278814
- there were still some holes left when json log messages got through. hopefully the problem is gone now
- by using `TypeLoggerResource` to close loggers we can now get away without flushing to disk while running, but do so on process exit. this has the potential to speed things up
- introduced an `ExitCode` structure to separate final logging after program completion and exiting process. this is to make sure we have time to flush first. This means that `fatal` does not call `System.exit` anymore
- add support for `bleep setup-ide` through JVM, towards #260. There is also a `--force-jvm` flag
- collected all loggers in `bleepLoggers`