### PR TITLE
Bloop-rifle update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,10 @@ jobs:
         env:
           CI: true
         run: |
-          bleep compile
-          bleep test
+          bleep compile bleep-cli@jvm3
+          bleep setup-dev-script bleep-cli@jvm3
+          bleep config compile-server stop-all
+          ./bleep-cli@jvm3.sh test
 
   build-native-image:
     name: Native image build on ${{ matrix.os }}
@@ -64,8 +66,10 @@ jobs:
       - name: Build native image (non-windows)
         # stop compile server after build since the new version may use a newer version of bloop
         run: |
-          bleep native-image ${{ matrix.file_name }}
+          bleep compile bleep-cli@jvm3
+          bleep setup-dev-script bleep-cli@jvm3
           bleep config compile-server stop-all
+          ./bleep-cli@jvm3.sh native-image ${{ matrix.file_name }}
 
         if: runner.os != 'Windows'
 

--- a/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/proxy-config.json
+++ b/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/proxy-config.json
@@ -4,7 +4,7 @@
     "org.eclipse.lsp4j.jsonrpc.Endpoint"
   ],
   [
-    "scala.build.bloop.BuildServer",
+    "bloop.rifle.BuildServer",
     "org.eclipse.lsp4j.jsonrpc.Endpoint"
   ]
 ]

