### PR TITLE
Move help output form stderr to stdout

### DIFF
--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -405,7 +405,7 @@ object Main {
         }
     }
 
-  def main(_args: Array[String]): Unit = {
+  def _main(_args: Array[String]): ExitCode = {
     val userPaths = UserPaths.fromAppDirs
 
     val exitCode: ExitCode = _args.toList match {
@@ -485,9 +485,11 @@ object Main {
           }
         }
     }
-
-    System.exit(exitCode.value)
+    exitCode
   }
+
+  def main(args: Array[String]): Unit =
+    System.exit(_main(args).value)
 
   def withCompletions(_args: Array[String], userPaths: UserPaths, commonOpts: CommonOpts, args: List[String])(f: Completer.Res => ExitCode): ExitCode = {
     val (_, restArgs) = CommonOpts.parse(args)
@@ -537,10 +539,13 @@ object Main {
   private def run[Cmd](opts: Opts[Cmd], restArgs: List[String], logger: Logger)(runCommand: Cmd => Either[BleepException, Unit]): ExitCode =
     Command("bleep", s"Bleeping fast build! (version ${model.BleepVersion.current.value})")(opts).parse(restArgs, sys.env) match {
       case Left(help) =>
-        System.out.println(help)
         help.errors match {
-          case List() => ExitCode.Success
-          case _      => ExitCode.Failure
+          case List() =>
+            System.out.println(help)
+            ExitCode.Success
+          case _ =>
+            System.err.println(help)
+            ExitCode.Failure
         }
       case Right(cmd) =>
         Try(runCommand(cmd)) match {

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -537,14 +537,14 @@ object Main {
   private def run[Cmd](opts: Opts[Cmd], restArgs: List[String], logger: Logger)(runCommand: Cmd => Either[BleepException, Unit]): ExitCode =
     Command("bleep", s"Bleeping fast build! (version ${model.BleepVersion.current.value})")(opts).parse(restArgs, sys.env) match {
       case Left(help) =>
-        System.err.println(help)
+        System.out.println(help)
         help.errors match {
           case List() => ExitCode.Success
           case _      => ExitCode.Failure
         }
       case Right(cmd) =>
         Try(runCommand(cmd)) match {
-          case Failure(th)        => fatal("command failed unexpectedly", logger, th) // This really shouldn't happen
+          case Failure(th)        => fatal("command failed unexpectedly! This really shouldn't happen. Please report.", logger, th)
           case Success(Left(th))  => fatal("command failed", logger, th)
           case Success(Right(())) => ExitCode.Success
         }

--- a/bleep-tests/src/scala/bleep/CliInvocationTest.scala
+++ b/bleep-tests/src/scala/bleep/CliInvocationTest.scala
@@ -1,0 +1,63 @@
+package bleep
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.BufferedOutputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileDescriptor
+import java.io.FileOutputStream
+import java.io.PrintStream
+
+
+class CliInvocationTest extends AnyFunSuite {
+  case class IoBuffer(
+    stdOutBuffer: ByteArrayOutputStream,
+    stdErrBuffer: ByteArrayOutputStream)
+  
+  // https://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html
+  
+  test("'--help' output should go to stdout, nothing on stderr") {
+    val captured = callMainSlurpingStdIo(Array("--help"))
+    
+    assert(captured.stdOutBuffer.toString.linesIterator.filter(_ match {
+      case "Usage:" | "Options and flags:" | "Subcommands:" => true
+      case _ => false
+    }).toList.size == 3)
+    
+    assert(captured.stdErrBuffer.size == 0)
+  }
+  
+  test("failed bleep invocation help output should go to stderr") {
+    val captured = callMainSlurpingStdIo(Array("--this-option-does-not-exist"))
+    
+    assert(captured.stdErrBuffer.toString.linesIterator.filter(_ match {
+      case "Usage:" | "Options and flags:" | "Subcommands:" => true
+      case "Unexpected option: --this-option-does-not-exist" => true
+      case _ => false
+    }).toList.size == 3 + 1)
+  }
+  
+  def callMainSlurpingStdIo(arguments: Array[String]): IoBuffer = {
+    val systemOut = System.out
+    val systemErr = System.err
+
+    val stdOutBuffer = ByteArrayOutputStream()
+    val stdErrBuffer = ByteArrayOutputStream()
+    val bufferedOut = PrintStream(stdOutBuffer)
+    val bufferedErr = PrintStream(stdErrBuffer)
+
+    System.setOut(bufferedOut)
+    System.setErr(bufferedErr)
+
+    Main._main(arguments)
+
+    bufferedOut.close()
+    bufferedErr.close()
+    System.setOut(systemOut)
+    System.setErr(systemErr)
+
+    IoBuffer(stdOutBuffer, stdErrBuffer)
+  }
+}

--- a/bleep-tests/src/scala/bleep/CliInvocationTest.scala
+++ b/bleep-tests/src/scala/bleep/CliInvocationTest.scala
@@ -10,35 +10,42 @@ import java.io.FileDescriptor
 import java.io.FileOutputStream
 import java.io.PrintStream
 
-
 class CliInvocationTest extends AnyFunSuite {
-  case class IoBuffer(
-    stdOutBuffer: ByteArrayOutputStream,
-    stdErrBuffer: ByteArrayOutputStream)
-  
+  case class IoBuffer(stdOutBuffer: ByteArrayOutputStream, stdErrBuffer: ByteArrayOutputStream)
+
   // https://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html
-  
+
   test("'--help' output should go to stdout, nothing on stderr") {
     val captured = callMainSlurpingStdIo(Array("--help"))
-    
-    assert(captured.stdOutBuffer.toString.linesIterator.filter(_ match {
-      case "Usage:" | "Options and flags:" | "Subcommands:" => true
-      case _ => false
-    }).toList.size == 3)
-    
+
+    assert(
+      captured.stdOutBuffer.toString.linesIterator
+        .filter(_ match {
+          case "Usage:" | "Options and flags:" | "Subcommands:" => true
+          case _                                                => false
+        })
+        .toList
+        .size == 3
+    )
+
     assert(captured.stdErrBuffer.size == 0)
   }
-  
+
   test("failed bleep invocation help output should go to stderr") {
     val captured = callMainSlurpingStdIo(Array("--this-option-does-not-exist"))
-    
-    assert(captured.stdErrBuffer.toString.linesIterator.filter(_ match {
-      case "Usage:" | "Options and flags:" | "Subcommands:" => true
-      case "Unexpected option: --this-option-does-not-exist" => true
-      case _ => false
-    }).toList.size == 3 + 1)
+
+    assert(
+      captured.stdErrBuffer.toString.linesIterator
+        .filter(_ match {
+          case "Usage:" | "Options and flags:" | "Subcommands:"  => true
+          case "Unexpected option: --this-option-does-not-exist" => true
+          case _                                                 => false
+        })
+        .toList
+        .size == 3 + 1
+    )
   }
-  
+
   def callMainSlurpingStdIo(arguments: Array[String]): IoBuffer = {
     val systemOut = System.out
     val systemErr = System.err


### PR DESCRIPTION
I've never seen a CLI tool outputting help messages on stderr until now. Looks wrong to me.

Also improved the failure message with some more end-user actionable suggestion. Users couldn't see the code comment… :smile: