### PR TITLE
set bloop working directory to project root

### DIFF
--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -43,7 +43,8 @@ object BspImpl {
           resolvedJvm = pre.resolvedJvm.forceGet,
           userPaths = pre.userPaths,
           resolver = resolver,
-          bleepRifleLogger = bleepRifleLogger
+          bleepRifleLogger = bleepRifleLogger,
+          workingDir = Some(pre.buildPaths.cwd)
         )
 
       val workspaceDir = pre.buildPaths.buildVariantDir

--- a/bleep-core/src/scala/bleep/BleepCommandRemote.scala
+++ b/bleep-core/src/scala/bleep/BleepCommandRemote.scala
@@ -30,7 +30,8 @@ abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {
         started.resolvedJvm.forceGet,
         started.pre.userPaths,
         started.resolver,
-        bleepRifleLogger
+        bleepRifleLogger,
+        Some(started.pre.buildPaths.cwd)
       )
 
     val buildClient: BspClientDisplayProgress =

--- a/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
@@ -19,13 +19,14 @@ object SetupBloopRifle {
       resolvedJvm: ResolvedJvm,
       userPaths: UserPaths,
       resolver: CoursierResolver,
-      bleepRifleLogger: BleepRifleLogger
+      bleepRifleLogger: BleepRifleLogger,
+      workingDir: Option[Path]
   ): BloopRifleConfig = {
     val default = BloopRifleConfig
       .default(
         BloopRifleConfig.Address.DomainSocket(bspSocketFile(userPaths, compileServerMode, resolvedJvm.jvm)),
         bloopClassPath(resolver),
-        FileUtils.TempDir.toFile
+        workingDir.getOrElse(FileUtils.TempDir).toFile
       )
 
     default.copy(


### PR DESCRIPTION
Setting the build servers working directory to be the project's root folder.

This is useful for macros resolving files relative to the project root.

Should this choice be configurable?