### PR TITLE
Fix build for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           bleep compile
           bleep setup-dev-script bleep-cli@jvm3
           bleep config compile-server stop-all
-          ./bleep-cli@jvm3.sh test
+          ./bleep-cli@jvm3.sh --dev test 
 
   build-native-image:
     name: Native image build on ${{ matrix.os }}
@@ -69,7 +69,7 @@ jobs:
           bleep compile bleep-cli@jvm3
           bleep setup-dev-script bleep-cli@jvm3
           bleep config compile-server stop-all
-          ./bleep-cli@jvm3.sh native-image ${{ matrix.file_name }}
+          ./bleep-cli@jvm3.sh --dev native-image ${{ matrix.file_name }}
 
         if: runner.os != 'Windows'
 

--- a/bleep-tests/src/scala/bleep/CliInvocationTest.scala
+++ b/bleep-tests/src/scala/bleep/CliInvocationTest.scala
@@ -2,13 +2,7 @@ package bleep
 
 import org.scalatest.funsuite.AnyFunSuite
 
-import java.io.BufferedOutputStream
-import java.io.ByteArrayOutputStream
-import java.io.DataOutputStream
-import java.io.File
-import java.io.FileDescriptor
-import java.io.FileOutputStream
-import java.io.PrintStream
+import java.io.{ByteArrayOutputStream, PrintStream}
 
 class CliInvocationTest extends AnyFunSuite {
   case class IoBuffer(stdOutBuffer: ByteArrayOutputStream, stdErrBuffer: ByteArrayOutputStream)
@@ -58,7 +52,8 @@ class CliInvocationTest extends AnyFunSuite {
     System.setOut(bufferedOut)
     System.setErr(bufferedErr)
 
-    Main._main(arguments)
+    // without `--dev`, `Main may try to boot another bleep version
+    Main._main(Array("--dev") ++ arguments)
 
     bufferedOut.close()
     bufferedErr.close()

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -9,7 +9,8 @@ projects:
     - com.monovore::decline:2.4.1
     - org.gnieh::diffson-circe:4.4.0
     - org.scalameta:svm-subs:101.0.0
-    - org.typelevel::cats-core:2.10.0
+    # note: weird binary incompatibility when bumping this for scala3
+    - org.typelevel::cats-core:2.9.0
     dependsOn: bleep-core
     extends:
     - template-common


### PR DESCRIPTION
some more fallout from the bloop upgrade it seems. one detail which was wrong on my part, and now the native-image binary seems unable to run tests. and CI considers those tests green! pff