### PR TITLE
integrate newer sbt-tpolecat

### DIFF
--- a/bleep-cli/src/scala/bleep/sbtimport/buildFromBloopFiles.scala
+++ b/bleep-cli/src/scala/bleep/sbtimport/buildFromBloopFiles.scala
@@ -546,7 +546,7 @@ object buildFromBloopFiles {
     val (strict, remainingOptions) = {
       val tpolecat = new TpolecatPlugin(DevMode)
 
-      val tpolecatOptions = model.Options.parse(tpolecat.scalacOptions(s.version).toList, None)
+      val tpolecatOptions = tpolecat.scalacOptions(s.version)
       if (tpolecatOptions.values.forall(notCompilerPlugins.contains))
         (Some(true), new model.Options(notCompilerPlugins -- tpolecatOptions.values))
       else

--- a/bleep-core/src/scala/bleep/GenBloopFiles.scala
+++ b/bleep-core/src/scala/bleep/GenBloopFiles.scala
@@ -363,7 +363,7 @@ object GenBloopFiles {
             case Some(scala) =>
               val base = scala.options.union(compilerPlugins).union(versionCombo.compilerOptions)
               if (scala.strict.getOrElse(false)) {
-                val tpolecat = model.Options.parse(new TpolecatPlugin(DevMode).scalacOptions(scalaVersion.scalaVersion).toList, None)
+                val tpolecat = new TpolecatPlugin(DevMode).scalacOptions(scalaVersion.scalaVersion)
                 base.union(tpolecat)
               } else base
             case None => model.Options.empty

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -28,7 +28,7 @@ projects:
     - bleep-model
     - bleep-nosbt
     extends: template-cross-all
-    sources: ../liberated/sbt-tpolecat/src/main/scala
+    sources: ../liberated/sbt-tpolecat/plugin/src/main/scala
   bleep-model:
     dependencies:
     - io.circe::circe-core:0.14.4

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 0.0.1
+$version: 0.0.2
 jvm:
   name: graalvm-java17:22.3.1
 projects:

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@js213.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@js213.json
@@ -37,6 +37,7 @@
       "options": [
         "-Wdead-code",
         "-Wextra-implicit",
+        "-Wnonunit-statement",
         "-Wnumeric-widen",
         "-Wunused:explicits",
         "-Wunused:implicits",

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@jvm213.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@jvm213.json
@@ -35,6 +35,7 @@
       "options": [
         "-Wdead-code",
         "-Wextra-implicit",
+        "-Wnonunit-statement",
         "-Wnumeric-widen",
         "-Wunused:explicits",
         "-Wunused:implicits",

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@js213.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@js213.json
@@ -57,6 +57,7 @@
       "options": [
         "-Wdead-code",
         "-Wextra-implicit",
+        "-Wnonunit-statement",
         "-Wnumeric-widen",
         "-Wunused:explicits",
         "-Wunused:implicits",

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm213.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm213.json
@@ -56,6 +56,7 @@
       "options": [
         "-Wdead-code",
         "-Wextra-implicit",
+        "-Wnonunit-statement",
         "-Wnumeric-widen",
         "-Wunused:explicits",
         "-Wunused:implicits",


### PR DESCRIPTION
Enabling `strict` in build didn't bring in the good new stuff for scala 3.3.0