### PR TITLE
Update UserPaths.scala

### DIFF
--- a/bleep-core/src/scala/bleep/UserPaths.scala
+++ b/bleep-core/src/scala/bleep/UserPaths.scala
@@ -13,7 +13,7 @@ case class UserPaths(cacheDir: Path, configDir: Path) {
 
 object UserPaths {
   def fromAppDirs: UserPaths = {
-    val dirs = ProjectDirectories.from("build", null, "bleep")
+    val dirs = ProjectDirectories.from(null, "build", "bleep")
     val cacheDir = Path.of(dirs.cacheDir)
     val configDir = Path.of(dirs.configDir)
 


### PR DESCRIPTION
I'm not an expert on this, but looking at the example
https://github.com/dirs-dev/directories-jvm#example

With this proposed change you'd get
```
// Lin: /home/alice/.config/bleep
// Mac: /Users/Alice/Library/Application Support/build.bleep
// Win: C:\Users\Alice\AppData\Roaming\build\bleep\config
```
Which is probably the desired outcome?