### PR TITLE
Improve BSP error handling

### DIFF
--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -455,8 +455,9 @@ object Main {
         val buildLoader = BuildLoader.find(cwd)
         maybeRunWithDifferentVersion(_args, bleepLoggers.stderrAll(commonOpts).untyped, buildLoader, commonOpts).andThen {
           val buildPaths = BuildPaths(cwd, buildLoader, model.BuildVariant.BSP)
+          val config = BleepConfigOps.loadOrDefault(userPaths).orThrow
 
-          bleepLoggers.stderrAndFileLogging(commonOpts, buildPaths).untyped.use { logger =>
+          bleepLoggers.stderrAndFileLogging(config, commonOpts, buildPaths).untyped.use { logger =>
             buildLoader.existing.map(existing => Prebootstrapped(logger, userPaths, buildPaths, existing, ec)) match {
               case Left(be) => fatal("", logger, be)
               case Right(pre) =>

--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -1,6 +1,7 @@
 package bleep
 package bsp
 
+import bleep.internal.fatal
 import ch.epfl.scala.bsp4j
 import org.eclipse.lsp4j.jsonrpc
 
@@ -54,8 +55,8 @@ object BspImpl {
               .build(pre.logger, pre.existingBuild) { () =>
                 pre.logger.info("Detecting changed build")
                 buildChangeTracker.ensureBloopUpToDate() match {
-                  case Left(value) => pre.logger.error("Could not reload build", value)
-                  case Right(_)    => pre.logger.info("Loaded changed build")
+                  case Left(th) => fatal.log("Could not reload build", pre.logger, th)
+                  case Right(_) => pre.logger.info("Loaded changed build")
                 }
               }
               .run(FileWatching.StopWhen.Never, 100)

--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -26,6 +26,7 @@ object BspImpl {
         .setOutput(System.out)
         .setRemoteInterface(classOf[bsp4j.BuildClient])
         .setLocalService(bspBloopServer)
+        .setExceptionHandler(new ExceptionHandler(pre.logger))
         .create()
 
       val localClient = new BspForwardClient(Some(launcher.getRemoteProxy))

--- a/bleep-core/src/scala/bleep/BleepCacheLogger.scala
+++ b/bleep-core/src/scala/bleep/BleepCacheLogger.scala
@@ -1,5 +1,6 @@
 package bleep
 
+import bleep.internal.throwableMessages
 import bleep.logging.Logger
 import coursier.cache.CacheLogger
 import coursier.error.CoursierError
@@ -7,7 +8,7 @@ import coursier.util.Artifact
 
 class BleepCacheLogger(logger: Logger) extends CacheLogger {
   def retrying(err: CoursierError, retriesLeft: Int): Unit =
-    logger.withContext(retriesLeft).info("Resolving dependencies failed. Retrying", err)
+    logger.withContext(retriesLeft).info(s"Resolving dependencies failed. Retrying. Error: ${throwableMessages(err).mkString(": ")}")
 
   override def downloadingArtifact(url: String, artifact: Artifact): Unit =
     logger.withContext(url).info("downloading")

--- a/bleep-core/src/scala/bleep/bsp/BleepBspServer.scala
+++ b/bleep-core/src/scala/bleep/bsp/BleepBspServer.scala
@@ -5,16 +5,16 @@ import bleep.internal.throwableMessages
 import bleep.logging.Logger
 import ch.epfl.scala.bsp4j
 import com.google.gson.{JsonObject, JsonPrimitive}
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+import org.eclipse.lsp4j.jsonrpc.messages.{ResponseError, ResponseErrorCode}
 
-import java.io.{PrintWriter, StringWriter}
 import java.util
-import java.util.concurrent.{CompletableFuture, TimeUnit}
+import java.util.concurrent.CompletableFuture
 import java.util.function.BiFunction
 import scala.build.bloop.BuildServer
 import scala.build.blooprifle.internal.Constants
 import scala.concurrent.{Future, Promise}
 import scala.jdk.CollectionConverters._
-import scala.util.Random
 
 class BleepBspServer(
     val logger: Logger,
@@ -24,29 +24,51 @@ class BleepBspServer(
 ) extends BuildServer {
   val supportedLanguages: util.List[String] = List("scala", "java").asJava
 
-  protected def onFatalError(throwable: Throwable, context: String): Nothing = {
-    val sw = new StringWriter()
-    throwable.printStackTrace(new PrintWriter(sw))
-    val message = s"Fatal error has occurred within $context. Shutting down the server:\n ${sw.toString}"
-    System.err.println(message)
-    sendToIdeClient.onBuildLogMessage(new bsp4j.LogMessageParams(bsp4j.MessageType.ERROR, message))
+  var isMetals = true
 
-    // wait random bit before shutting down server to reduce risk of multiple bleep instances starting bloop at the same time
-    val timeout = Random.nextInt(400)
-    TimeUnit.MILLISECONDS.sleep(100L + timeout)
-    sys.exit(1)
+  def fail(msg: String, th: Throwable): Nothing = {
+    logger.debug(msg, th)
+    logger.warn(s"$msg: ${throwableMessages(th).mkString(": ")}")
+    if (isMetals) {
+      sys.exit(1)
+    }
+    throw new ResponseErrorException(
+      new ResponseError(ResponseErrorCode.UnknownErrorCode, s"$msg: ${throwableMessages(th).mkString(": ")}", null)
+    )
   }
 
-  def fatalExceptionHandler[T](methodName: String, params: Any*): BiFunction[T, Throwable, T] =
+  def handleBloopFailure[T](methodName: String, params: Any*): BiFunction[T, Throwable, T] =
     (maybeValue: T, maybeException: Throwable) =>
       maybeException match {
         case null =>
           maybeValue
         case error =>
-          val methodContext = s"bloop bsp server, method: $methodName"
-          val context = if (params.isEmpty) methodContext else params.mkString(s"$methodContext, with params: ", ", ", "")
-          onFatalError(error, context)
+          ExceptionHandler.look(classOf[java.net.SocketException])(error) match {
+            case Some(socketException) =>
+              buildShutdown() // don't wait for this
+              fail("Lost contact with bloop server. initializing shutdown", socketException)
+
+            case None =>
+              val methodContext = s"Got error from bloop while running: $methodName: ${error.getClass.getName}"
+              val context = if (params.isEmpty) methodContext else params.mkString(s"$methodContext, with params: ", ", ", "")
+              fail(context, error)
+          }
       }
+
+  def enter(name: String, args: Any*): Unit = {
+    logger.debug(s"$name(${args.mkString(", ")})")
+
+    buildChangeTracker.currentBuildError match {
+      case Some(_) =>
+        // try to reload and see if we can salvage the broken build situation
+        buildChangeTracker.ensureBloopUpToDate() match {
+          case Left(bleepException) => fail("Bleep is not able to load your build", bleepException)
+          case Right(_)             => ()
+        }
+
+      case None => ()
+    }
+  }
 
   private def capabilities: bsp4j.BuildServerCapabilities = {
     val ret = new bsp4j.BuildServerCapabilities
@@ -66,19 +88,19 @@ class BleepBspServer(
   }
 
   override def buildInitialize(params: bsp4j.InitializeBuildParams): CompletableFuture[bsp4j.InitializeBuildResult] = {
-    logger.debug(("buildInitialize", params.toString))
+    enter("buildInitialize", params.toString)
 
     buildChangeTracker.ensureBloopUpToDate() match {
-      case Left(th) =>
-        sendToIdeClient.onBuildShowMessage(new bsp4j.ShowMessageParams(bsp4j.MessageType.ERROR, throwableMessages(th).mkString(": ")))
-
-        logger.error("couldn't refresh build", th)
-        CompletableFuture.failedFuture(th)
+      case Left(bleepException) =>
+        fail("couldn't load build", bleepException)
       case Right(started) =>
         val workspaceDir = started.buildPaths.buildVariantDir
 
+        val displayName = params.getDisplayName // "Metals" or "IntelliJ-BSP"
+        isMetals = displayName != "Metals"
+
         val initParams = new bsp4j.InitializeBuildParams(
-          s"bleep / ${params.getDisplayName}",
+          s"bleep / $displayName",
           s"${model.BleepVersion.current.value} / ${params.getVersion}",
           Constants.bspVersion,
           workspaceDir.toUri.toASCIIString,
@@ -104,7 +126,7 @@ class BleepBspServer(
         logger.debug("Sending buildInitialize BSP command to Bloop")
         bloopServer
           .buildInitialize(initParams)
-          .handle(fatalExceptionHandler("buildInitialize", initParams))
+          .handle(handleBloopFailure("buildInitialize", initParams))
           .thenApply { _ =>
             bloopServer.onBuildInitialized()
             new bsp4j.InitializeBuildResult("bleep", model.BleepVersion.current.value, Constants.bspVersion, capabilities)
@@ -113,108 +135,107 @@ class BleepBspServer(
   }
 
   override def workspaceBuildTargets(): CompletableFuture[bsp4j.WorkspaceBuildTargetsResult] = {
-    logger.debug("workspaceBuildTargets")
+    enter("workspaceBuildTargets")
 
     buildChangeTracker.ensureBloopUpToDate() match {
-      case Left(th) =>
-        logger.error("couldn't refresh build", th)
-        CompletableFuture.failedFuture(th)
+      case Left(bleepException) =>
+        fail("couldn't refresh build", bleepException)
       case Right(_) =>
-        bloopServer.workspaceBuildTargets().handle(fatalExceptionHandler("workspaceBuildTargets"))
+        bloopServer.workspaceBuildTargets().handle(handleBloopFailure("workspaceBuildTargets"))
     }
   }
 
   override def onBuildInitialized(): Unit = {
-    logger.debug("onBuildInitialized")
+    enter("onBuildInitialized")
     ()
   }
 
   override def workspaceReload(): CompletableFuture[Object] = {
-    logger.debug("workspaceReload")
+    enter("workspaceReload")
     // Bloop does not support workspaceReload and Intellij calls it at the start
-    CompletableFuture.completedFuture(new Object).handle(fatalExceptionHandler("workspaceReload"))
+    CompletableFuture.completedFuture(new Object).handle(handleBloopFailure("workspaceReload"))
   }
 
   override def buildTargetCleanCache(params: bsp4j.CleanCacheParams): CompletableFuture[bsp4j.CleanCacheResult] = {
-    logger.debug(("buildTargetCleanCache", params.toString))
-    bloopServer.buildTargetCleanCache(params).handle(fatalExceptionHandler("buildTargetCleanCache", params))
+    enter("buildTargetCleanCache", params)
+    bloopServer.buildTargetCleanCache(params).handle(handleBloopFailure("buildTargetCleanCache", params))
   }
   override def buildTargetCompile(params: bsp4j.CompileParams): CompletableFuture[bsp4j.CompileResult] = {
-    logger.debug(("buildTargetCompile", params.toString))
-    bloopServer.buildTargetCompile(params).handle(fatalExceptionHandler("buildTargetCompile", params))
+    enter("buildTargetCompile", params)
+    bloopServer.buildTargetCompile(params).handle(handleBloopFailure("buildTargetCompile", params))
   }
   override def buildTargetDependencySources(params: bsp4j.DependencySourcesParams): CompletableFuture[bsp4j.DependencySourcesResult] = {
-    logger.debug(("buildTargetDependencySources", params.toString))
-    bloopServer.buildTargetDependencySources(params).handle(fatalExceptionHandler("buildTargetDependencySources", params))
+    enter("buildTargetDependencySources", params)
+    bloopServer.buildTargetDependencySources(params).handle(handleBloopFailure("buildTargetDependencySources", params))
   }
   override def buildTargetInverseSources(params: bsp4j.InverseSourcesParams): CompletableFuture[bsp4j.InverseSourcesResult] = {
-    logger.debug(("buildTargetInverseSources", params.toString))
-    bloopServer.buildTargetInverseSources(params).handle(fatalExceptionHandler("buildTargetInverseSources", params))
+    enter("buildTargetInverseSources", params)
+    bloopServer.buildTargetInverseSources(params).handle(handleBloopFailure("buildTargetInverseSources", params))
   }
   override def buildTargetResources(params: bsp4j.ResourcesParams): CompletableFuture[bsp4j.ResourcesResult] = {
-    logger.debug(("buildTargetResources", params.toString))
-    bloopServer.buildTargetResources(params).handle(fatalExceptionHandler("buildTargetResources", params))
+    enter("buildTargetResources", params)
+    bloopServer.buildTargetResources(params).handle(handleBloopFailure("buildTargetResources", params))
   }
   override def buildTargetRun(params: bsp4j.RunParams): CompletableFuture[bsp4j.RunResult] = {
-    logger.debug(("buildTargetRun", params.toString))
-    bloopServer.buildTargetRun(params).handle(fatalExceptionHandler("buildTargetRun", params))
+    enter("buildTargetRun", params)
+    bloopServer.buildTargetRun(params).handle(handleBloopFailure("buildTargetRun", params))
   }
   override def buildTargetSources(params: bsp4j.SourcesParams): CompletableFuture[bsp4j.SourcesResult] = {
-    logger.debug(("buildTargetSources", params.toString))
-    bloopServer.buildTargetSources(params).handle(fatalExceptionHandler("buildTargetSources", params))
+    enter("buildTargetSources")
+    bloopServer.buildTargetSources(params).handle(handleBloopFailure("buildTargetSources", params))
   }
   override def buildTargetTest(params: bsp4j.TestParams): CompletableFuture[bsp4j.TestResult] = {
-    logger.debug(("buildTargetTest", params.toString))
-    bloopServer.buildTargetTest(params).handle(fatalExceptionHandler("buildTargetTest", params))
+    enter("buildTargetTest")
+    bloopServer.buildTargetTest(params).handle(handleBloopFailure("buildTargetTest", params))
   }
   override def buildTargetDependencyModules(params: bsp4j.DependencyModulesParams): CompletableFuture[bsp4j.DependencyModulesResult] = {
-    logger.debug(("buildTargetDependencyModules", params.toString))
-    bloopServer.buildTargetDependencyModules(params).handle(fatalExceptionHandler("buildTargetDependencyModules", params))
+    enter("buildTargetDependencyModules", params)
+    bloopServer.buildTargetDependencyModules(params).handle(handleBloopFailure("buildTargetDependencyModules", params))
   }
   override def buildTargetJavacOptions(params: bsp4j.JavacOptionsParams): CompletableFuture[bsp4j.JavacOptionsResult] = {
-    logger.debug(("buildTargetJavacOptions", params.toString))
-    bloopServer.buildTargetJavacOptions(params).handle(fatalExceptionHandler("buildTargetJavacOptions", params))
+    enter("buildTargetJavacOptions", params)
+    bloopServer.buildTargetJavacOptions(params).handle(handleBloopFailure("buildTargetJavacOptions", params))
   }
   override def buildTargetScalaMainClasses(params: bsp4j.ScalaMainClassesParams): CompletableFuture[bsp4j.ScalaMainClassesResult] = {
-    logger.debug(("buildTargetScalaMainClasses", params.toString))
-    bloopServer.buildTargetScalaMainClasses(params).handle(fatalExceptionHandler("buildTargetScalaMainClasses", params))
+    enter("buildTargetScalaMainClasses", params)
+    bloopServer.buildTargetScalaMainClasses(params).handle(handleBloopFailure("buildTargetScalaMainClasses", params))
   }
   override def buildTargetScalaTestClasses(params: bsp4j.ScalaTestClassesParams): CompletableFuture[bsp4j.ScalaTestClassesResult] = {
-    logger.debug(("buildTargetScalaTestClasses", params.toString))
-    bloopServer.buildTargetScalaTestClasses(params).handle(fatalExceptionHandler("buildTargetScalaTestClasses", params))
+    enter("buildTargetScalaTestClasses", params)
+    bloopServer.buildTargetScalaTestClasses(params).handle(handleBloopFailure("buildTargetScalaTestClasses", params))
   }
   override def buildTargetScalacOptions(params: bsp4j.ScalacOptionsParams): CompletableFuture[bsp4j.ScalacOptionsResult] = {
-    logger.debug(("buildTargetScalacOptions", params.toString))
-    bloopServer.buildTargetScalacOptions(params).handle(fatalExceptionHandler("buildTargetScalacOptions", params))
+    enter("buildTargetScalacOptions", params)
+    bloopServer.buildTargetScalacOptions(params).handle(handleBloopFailure("buildTargetScalacOptions", params))
   }
   override def debugSessionStart(params: bsp4j.DebugSessionParams): CompletableFuture[bsp4j.DebugSessionAddress] = {
-    logger.debug(("debugSessionStart", params.toString))
-    bloopServer.debugSessionStart(params).handle(fatalExceptionHandler("debugSessionStart", params))
+    enter("debugSessionStart", params)
+    bloopServer.debugSessionStart(params).handle(handleBloopFailure("debugSessionStart", params))
   }
   override def buildTargetOutputPaths(params: bsp4j.OutputPathsParams): CompletableFuture[bsp4j.OutputPathsResult] = {
-    logger.debug(("buildTargetOutputPaths", params.toString))
-    bloopServer.buildTargetOutputPaths(params).handle(fatalExceptionHandler("buildTargetOutputPaths", params))
+    enter("buildTargetOutputPaths", params)
+    bloopServer.buildTargetOutputPaths(params).handle(handleBloopFailure("buildTargetOutputPaths", params))
   }
   override def jvmRunEnvironment(params: bsp4j.JvmRunEnvironmentParams): CompletableFuture[bsp4j.JvmRunEnvironmentResult] = {
-    logger.debug(("jvmRunEnvironment", params.toString))
-    bloopServer.jvmRunEnvironment(params).handle(fatalExceptionHandler("jvmRunEnvironment", params))
+    enter("jvmRunEnvironment", params)
+    bloopServer.jvmRunEnvironment(params).handle(handleBloopFailure("jvmRunEnvironment", params))
   }
   override def jvmTestEnvironment(params: bsp4j.JvmTestEnvironmentParams): CompletableFuture[bsp4j.JvmTestEnvironmentResult] = {
-    logger.debug(("jvmTestEnvironment", params.toString))
-    bloopServer.jvmTestEnvironment(params).handle(fatalExceptionHandler("jvmTestEnvironment", params))
+    enter("jvmTestEnvironment", params)
+    bloopServer.jvmTestEnvironment(params).handle(handleBloopFailure("jvmTestEnvironment", params))
   }
 
   private val shutdownPromise = Promise[Unit]()
 
   override def buildShutdown(): CompletableFuture[Object] = {
-    logger.debug("buildShutdown")
+    enter("buildShutdown")
     if (!shutdownPromise.isCompleted)
       shutdownPromise.success(())
     bloopServer.buildShutdown()
   }
 
   override def onBuildExit(): Unit = {
-    logger.debug("onBuildExit")
+    enter("onBuildExit")
     ()
   }
 

--- a/bleep-core/src/scala/bleep/bsp/BuildChangeTracker.scala
+++ b/bleep-core/src/scala/bleep/bsp/BuildChangeTracker.scala
@@ -10,6 +10,7 @@ import scala.jdk.CollectionConverters._
 
 trait BuildChangeTracker {
   def ensureBloopUpToDate(): Either[BleepException, Started]
+  def currentBuildError: Option[BleepException]
 }
 
 object BuildChangeTracker {
@@ -40,6 +41,8 @@ object BuildChangeTracker {
             newState
         }
       }.maybeStarted
+
+    override def currentBuildError: Option[BleepException] = atomicState.get().maybeStarted.left.toOption
   }
 
   private def load(pre: Prebootstrapped): Either[BleepException, Started] =

--- a/bleep-core/src/scala/bleep/bsp/ExceptionHandler.scala
+++ b/bleep-core/src/scala/bleep/bsp/ExceptionHandler.scala
@@ -1,0 +1,39 @@
+package bleep
+package bsp
+
+import bleep.logging.Logger
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+import org.eclipse.lsp4j.jsonrpc.messages.{ResponseError, ResponseErrorCode}
+
+import java.io.{ByteArrayOutputStream, PrintWriter}
+import java.util.function.Function
+
+// the default exception handler doesn't look deep enough in an exception chain to dig out the `ResponseErrorException`
+// good that after all these years java libraries can still disappoint.
+class ExceptionHandler(logger: Logger) extends Function[Throwable, ResponseError] {
+  override def apply(th: Throwable): ResponseError =
+    ExceptionHandler.look(classOf[ResponseErrorException])(th) match {
+      case Some(found) => found.getResponseError
+      case None        => default(th)
+    }
+
+  def default(th: Throwable): ResponseError = {
+    val header = "Internal error"
+    logger.warn(header, th)
+    val error = new ResponseError
+    error.setMessage(header + ".")
+    error.setCode(ResponseErrorCode.InternalError)
+    val stackTrace = new ByteArrayOutputStream
+    val stackTraceWriter = new PrintWriter(stackTrace)
+    th.printStackTrace(stackTraceWriter)
+    stackTraceWriter.flush()
+    error.setData(stackTrace.toString)
+    error
+  }
+}
+
+object ExceptionHandler {
+  def look[T <: Throwable](clazz: Class[T])(th: Throwable): Option[T] =
+    if (clazz.isInstance(th)) Some(th.asInstanceOf[T])
+    else Option(th.getCause).flatMap(look(clazz)).orElse(th.getSuppressed.toList.flatMap(look(clazz)).headOption)
+}

--- a/bleep-core/src/scala/bleep/internal/fatal.scala
+++ b/bleep-core/src/scala/bleep/internal/fatal.scala
@@ -19,7 +19,7 @@ object fatal {
     throwable match {
       case buildException: BleepException =>
         logger.debug(context, buildException)
-        logger.error(throwableMessages(buildException).mkString(": "))
+        logger.error(s"$context: ${throwableMessages(buildException).mkString(": ")}")
       case unexpected =>
         logger.error(context, unexpected)
     }


### PR DESCRIPTION
One part of the changeset is rather experimental: I'm experimenting with differentiating between intellij and metals since they behave differently.

For metals we always close the BSP connection on any failure, while for intellij it seems to work better to show and error and let it try again.

Hery likely some followup for this