### PR TITLE
Add `--version` command line option

### DIFF
--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -249,7 +249,8 @@ object Main {
             (projectName, Opts.option[String]("--main-class", "override main class").orNone).mapN { case (projectNames, main) =>
               new commands.SetupDevScript(started, projectNames, main)
             }
-          )
+          ),
+          Opts.subcommand("version", "output version information and exit")(Opts(null.asInstanceOf[BleepBuildCommand])),
         ),
         started.build.scripts.map { case (scriptName, _) =>
           Opts.subcommand(scriptName.value, s"run script ${scriptName.value}")(
@@ -258,7 +259,7 @@ object Main {
         }
       )
 
-      commonOpts *> Opts.flag("version", "output version information and exit") *> allCommands.flatten.foldK
+      commonOpts *> Opts.flag("version", "output version information and exit").orFalse *> allCommands.flatten.foldK
     }
 
     ret
@@ -459,7 +460,7 @@ object Main {
       case args =>
         if (args.contains("--version") || args.contains("version")) {
           // This is a little bit hacky but the only way to not have any output before the version.
-          println(s"bleep ${model.BleepVersion.current.value}")
+          commands.Version.run()
           System.exit(0)
         }
 

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -457,12 +457,12 @@ object Main {
         }
 
       case args =>
-        if (args.contains("--version")) {
+        if (args.contains("--version") || args.contains("version")) {
           // This is a little bit hacky but the only way to not have any output before the version.
           println(s"bleep ${model.BleepVersion.current.value}")
           System.exit(0)
         }
-          
+
         val (commonOpts, restArgs) = CommonOpts.parse(args)
         val cwd = cwdFor(commonOpts)
 

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -258,7 +258,7 @@ object Main {
         }
       )
 
-      commonOpts *> allCommands.flatten.foldK
+      commonOpts *> Opts.flag("version", "output version information and exit") *> allCommands.flatten.foldK
     }
 
     ret
@@ -457,6 +457,12 @@ object Main {
         }
 
       case args =>
+        if (args.contains("--version")) {
+          // This is a little bit hacky but the only way to not have any output before the version.
+          println(s"bleep ${model.BleepVersion.current.value}")
+          System.exit(0)
+        }
+          
         val (commonOpts, restArgs) = CommonOpts.parse(args)
         val cwd = cwdFor(commonOpts)
 

--- a/bleep-cli/src/scala/bleep/commands/Version.scala
+++ b/bleep-cli/src/scala/bleep/commands/Version.scala
@@ -1,0 +1,10 @@
+package bleep
+package commands
+
+
+object Version extends BleepNoBuildCommand {
+  override def run(): Either[BleepException, Unit] = {
+    println(s"bleep ${model.BleepVersion.current.value}")
+    Right(())
+  }
+}


### PR DESCRIPTION
I've got confused a few time which `bleep` build I'm currently calling.

There is no `--version` option at the moment so I added one.

I didn't find a way to do it "less hacky" as when using the `decline` lib more idiomatic together with a proper `command` one would always get other output before the version string. This is not good for scripting as you would need more complex logic to parse the version.

(A suggestion for a follow up: I think just using `decline` without any hackery around it would make things more simple and easier to maintain. Also it's sub-optimal imho to have "hidden" CLI options like `bsp` because of this hackery.)

I think there could be more output following the line with the version string, like for example a link to the homepage, or a license hint, but I'm not sure what would be preferred here, so it's currently just the name of the tool and its version.

In case there are suggestion to add more output I'm happy to update the PR!