### PR TITLE
Shorten path to cache/config directories and socket names

### DIFF
--- a/bleep-cli/src/scala/bleep/commands/CompileServerStopAll.scala
+++ b/bleep-cli/src/scala/bleep/commands/CompileServerStopAll.scala
@@ -2,7 +2,7 @@ package bleep
 package commands
 
 import bleep.BleepException
-import bleep.bsp.{BleepRifleLogger, SetupBloopRifle}
+import bleep.bsp.BleepRifleLogger
 import bleep.internal.FileUtils
 import bleep.logging.Logger
 
@@ -15,8 +15,7 @@ import scala.jdk.StreamConverters.StreamHasToScala
 case class CompileServerStopAll(logger: Logger, userPaths: UserPaths) extends BleepCommand {
   override def run(): Either[BleepException, Unit] = {
     val socketDirs: List[Path] =
-      if (FileUtils.exists(userPaths.bspSocketDir))
-        Files.list(userPaths.bspSocketDir).filter(_.getFileName.toString.contains(SetupBloopRifle.SharedPrefix)).toScala(List)
+      if (FileUtils.exists(userPaths.bspSocketDir)) Files.list(userPaths.bspSocketDir).toScala(List)
       else Nil
 
     val rifleLogger = new BleepRifleLogger(logger)
@@ -32,6 +31,7 @@ case class CompileServerStopAll(logger: Logger, userPaths: UserPaths) extends Bl
           err = rifleLogger.bloopBspStderr.getOrElse(OutputStream.nullOutputStream()),
           logger = rifleLogger
         )
+        FileUtils.deleteDirectory(socketDir)
       } else
         logger.info(s"bloop server was not running at socket $socketDir")
     }

--- a/bleep-core/src/scala/bleep/UserPaths.scala
+++ b/bleep-core/src/scala/bleep/UserPaths.scala
@@ -5,7 +5,7 @@ import coursier.cache.shaded.dirs.ProjectDirectories
 import java.nio.file.Path
 
 case class UserPaths(cacheDir: Path, configDir: Path) {
-  val bspSocketDir = cacheDir / "bsp-socket"
+  val bspSocketDir = cacheDir / "socket"
   val resolveCacheDir = cacheDir / "coursier"
   val resolveJvmCacheDir = cacheDir / "coursier-jvms"
   val configYaml = configDir / "config.yaml"
@@ -13,7 +13,7 @@ case class UserPaths(cacheDir: Path, configDir: Path) {
 
 object UserPaths {
   def fromAppDirs: UserPaths = {
-    val dirs = ProjectDirectories.from("build", "bleep", "bleep")
+    val dirs = ProjectDirectories.from("build", null, "bleep")
     val cacheDir = Path.of(dirs.cacheDir)
     val configDir = Path.of(dirs.configDir)
 

--- a/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
@@ -78,8 +78,6 @@ object SetupBloopRifle {
     }
     dir
   }
-  val SharedPrefix = "shared-for-jvm"
-
   def bspSocketFile(userPaths: UserPaths, mode: model.CompileServerMode, jvm: model.Jvm): Path = {
     val somewhatRandomIdentifier = Try(ProcessHandle.current.pid) match {
       case Failure(_) =>
@@ -93,8 +91,7 @@ object SetupBloopRifle {
         case model.CompileServerMode.NewEachInvocation => somewhatRandomIdentifier
         case model.CompileServerMode.Shared            =>
           // windows does not accept colon in path names
-          val str = jvm.name.replace(':', '_')
-          s"$SharedPrefix-$str"
+          jvm.name.replace(':', '_')
       }
 
     val socket: Path =


### PR DESCRIPTION
There is apparently a 100 char limit in place, this makes it a bit more probable that the generated names are short enough.

Fixes #281

This is an example socket name on my machine: `/Users/oyvind/Library/Caches/build.bleep/socket/graalvm-java17_22.3.0`, which is 70 chars. This leaves room for a username of ~36 chars

The configuration file now lives here `/Users/oyvind/Library/Application Support/build.bleep/config.yaml`

