### PR TITLE
Fix autocompletion

### DIFF
--- a/bleep-cli/src/scala/com/monovore/decline/Completer.scala
+++ b/bleep-cli/src/scala/com/monovore/decline/Completer.scala
@@ -68,7 +68,7 @@ final class Completer(possibleCompletionsForMetavar: String => List[String]) {
         completeMetaVar(args, metavar)
 
       case Opt.OptionalOptArg(_, _, _, _) =>
-        sys.error("unimplemented")
+        Res.NoMatch // todo
     }
   }
 


### PR DESCRIPTION
There is a case `Opt.OptionalOptArg` which is unimplemented, because it didn't exist when I wrote the support originally.

I don't have the time to fix it properly now, but this will at least unbreak all the other completion