### PR TITLE
Do not cache the system's jvm

### DIFF
--- a/bleep-model/src/scala/bleep/FetchJvm.scala
+++ b/bleep-model/src/scala/bleep/FetchJvm.scala
@@ -17,7 +17,7 @@ object FetchJvm {
     }
 
     maybeCacheDir match {
-      case Some(cacheDir) =>
+      case Some(cacheDir) if !Jvm.isSystem(jvm) =>
         val cacheFile = {
           val relPath = RelPath(
             List(Some(arch), jvm.index, Some(jvm.name)).flatten
@@ -39,7 +39,8 @@ object FetchJvm {
           fetched
         }
 
-      case None => doFetch(cacheLogger, jvm, ec, arch)
+      case Some(_) | None => // No cache directory defined, or the system's jvm is used.
+        doFetch(cacheLogger, jvm, ec, arch)
     }
   }
 

--- a/bleep-model/src/scala/bleep/model/Jvm.scala
+++ b/bleep-model/src/scala/bleep/model/Jvm.scala
@@ -10,4 +10,6 @@ object Jvm {
   val system = Jvm("system", None)
   implicit val encodes: Encoder[Jvm] = deriveEncoder
   implicit val decodes: Decoder[Jvm] = deriveDecoder
+
+  def isSystem(jvm: Jvm): Boolean = jvm == system
 }


### PR DESCRIPTION
As seen in #278, caching the system's JVM can be tricky because updating JAVA_HOME will have no effect as the cache entry remains and the new JAVA_HOME is unused.

Closes https://github.com/oyvindberg/bleep/issues/278

Created as a draft because I'm not sure if you'd like test for this and I still need to manually test this here.