### PR TITLE
Tweak error message for when script run fails

### DIFF
--- a/bleep-core/src/scala/bleep/bootstrap.scala
+++ b/bleep-core/src/scala/bleep/bootstrap.scala
@@ -29,7 +29,7 @@ object bootstrap {
             fatal("Couldn't initialize bleep", logger, buildException)
           case Right(started) =>
             Try(f(started, new Commands(started))) match {
-              case Failure(th) => fatal("failed :(", logger, th)
+              case Failure(th) => fatal(s"Failed to run script: `$scriptName`.", logger, th)
               case Success(_)  => ExitCode.Success
             }
         }


### PR DESCRIPTION
This is just a small PR to tweak the error message that shows up when running a script that fails. Feel free to close it if you prefer the original, I just felt like `failed :(` was unhelpful