### PR TITLE
Towards stabilizing BSP

### DIFF
--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -31,7 +31,10 @@ object BspImpl {
       val localClient = new BspForwardClient(Some(launcher.getRemoteProxy), pre.logger)
 
       val config = BleepConfigOps.loadOrDefault(pre.userPaths).orThrow
-      val build = pre.existingBuild.buildFile.forceGet.orThrow
+
+      val build = pre.existingBuild.buildFile.forceGet.getOrElse {
+        model.BuildFile(model.$schema, model.BleepVersion.current, model.JsonMap.empty, model.JsonMap.empty, model.JsonList.empty, model.JsonMap.empty, None)
+      }
       val bleepRifleLogger = new BleepRifleLogger(pre.logger)
       val resolver = CoursierResolver.Factory.default(pre, config, build)
       val bloopRifleConfig =

--- a/bleep-core/src/scala/bleep/internal/Throwables.scala
+++ b/bleep-core/src/scala/bleep/internal/Throwables.scala
@@ -2,6 +2,7 @@ package bleep
 package internal
 
 import bleep.logging.Logger
+import sourcecode.{Enclosing, File, Line}
 
 import java.io.{PrintWriter, StringWriter}
 
@@ -22,7 +23,7 @@ object Throwables {
     sw.toString
   }
 
-  def log(context: String, logger: Logger, throwable: Throwable): Unit =
+  def log(context: String, logger: Logger, throwable: Throwable)(implicit l: Line, f: File, e: Enclosing): Unit =
     throwable match {
       case buildException: BleepException =>
         logger.debug(context, buildException)


### PR DESCRIPTION
- The current bsp4j design is unsustainably bad, but fixing it takes a lot of work, so we're patching it.
- exceptions trigger another way of failing, so I worked around with a few well places `Try`s
- Fixed a bug which held onto old state in the presence of a broken build (causing watch mode to flip the old state back in)
- send warnings to IDE through BSP to complain about broken build
- reinstate running sourcegen for compile task (should probably be for other BSP methods as well, but let's see how far `compile` takes us).
 - Fixes a bug where a build which is broken on BSP boot will both fail and hang. Now it won't hang anymore, but it's all brittle.
