### PR TITLE
`BleepExecutable` followup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           submodules: recursive
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
       - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:
@@ -52,11 +51,11 @@ jobs:
             file_name: bleep.exe
             artifact_name: bleep-x86_64-pc-win32
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+
       - uses: bleep-build/bleep-setup-action@0.0.1
 
       - uses: coursier/cache-action@v6
@@ -142,7 +141,6 @@ jobs:
         with:
           submodules: recursive
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
       - id: get_version
         uses: battila7/get-version-action@v2
         with:

--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -40,7 +40,7 @@ object BspImpl {
           resolvedJvm = pre.resolvedJvm.forceGet,
           userPaths = pre.userPaths,
           resolver = resolver,
-          bleepExecutable = BleepExecutable.getCommand(resolver, pre, forceJvm = false),
+          bleepExecutable = Lazy(BleepExecutable.getCommand(resolver, pre, forceJvm = false)),
           bleepRifleLogger = bleepRifleLogger
         )
 

--- a/bleep-core/src/scala/bleep/BleepCommandRemote.scala
+++ b/bleep-core/src/scala/bleep/BleepCommandRemote.scala
@@ -41,7 +41,7 @@ abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
         started.resolvedJvm.forceGet,
         started.pre.userPaths,
         started.resolver,
-        started.bleepExecutable.forceGet,
+        started.bleepExecutable,
         bleepRifleLogger
       )
 

--- a/bleep-core/src/scala/bleep/BleepExecutable.scala
+++ b/bleep-core/src/scala/bleep/BleepExecutable.scala
@@ -85,14 +85,6 @@ object BleepExecutable {
       }
     }
 
-  implicit class IndexOfOpt(haystack: List[String]) {
-    def indexOfOpt(needle: String): Option[Int] =
-      haystack.indexOf(needle) match {
-        case -1 => None
-        case n  => Some(n)
-      }
-  }
-
   def findCurrentBleep(logger: Logger): Option[BleepExecutable] = {
     def complain(msg: String, currentInfo: Option[ProcessHandle.Info] = None): None.type = {
       logger


### PR DESCRIPTION
Followup to b1122ee8: allow M24 to build newest code without supplying bleep literal to script