### PR TITLE
Update schema.json to define "index" as a "string" variable.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -300,7 +300,7 @@
         },
         "index": {
           "description": "the default index is the coursier index, located at https://github.com/coursier/jvm-index/raw/master/index.json . If you need to use a JVM which is not there, you can specify another index here",
-          "type": "boolean"
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
I think string is the correct type here? It seems like boolean definitely is the wrong one at least 😁 