--- a/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/reflect-config.json
+++ b/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/reflect-config.json
@@ -210,13 +210,6 @@
     "allDeclaredFields": true
   },
   {
-    "name": "ch.epfl.scala.bsp4j.FileChangeType",
-    "allDeclaredConstructors": true,
-    "allPublicConstructors": true,
-    "allDeclaredMethods": true,
-    "allDeclaredFields": true
-  },
-  {
     "name": "ch.epfl.scala.bsp4j.InitializeBuildParams",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
@@ -568,13 +561,6 @@
   },
   {
     "name": "ch.epfl.scala.bsp4j.StatusCode",
-    "allDeclaredConstructors": true,
-    "allPublicConstructors": true,
-    "allDeclaredMethods": true,
-    "allDeclaredFields": true
-  },
-  {
-    "name": "ch.epfl.scala.bsp4j.TaskDataKind",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
     "allDeclaredMethods": true,

--- a/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/reflect-config.json
+++ b/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/reflect-config.json
@@ -266,6 +266,13 @@
     "allDeclaredFields": true
   },
   {
+    "name": "ch.epfl.scala.bsp4j.JvmMainClass",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "ch.epfl.scala.bsp4j.JvmBuildServer",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
@@ -679,14 +686,7 @@
     "allDeclaredFields": true
   },
   {
-    "name": "scala.build.bloop.BuildServer",
-    "allDeclaredConstructors": true,
-    "allPublicConstructors": true,
-    "allDeclaredMethods": true,
-    "allDeclaredFields": true
-  },
-  {
-    "name": "scala.build.bloop.bloop4j.BloopExtraBuildParams",
+    "name": "bloop.rifle.BuildServer",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
     "allDeclaredMethods": true,

--- a/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/reflect-config.json
+++ b/bleep-cli/src/resources/META-INF/native-image/org.scala-lang/scala-lang/reflect-config.json
@@ -28,6 +28,13 @@
     "allDeclaredFields": true
   },
   {
+    "name": "bloop.rifle.bloop4j.BloopExtraBuildParams",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "ch.epfl.scala.bsp4j.BuildServerCapabilities",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,

--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -154,7 +154,6 @@ object BspImpl {
       .setLocalService(buildClient)
       .create()
     val server = launcher.getRemoteProxy
-    buildClient.onConnectWithServer(server)
 
     val f = launcher.startListening()
 

--- a/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspImpl.scala
@@ -7,9 +7,9 @@ import org.eclipse.lsp4j.jsonrpc
 
 import java.net.Socket
 import java.nio.file.{Files, Path}
-import scala.build.bloop.{BloopServer, BloopThreads, BuildServer}
-import scala.build.blooprifle.internal.Operations
-import scala.build.blooprifle.{BloopRifle, BloopRifleConfig, BloopRifleLogger, FailedToStartServerException}
+import bloop.rifle.{BloopServer, BloopThreads, BuildServer}
+import bloop.rifle.internal.Operations
+import bloop.rifle.{BloopRifle, BloopRifleConfig, BloopRifleLogger, FailedToStartServerException}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success, Try}

--- a/bleep-cli/src/scala/bleep/commands/CompileServerStopAll.scala
+++ b/bleep-cli/src/scala/bleep/commands/CompileServerStopAll.scala
@@ -8,8 +8,8 @@ import bleep.logging.Logger
 
 import java.io.OutputStream
 import java.nio.file.{Files, Path}
-import scala.build.blooprifle.BloopRifleConfig
-import scala.build.blooprifle.internal.Operations
+import bloop.rifle.BloopRifleConfig
+import bloop.rifle.internal.Operations
 import scala.jdk.StreamConverters.StreamHasToScala
 
 case class CompileServerStopAll(logger: Logger, userPaths: UserPaths) extends BleepCommand {

--- a/bleep-cli/src/scala/bleep/commands/SetupIde.scala
+++ b/bleep-cli/src/scala/bleep/commands/SetupIde.scala
@@ -27,7 +27,7 @@ case class SetupIde(maybeSelectedProjects: Option[List[String]], forceJvm: Boole
       "bleep",
       (started.bleepExecutable.forceGet.whole ++ List("bsp")).asJava,
       model.BleepVersion.current.value,
-      scala.build.blooprifle.internal.Constants.bspVersion,
+      bloop.rifle.internal.Constants.bspVersion,
       List("scala", "java").asJava
     )
 

--- a/bleep-core/src/scala/bleep/BleepCommandRemote.scala
+++ b/bleep-core/src/scala/bleep/BleepCommandRemote.scala
@@ -6,9 +6,9 @@ import ch.epfl.scala.bsp4j
 
 import java.nio.file.Files
 import java.util
-import scala.build.bloop.{BloopServer, BloopThreads, BuildServer}
-import scala.build.blooprifle.internal.Operations
-import scala.build.blooprifle.{BloopRifleConfig, FailedToStartServerException}
+import bloop.rifle.{BloopServer, BloopThreads, BuildServer}
+import bloop.rifle.internal.Operations
+import bloop.rifle.{BloopRifleConfig, FailedToStartServerException}
 import scala.util.Try
 
 abstract class BleepCommandRemote(watch: Boolean) extends BleepBuildCommand {

--- a/bleep-core/src/scala/bleep/bsp/BleepBspServer.scala
+++ b/bleep-core/src/scala/bleep/bsp/BleepBspServer.scala
@@ -229,13 +229,13 @@ class BleepBspServer(
     logger.debug(("buildTargetOutputPaths", params.toString))
     bloopServer.buildTargetOutputPaths(params).handle(fatalExceptionHandler("buildTargetOutputPaths", params))
   }
-  override def jvmRunEnvironment(params: bsp4j.JvmRunEnvironmentParams): CompletableFuture[bsp4j.JvmRunEnvironmentResult] = {
+  override def buildTargetJvmRunEnvironment(params: bsp4j.JvmRunEnvironmentParams): CompletableFuture[bsp4j.JvmRunEnvironmentResult] = {
     logger.debug(("jvmRunEnvironment", params.toString))
-    bloopServer.jvmRunEnvironment(params).handle(fatalExceptionHandler("jvmRunEnvironment", params))
+    bloopServer.buildTargetJvmRunEnvironment(params).handle(fatalExceptionHandler("jvmRunEnvironment", params))
   }
-  override def jvmTestEnvironment(params: bsp4j.JvmTestEnvironmentParams): CompletableFuture[bsp4j.JvmTestEnvironmentResult] = {
+  override def buildTargetJvmTestEnvironment(params: bsp4j.JvmTestEnvironmentParams): CompletableFuture[bsp4j.JvmTestEnvironmentResult] = {
     logger.debug(("jvmTestEnvironment", params.toString))
-    bloopServer.jvmTestEnvironment(params).handle(fatalExceptionHandler("jvmTestEnvironment", params))
+    bloopServer.buildTargetJvmTestEnvironment(params).handle(fatalExceptionHandler("jvmTestEnvironment", params))
   }
 
   private val shutdownPromise = Promise[Unit]()

--- a/bleep-core/src/scala/bleep/bsp/BleepBspServer.scala
+++ b/bleep-core/src/scala/bleep/bsp/BleepBspServer.scala
@@ -12,8 +12,8 @@ import org.eclipse.lsp4j.jsonrpc.messages.{ResponseError, ResponseErrorCode}
 import java.util
 import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util.function.BiFunction
-import scala.build.bloop.BuildServer
-import scala.build.blooprifle.internal.Constants
+import bloop.rifle.BuildServer
+import bloop.rifle.internal.Constants
 import scala.concurrent.{Future, Promise}
 import scala.jdk.CollectionConverters.*
 import scala.util.Random
@@ -81,7 +81,7 @@ class BleepBspServer(
       case Left(th) =>
         warn("couldn't refresh the build", th)
         CompletableFuture.failedFuture(
-          new ResponseErrorException(new ResponseError(ResponseErrorCode.serverErrorEnd, "couldn't refresh the build", new Object))
+          new ResponseErrorException(new ResponseError(ResponseErrorCode.jsonrpcReservedErrorRangeEnd, "couldn't refresh the build", new Object))
         )
       case Right(started) =>
         val workspaceDir = started.buildPaths.buildVariantDir
@@ -128,7 +128,7 @@ class BleepBspServer(
       case Left(th) =>
         warn("Couldn't refresh the build", th)
         CompletableFuture.failedFuture(
-          new ResponseErrorException(new ResponseError(ResponseErrorCode.serverErrorEnd, "couldn't refresh the build", new Object))
+          new ResponseErrorException(new ResponseError(ResponseErrorCode.jsonrpcReservedErrorRangeEnd, "couldn't refresh the build", new Object))
         )
       case Right(_) =>
         bloopServer.workspaceBuildTargets().handle(fatalExceptionHandler("workspaceBuildTargets"))

--- a/bleep-core/src/scala/bleep/bsp/BleepRifleLogger.scala
+++ b/bleep-core/src/scala/bleep/bsp/BleepRifleLogger.scala
@@ -4,7 +4,7 @@ import bleep.logging.{Logger, LoggerFn}
 
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
-import scala.build.blooprifle.BloopRifleLogger
+import bloop.rifle.BloopRifleLogger
 
 class BleepRifleLogger(logger: Logger) extends BloopRifleLogger {
   val bloopLogger = logger.withPath("bloop")

--- a/bleep-core/src/scala/bleep/bsp/BspThreads.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspThreads.scala
@@ -2,7 +2,7 @@ package bleep.bsp
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ExecutorService, Executors, ThreadFactory}
-import scala.build.bloop.BloopThreads
+import bloop.rifle.BloopThreads
 
 final case class BspThreads(
     buildThreads: BloopThreads,

--- a/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
@@ -8,7 +8,7 @@ import coursier.parse.ModuleParser
 import java.io.File
 import java.nio.file.*
 import java.nio.file.attribute.PosixFilePermission
-import scala.build.blooprifle.BloopRifleConfig
+import bloop.rifle.BloopRifleConfig
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Properties, Random, Success, Try}

--- a/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/SetupBloopRifle.scala
@@ -38,11 +38,17 @@ object SetupBloopRifle {
   }
 
   def bloopClassPath(resolver: CoursierResolver)(bloopVersion: String): Either[BleepException, (Seq[File], Boolean)] =
-    ModuleParser.module(BloopRifleConfig.defaultModule, BloopRifleConfig.defaultScalaVersion) match {
+    ModuleParser.module("io.github.alexarchambault.bleep:bloop-frontend_2.13", BloopRifleConfig.defaultScalaVersion) match {
       case Left(msg) => Left(new BleepException.ModuleFormatError(BloopRifleConfig.defaultModule, msg))
       case Right(mod) =>
         val dep = model.Dep.JavaDependency(mod.organization, mod.name, bloopVersion)
-        resolver.resolve(Set(dep), model.VersionCombo.Java, libraryVersionSchemes = SortedSet.empty[model.LibraryVersionScheme]) match {
+        val libraryVersionSchemes = SortedSet(
+          model.LibraryVersionScheme(
+            model.LibraryVersionScheme.VersionScheme.Always,
+            model.Dep.Java("org.scala-lang.modules", "scala-parallel-collections_2.13", "always")
+          )
+        )
+        resolver.resolve(Set(dep), model.VersionCombo.Java, libraryVersionSchemes = libraryVersionSchemes) match {
           case Left(coursierError) =>
             Left(new BleepException.ResolveError(coursierError, "installing bloop"))
           case Right(value) =>

--- a/bleep-core/src/scala/bleep/commands/Compile.scala
+++ b/bleep-core/src/scala/bleep/commands/Compile.scala
@@ -5,7 +5,7 @@ import bleep.bsp.BspCommandFailed
 import bleep.internal.{DoSourceGen, TransitiveProjects}
 import ch.epfl.scala.bsp4j
 
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 
 case class Compile(watch: Boolean, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) with BleepCommandRemote.OnlyChanged {
 

--- a/bleep-core/src/scala/bleep/commands/Dist.scala
+++ b/bleep-core/src/scala/bleep/commands/Dist.scala
@@ -5,7 +5,7 @@ import bleep.internal.TransitiveProjects
 import bleep.packaging.dist
 
 import java.nio.file.Path
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 
 object Dist {
   case class Options(

--- a/bleep-core/src/scala/bleep/commands/PublishLocal.scala
+++ b/bleep-core/src/scala/bleep/commands/PublishLocal.scala
@@ -5,7 +5,7 @@ import bleep.internal.TransitiveProjects
 import bleep.packaging.{packageLibraries, CoordinatesFor, PackagedLibrary, PublishLayout}
 
 import java.nio.file.Path
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 import scala.collection.immutable.SortedMap
 import bleep.packaging.ManifestCreator
 

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -6,7 +6,7 @@ import bleep.internal.{bleepLoggers, jvmRunCommand, DoSourceGen, Throwables, Tra
 import ch.epfl.scala.bsp4j
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 

--- a/bleep-core/src/scala/bleep/commands/Script.scala
+++ b/bleep-core/src/scala/bleep/commands/Script.scala
@@ -4,7 +4,7 @@ package commands
 import bleep.internal.{traverseish, TransitiveProjects}
 import bleep.model.ScriptDef
 
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 
 case class Script(name: model.ScriptName, args: List[String], watch: Boolean) extends BleepCommandRemote(watch) {
   override def watchableProjects(started: Started): TransitiveProjects = {

--- a/bleep-core/src/scala/bleep/commands/SourceGen.scala
+++ b/bleep-core/src/scala/bleep/commands/SourceGen.scala
@@ -3,7 +3,7 @@ package commands
 
 import bleep.internal.{traverseish, TransitiveProjects}
 
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 
 case class SourceGen(watch: Boolean, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) {
   override def watchableProjects(started: Started): TransitiveProjects = {

--- a/bleep-core/src/scala/bleep/commands/Test.scala
+++ b/bleep-core/src/scala/bleep/commands/Test.scala
@@ -5,7 +5,7 @@ import bleep.bsp.BspCommandFailed
 import bleep.internal.{DoSourceGen, TransitiveProjects}
 import ch.epfl.scala.bsp4j
 
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 
 case class Test(watch: Boolean, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) with BleepCommandRemote.OnlyChanged {
 

--- a/bleep-core/src/scala/bleep/discoverMain.scala
+++ b/bleep-core/src/scala/bleep/discoverMain.scala
@@ -4,7 +4,7 @@ import bleep.logging.Logger
 import ch.epfl.scala.bsp4j
 
 import java.util
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 import scala.jdk.CollectionConverters.*
 
 object discoverMain {

--- a/bleep-core/src/scala/bleep/internal/BspClientDisplayProgress.scala
+++ b/bleep-core/src/scala/bleep/internal/BspClientDisplayProgress.scala
@@ -14,10 +14,10 @@ object BspClientDisplayProgress {
 
   def logLevelFor(messageType: MessageType): LogLevel =
     messageType match {
-      case bsp4j.MessageType.ERROR       => LogLevel.error
-      case bsp4j.MessageType.WARNING     => LogLevel.warn
-      case bsp4j.MessageType.INFORMATION => LogLevel.info
-      case bsp4j.MessageType.LOG         => LogLevel.debug
+      case bsp4j.MessageType.ERROR   => LogLevel.error
+      case bsp4j.MessageType.WARNING => LogLevel.warn
+      case bsp4j.MessageType.INFO    => LogLevel.info
+      case bsp4j.MessageType.LOG     => LogLevel.debug
     }
 }
 

--- a/bleep-core/src/scala/bleep/internal/BspClientDisplayProgress.scala
+++ b/bleep-core/src/scala/bleep/internal/BspClientDisplayProgress.scala
@@ -17,7 +17,7 @@ object BspClientDisplayProgress {
       case bsp4j.MessageType.ERROR       => LogLevel.error
       case bsp4j.MessageType.WARNING     => LogLevel.warn
       case bsp4j.MessageType.INFORMATION => LogLevel.info
-      case bsp4j.MessageType.LOG         => LogLevel.info
+      case bsp4j.MessageType.LOG         => LogLevel.debug
     }
 }
 

--- a/bleep-core/src/scala/bleep/internal/DoSourceGen.scala
+++ b/bleep-core/src/scala/bleep/internal/DoSourceGen.scala
@@ -7,7 +7,7 @@ import bleep.internal.compat.IteratorCompatOps
 import java.nio.file.attribute.FileTime
 import java.nio.file.{Files, Path}
 import java.time.{Duration, Instant}
-import scala.build.bloop.BuildServer
+import bloop.rifle.BuildServer
 import scala.collection.compat.*
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -24,7 +24,7 @@ projects:
     - com.swoval:file-tree-views:2.1.10
     - org.graalvm.nativeimage:svm:22.3.1
     - for3Use213: true
-      module: io.github.alexarchambault.bleep::bloop-rifle:1.5.11-sc-1
+      module: io.github.alexarchambault.bleep::bloop-rifle:1.5.11-sc-2
     dependsOn:
     - bleep-model
     - bleep-nosbt

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -23,11 +23,12 @@ projects:
     - com.lihaoyi::fansi:0.4.0
     - com.swoval:file-tree-views:2.1.10
     - org.graalvm.nativeimage:svm:22.3.1
-    - org.virtuslab.scala-cli::bloop-rifle:1.0.0-RC1
+    - for3Use213: true
+      module: io.github.alexarchambault.bleep::bloop-rifle:1.5.10-sc-2
     dependsOn:
     - bleep-model
     - bleep-nosbt
-    extends: template-cross-all
+    extends: template-cross-new
     sources: ../liberated/sbt-tpolecat/plugin/src/main/scala
   bleep-model:
     dependencies:
@@ -62,24 +63,24 @@ projects:
     - bleep-plugin-pgp
     - bleep-plugin-sonatype
     extends:
-    - template-cross-all
+    - template-cross-new
     - template-parcollection-ok
     sources: ../liberated/sbt-ci-release/plugin/src/main/scala
   bleep-plugin-dynver:
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends: template-cross-new
     sources:
     - ../liberated/sbt-dynver/dynver/src/main/scala
     - ../liberated/sbt-dynver/sbtdynver/src/main/scala
   bleep-plugin-git-versioning:
     dependencies: se.sawano.java:alphanumeric-comparator:1.4.1
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends: template-cross-new
     sources: ../liberated/sbt-git-versioning/src/main/scala
   bleep-plugin-jni:
     dependencies: org.ow2.asm:asm:9.5
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends: template-cross-new
     sources:
     - ../liberated/sbt-jni/core/src/main/scala
     - ../liberated/sbt-jni/plugin/src/main/java
@@ -87,14 +88,14 @@ projects:
   bleep-plugin-mdoc:
     dependencies: org.jsoup:jsoup:1.16.1
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends: template-cross-new
     sources: ../liberated/mdoc/mdoc-sbt/src/main/scala
   bleep-plugin-native-image:
     dependencies:
     - com.lihaoyi::os-lib:0.9.1
     - org.ow2.asm:asm:9.5
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends: template-cross-new
     resources: ../liberated/sbt-native-image/plugin/src/main/resources
     sources: ../liberated/sbt-native-image/plugin/src/main/scala
   bleep-plugin-pgp:
@@ -103,7 +104,7 @@ projects:
     - org.bouncycastle:bcpg-jdk15on:1.70
     - org.scala-lang.modules::scala-parser-combinators:2.3.0
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends: template-cross-new
     sources:
     - ../liberated/sbt-pgp/gpg-library/src/main/scala
     - ../liberated/sbt-pgp/sbt-pgp/src/main/scala
@@ -113,7 +114,7 @@ projects:
     - org.wvlet.airframe::airframe-http:23.5.6
     dependsOn: bleep-core
     extends:
-    - template-cross-all
+    - template-cross-new
     - template-parcollection-ok
     sources: ../liberated/sbt-sonatype/src/main/scala
   bleep-tests:
@@ -168,14 +169,14 @@ templates:
       jvm212:
         scala:
           options: -Xsource:3
-          version: 2.12.17
+          version: 2.12.18
     extends: template-cross-new
   template-cross-new:
     cross:
       jvm213:
         scala:
           options: -Xsource:3
-          version: 2.13.10
+          version: 2.13.11
       jvm3:
         extends: template-scala-3
     extends: template-common

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -24,7 +24,7 @@ projects:
     - com.swoval:file-tree-views:2.1.10
     - org.graalvm.nativeimage:svm:22.3.1
     - for3Use213: true
-      module: io.github.alexarchambault.bleep::bloop-rifle:1.5.10-sc-2
+      module: io.github.alexarchambault.bleep::bloop-rifle:1.5.11-sc-1
     dependsOn:
     - bleep-model
     - bleep-nosbt

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -13,7 +13,7 @@ projects:
     dependsOn: bleep-core
     extends:
     - template-common
-    - template-cross-new
+    - template-cross-all
     platform:
       mainClass: bleep.Main
   bleep-core:
@@ -28,7 +28,7 @@ projects:
     dependsOn:
     - bleep-model
     - bleep-nosbt
-    extends: template-cross-new
+    extends: template-cross-all
     sources: ../liberated/sbt-tpolecat/plugin/src/main/scala
   bleep-model:
     dependencies:
@@ -63,24 +63,24 @@ projects:
     - bleep-plugin-pgp
     - bleep-plugin-sonatype
     extends:
-    - template-cross-new
+    - template-cross-all
     - template-parcollection-ok
     sources: ../liberated/sbt-ci-release/plugin/src/main/scala
   bleep-plugin-dynver:
     dependsOn: bleep-core
-    extends: template-cross-new
+    extends: template-cross-all
     sources:
     - ../liberated/sbt-dynver/dynver/src/main/scala
     - ../liberated/sbt-dynver/sbtdynver/src/main/scala
   bleep-plugin-git-versioning:
     dependencies: se.sawano.java:alphanumeric-comparator:1.4.1
     dependsOn: bleep-core
-    extends: template-cross-new
+    extends: template-cross-all
     sources: ../liberated/sbt-git-versioning/src/main/scala
   bleep-plugin-jni:
     dependencies: org.ow2.asm:asm:9.5
     dependsOn: bleep-core
-    extends: template-cross-new
+    extends: template-cross-all
     sources:
     - ../liberated/sbt-jni/core/src/main/scala
     - ../liberated/sbt-jni/plugin/src/main/java
@@ -88,14 +88,14 @@ projects:
   bleep-plugin-mdoc:
     dependencies: org.jsoup:jsoup:1.16.1
     dependsOn: bleep-core
-    extends: template-cross-new
+    extends: template-cross-all
     sources: ../liberated/mdoc/mdoc-sbt/src/main/scala
   bleep-plugin-native-image:
     dependencies:
     - com.lihaoyi::os-lib:0.9.1
     - org.ow2.asm:asm:9.5
     dependsOn: bleep-core
-    extends: template-cross-new
+    extends: template-cross-all
     resources: ../liberated/sbt-native-image/plugin/src/main/resources
     sources: ../liberated/sbt-native-image/plugin/src/main/scala
   bleep-plugin-pgp:
@@ -104,7 +104,7 @@ projects:
     - org.bouncycastle:bcpg-jdk15on:1.70
     - org.scala-lang.modules::scala-parser-combinators:2.3.0
     dependsOn: bleep-core
-    extends: template-cross-new
+    extends: template-cross-all
     sources:
     - ../liberated/sbt-pgp/gpg-library/src/main/scala
     - ../liberated/sbt-pgp/sbt-pgp/src/main/scala
@@ -114,7 +114,7 @@ projects:
     - org.wvlet.airframe::airframe-http:23.5.6
     dependsOn: bleep-core
     extends:
-    - template-cross-new
+    - template-cross-all
     - template-parcollection-ok
     sources: ../liberated/sbt-sonatype/src/main/scala
   bleep-tests:
@@ -165,13 +165,6 @@ templates:
         -language:implicitConversions -unchecked
       strict: true
   template-cross-all:
-    cross:
-      jvm212:
-        scala:
-          options: -Xsource:3
-          version: 2.12.18
-    extends: template-cross-new
-  template-cross-new:
     cross:
       jvm213:
         scala:


### PR DESCRIPTION
Upstream moved, and some follow-up changes need
to be included as well.

Graal Native Image also needed some adjustments.

**Important:**
This PR depends on https://github.com/scala-cli/bloop-core/pull/153.

I'm not entirely sure about the build changes. But there seem to be some dependencies missing for 2.12. Should support for Scala 2.12 be dropped maybe altogether?