### PR TITLE
--test-only

### DIFF
--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -90,6 +90,8 @@ object Main {
         .orNone
         .map(started.chosenTestProjects)
 
+    val testSuites: Opts[Option[NonEmptyList[String]]] = Opts.options[String]("test-only", "Test only a subset of test suites", "o").orNone
+
     val hasSourcegenProjectNames: Opts[Array[model.CrossProjectName]] =
       Opts
         .arguments(metavars.hasSourceGenProject)(argumentFrom(metavars.hasSourceGenProject, Some(started.globs.hasSourceGenProjectNameMap)))
@@ -172,8 +174,8 @@ object Main {
             (watch, hasSourcegenProjectNames).mapN { case (watch, projectNames) => commands.SourceGen(watch, projectNames) }
           ),
           Opts.subcommand("test", "test projects")(
-            (watch, testProjectNames).mapN { case (watch, projectNames) =>
-              commands.Test(watch, projectNames)
+            (watch, testProjectNames, testSuites).mapN { case (watch, projectNames, testSuites) =>
+              commands.Test(watch, projectNames, testSuites)
             }
           ),
           Opts.subcommand("list-tests", "list tests in projects")(

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -90,7 +90,9 @@ object Main {
         .orNone
         .map(started.chosenTestProjects)
 
-    val testSuites: Opts[Option[NonEmptyList[String]]] = Opts.options[String]("test-only", "Test only a subset of test suites", "o").orNone
+    val testSuitesOnly: Opts[Option[NonEmptyList[String]]] = Opts.options[String]("only", "Test only a subset of test suites", "o").orNone
+    val testSuitesExclude: Opts[Option[NonEmptyList[String]]] =
+      Opts.options[String]("exclude", "Exclude specific test suites, if used the --only is ignored", "x").orNone
 
     val hasSourcegenProjectNames: Opts[Array[model.CrossProjectName]] =
       Opts
@@ -174,8 +176,8 @@ object Main {
             (watch, hasSourcegenProjectNames).mapN { case (watch, projectNames) => commands.SourceGen(watch, projectNames) }
           ),
           Opts.subcommand("test", "test projects")(
-            (watch, testProjectNames, testSuites).mapN { case (watch, projectNames, testSuites) =>
-              commands.Test(watch, projectNames, testSuites)
+            (watch, testProjectNames, testSuitesOnly, testSuitesExclude).mapN { case (watch, projectNames, testSuitesOnly, testSuitesExclude) =>
+              commands.Test(watch, projectNames, testSuitesOnly, testSuitesExclude)
             }
           ),
           Opts.subcommand("list-tests", "list tests in projects")(

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -90,9 +90,22 @@ object Main {
         .orNone
         .map(started.chosenTestProjects)
 
-    val testSuitesOnly: Opts[Option[NonEmptyList[String]]] = Opts.options[String]("only", "Test only a subset of test suites", "o").orNone
+    val testSuitesOnly: Opts[Option[NonEmptyList[String]]] =
+      Opts
+        .options[String](
+          "only",
+          "Test only a subset of test suite class names. Class name can be fully qualified to disambiguate",
+          "o"
+        )
+        .orNone
     val testSuitesExclude: Opts[Option[NonEmptyList[String]]] =
-      Opts.options[String]("exclude", "Exclude specific test suites, if used the --only is ignored", "x").orNone
+      Opts
+        .options[String](
+          "exclude",
+          "Exclude specific test suite class names. Class name can be fully qualified to disambiguate. Takes precedence over --only",
+          "x"
+        )
+        .orNone
 
     val hasSourcegenProjectNames: Opts[Array[model.CrossProjectName]] =
       Opts

--- a/bleep-core/src/scala/bleep/Commands.scala
+++ b/bleep-core/src/scala/bleep/Commands.scala
@@ -22,8 +22,13 @@ class Commands(started: Started) {
   ): Unit =
     force(commands.Run(project, maybeOverriddenMain, args, raw, watch))
 
-  def test(projects: List[model.CrossProjectName], watch: Boolean = false, classes: Option[NonEmptyList[String]]): Unit =
-    force(commands.Test(watch, projects.toArray, classes))
+  def test(
+      projects: List[model.CrossProjectName],
+      watch: Boolean = false,
+      testOnlyClasses: Option[NonEmptyList[String]],
+      testExcludeClasses: Option[NonEmptyList[String]]
+  ): Unit =
+    force(commands.Test(watch, projects.toArray, testOnlyClasses, testExcludeClasses))
 
   def script(name: model.ScriptName, args: List[String], watch: Boolean = false): Unit =
     force(commands.Script(name, args, watch))

--- a/bleep-core/src/scala/bleep/Commands.scala
+++ b/bleep-core/src/scala/bleep/Commands.scala
@@ -1,6 +1,7 @@
 package bleep
 
 import bleep.commands.PublishLocal
+import cats.data.NonEmptyList
 
 class Commands(started: Started) {
   private def force(cmd: BleepBuildCommand): Unit =
@@ -21,8 +22,8 @@ class Commands(started: Started) {
   ): Unit =
     force(commands.Run(project, maybeOverriddenMain, args, raw, watch))
 
-  def test(projects: List[model.CrossProjectName], watch: Boolean = false): Unit =
-    force(commands.Test(watch, projects.toArray))
+  def test(projects: List[model.CrossProjectName], watch: Boolean = false, classes: Option[NonEmptyList[String]]): Unit =
+    force(commands.Test(watch, projects.toArray, classes))
 
   def script(name: model.ScriptName, args: List[String], watch: Boolean = false): Unit =
     force(commands.Script(name, args, watch))

--- a/bleep-core/src/scala/bleep/commands/ListTests.scala
+++ b/bleep-core/src/scala/bleep/commands/ListTests.scala
@@ -26,7 +26,7 @@ case class ListTests(projects: Array[model.CrossProjectName]) extends BleepComma
 
   private def testsByCrossProject(started: Started, bloop: BuildServer): Iterator[(model.CrossProjectName, String)] = {
     val targets = BleepCommandRemote.buildTargets(started.buildPaths, projects)
-    val result = bloop.buildTargetScalaTestClasses(new ScalaTestClassesParams(targets)).get()
+    val result: bsp4j.ScalaTestClassesResult = bloop.buildTargetScalaTestClasses(new ScalaTestClassesParams(targets)).get()
 
     for {
       item <- result.getItems.iterator().asScala

--- a/bleep-core/src/scala/bleep/commands/Test.scala
+++ b/bleep-core/src/scala/bleep/commands/Test.scala
@@ -31,6 +31,69 @@ case class Test(
       }
     }
 
+  private def runTests(started: Started, bloop: BuildServer, testParams: bsp4j.TestParams) = {
+    val result = bloop.buildTargetTest(testParams).get()
+
+    result.getStatusCode match {
+      case bsp4j.StatusCode.OK =>
+        started.logger.info("Tests succeeded")
+        Right(())
+      case errorCode =>
+        Left(new BspCommandFailed("tests", projects, BspCommandFailed.StatusCode(errorCode)))
+    }
+  }
+
+  private def runWithFilters(started: Started, bloop: BuildServer, targets: java.util.List[bsp4j.BuildTargetIdentifier]) = {
+    val tests = bloop.buildTargetScalaTestClasses(new bsp4j.ScalaTestClassesParams(targets)).get()
+    val testClassesUnfiltered: List[String] = tests.getItems().asScala.flatMap(_.getClasses.asScala).toList
+
+    val testClasses = testSuitesExclude.map { exclude =>
+      val filtered = testClassesUnfiltered
+        .filter(fromBuildCls => exclude.toList.find(fromCliCls => isSameSuite(fromBuildCls, fromCliCls)).isDefined)
+      if (filtered.nonEmpty) testClassesUnfiltered.diff(filtered) else List.empty
+    }
+
+    val testParams = new bsp4j.TestParams(targets)
+
+    val hasSuites: Boolean =
+      testClasses match {
+        case None =>
+          testSuitesOnly
+            .map { classes =>
+              val testClassesData = new bsp4j.ScalaTestSuites(
+                intersectTestSuites(testClassesUnfiltered, classes.toList)
+                  .map(cls => new bsp4j.ScalaTestSuiteSelection(cls, List.empty[String].asJava))
+                  .asJava,
+                List.empty[String].asJava,
+                List.empty[String].asJava
+              )
+              testParams.setData(testClassesData)
+              testParams.setDataKind(bsp4j.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
+
+              !testClassesData.getSuites().isEmpty
+            }
+            .getOrElse(true)
+        case Some(value) =>
+          if (value.isEmpty) false
+          else {
+            val testClassesData = new bsp4j.ScalaTestSuites(
+              value.map(suite => new bsp4j.ScalaTestSuiteSelection(suite, List.empty[String].asJava)).asJava,
+              List.empty[String].asJava,
+              List.empty[String].asJava
+            )
+            testParams.setData(testClassesData)
+            testParams.setDataKind(bsp4j.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
+            true
+          }
+      }
+
+    if (hasSuites) {
+      runTests(started, bloop, testParams)
+    } else {
+      Left(new TestSuitesNotFound(testSuitesOnly.map(_.toList).getOrElse(List.empty[String])))
+    }
+  }
+
   override def watchableProjects(started: Started): TransitiveProjects =
     TransitiveProjects(started.build, projects)
 
@@ -40,62 +103,11 @@ case class Test(
   override def runWithServer(started: Started, bloop: BuildServer): Either[BleepException, Unit] =
     DoSourceGen(started, bloop, watchableProjects(started)).flatMap { _ =>
       val targets = BleepCommandRemote.buildTargets(started.buildPaths, projects)
-      val tests = bloop.buildTargetScalaTestClasses(new bsp4j.ScalaTestClassesParams(targets)).get()
-      val testClassesUnfiltered: List[String] = tests.getItems().asScala.flatMap(_.getClasses.asScala).toList
-
-      val testClasses = testSuitesExclude.map { exclude =>
-        val filtered = testClassesUnfiltered
-          .filter(fromBuildCls => exclude.toList.find(fromCliCls => isSameSuite(fromBuildCls, fromCliCls)).isDefined)
-        if (filtered.nonEmpty) testClassesUnfiltered.diff(filtered) else List.empty
-      }
-
-      val testParams = new bsp4j.TestParams(targets)
-
-      val hasSuites: Boolean =
-        testClasses match {
-          case None =>
-            testSuitesOnly
-              .map { classes =>
-                val testClassesData = new bsp4j.ScalaTestSuites(
-                  intersectTestSuites(testClassesUnfiltered, classes.toList)
-                    .map(cls => new bsp4j.ScalaTestSuiteSelection(cls, List.empty[String].asJava))
-                    .asJava,
-                  List.empty[String].asJava,
-                  List.empty[String].asJava
-                )
-                testParams.setData(testClassesData)
-                testParams.setDataKind(bsp4j.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
-
-                !testClassesData.getSuites().isEmpty
-              }
-              .getOrElse(true)
-          case Some(value) =>
-            if (value.isEmpty) false
-            else {
-              val testClassesData = new bsp4j.ScalaTestSuites(
-                value.map(suite => new bsp4j.ScalaTestSuiteSelection(suite, List.empty[String].asJava)).asJava,
-                List.empty[String].asJava,
-                List.empty[String].asJava
-              )
-              testParams.setData(testClassesData)
-              testParams.setDataKind(bsp4j.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
-              true
-            }
-        }
-
-      if (hasSuites) {
-        val result = bloop.buildTargetTest(testParams).get()
-
-        result.getStatusCode match {
-          case bsp4j.StatusCode.OK =>
-            started.logger.info("Tests succeeded")
-            Right(())
-          case errorCode =>
-            println(errorCode)
-            Left(new BspCommandFailed("tests", projects, BspCommandFailed.StatusCode(errorCode)))
-        }
-      } else {
-        Left(new TestSuitesNotFound(testSuitesOnly.map(_.toList).getOrElse(List.empty[String])))
+      (testSuitesExclude, testSuitesOnly) match {
+        case (None, None) =>
+          runTests(started, bloop, new bsp4j.TestParams(targets))
+        case _ =>
+          runWithFilters(started, bloop, targets)
       }
     }
 }

--- a/bleep-core/src/scala/bleep/commands/Test.scala
+++ b/bleep-core/src/scala/bleep/commands/Test.scala
@@ -4,10 +4,14 @@ package commands
 import bleep.bsp.BspCommandFailed
 import bleep.internal.{DoSourceGen, TransitiveProjects}
 import ch.epfl.scala.bsp4j
+import scala.jdk.CollectionConverters.*
 
 import bloop.rifle.BuildServer
+import cats.data.NonEmptyList
 
-case class Test(watch: Boolean, projects: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) with BleepCommandRemote.OnlyChanged {
+case class Test(watch: Boolean, projects: Array[model.CrossProjectName], testSuites: Option[NonEmptyList[String]])
+    extends BleepCommandRemote(watch)
+    with BleepCommandRemote.OnlyChanged {
 
   override def watchableProjects(started: Started): TransitiveProjects =
     TransitiveProjects(started.build, projects)
@@ -18,7 +22,22 @@ case class Test(watch: Boolean, projects: Array[model.CrossProjectName]) extends
   override def runWithServer(started: Started, bloop: BuildServer): Either[BleepException, Unit] =
     DoSourceGen(started, bloop, watchableProjects(started)).flatMap { _ =>
       val targets = BleepCommandRemote.buildTargets(started.buildPaths, projects)
-      val result = bloop.buildTargetTest(new bsp4j.TestParams(targets)).get()
+      val tests = bloop.buildTargetScalaTestClasses(new bsp4j.ScalaTestClassesParams(targets)).get()
+      val testClasses: List[String] = tests.getItems().asScala.flatMap(_.getClasses.asScala).toList
+
+      val testParams = new bsp4j.TestParams(targets)
+
+      testSuites.foreach { classes =>
+        val testClassesData = new bsp4j.ScalaTestSuites(
+          testClasses.filter(classes.toList.contains).map(cls => new bsp4j.ScalaTestSuiteSelection(cls, List.empty[String].asJava)).asJava,
+          List.empty[String].asJava,
+          List.empty[String].asJava
+        )
+        testParams.setData(testClassesData)
+        testParams.setDataKind(bsp4j.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
+      }
+
+      val result = bloop.buildTargetTest(testParams).get()
 
       result.getStatusCode match {
         case bsp4j.StatusCode.OK =>

--- a/bleep-core/src/scala/bleep/commands/Test.scala
+++ b/bleep-core/src/scala/bleep/commands/Test.scala
@@ -14,14 +14,11 @@ case class Test(watch: Boolean, projects: Array[model.CrossProjectName], testSui
     with BleepCommandRemote.OnlyChanged {
 
   private def intersectTestSuites(fromBuild: List[String], fromCli: List[String]): List[String] =
-    fromBuild.filter { fullyQualified =>
+    fromBuild.filter { fullyQualifiedCls =>
       fromCli.exists { fromCliCls =>
-        println(fullyQualified)
-        println(fromCliCls)
-        val fromBuildFqn = if (fullyQualified.contains(".")) fullyQualified.split(".").toList else List(fullyQualified)
-        val fromCliFqn = if (fromCliCls.contains(".")) fromCliCls.split(".").toList else List(fromCliCls)
-
-        fromBuildFqn == fromCliFqn || fromBuildFqn.last == fromCliFqn.last
+        val fromBuildFqn = fullyQualifiedCls.split('.')
+        val fromCliFqn = fromCliCls.split('.')
+        fromBuildFqn.sameElements(fromCliFqn) || fromBuildFqn.last == fromCliFqn.last
       }
     }
 

--- a/bleep-core/src/scala/bleep/commands/Test.scala
+++ b/bleep-core/src/scala/bleep/commands/Test.scala
@@ -3,12 +3,13 @@ package commands
 
 import bleep.bsp.BspCommandFailed
 import bleep.internal.{DoSourceGen, TransitiveProjects}
-import ch.epfl.scala.bsp4j
-import scala.jdk.CollectionConverters.*
-
 import bloop.rifle.BuildServer
 import cats.data.NonEmptyList
-import bleep.BleepException.TestSuitesNotFound
+import ch.epfl.scala.bsp4j
+import ch.epfl.scala.bsp4j.ScalaTestSuiteSelection
+
+import java.util
+import scala.jdk.CollectionConverters.*
 
 case class Test(
     watch: Boolean,
@@ -18,82 +19,6 @@ case class Test(
 ) extends BleepCommandRemote(watch)
     with BleepCommandRemote.OnlyChanged {
 
-  private def isSameSuite(fromBuild: String, fromCli: String) = {
-    val fromBuildFqn = fromBuild.split('.')
-    val fromCliFqn = fromCli.split('.')
-    fromBuildFqn.sameElements(fromCliFqn) || fromBuildFqn.last == fromCliFqn.last
-  }
-
-  private def intersectTestSuites(fromBuild: List[String], fromCli: List[String]): List[String] =
-    fromBuild.filter { fullyQualifiedCls =>
-      fromCli.exists { fromCliCls =>
-        isSameSuite(fullyQualifiedCls, fromCliCls)
-      }
-    }
-
-  private def runTests(started: Started, bloop: BuildServer, testParams: bsp4j.TestParams) = {
-    val result = bloop.buildTargetTest(testParams).get()
-
-    result.getStatusCode match {
-      case bsp4j.StatusCode.OK =>
-        started.logger.info("Tests succeeded")
-        Right(())
-      case errorCode =>
-        Left(new BspCommandFailed("tests", projects, BspCommandFailed.StatusCode(errorCode)))
-    }
-  }
-
-  private def runWithFilters(started: Started, bloop: BuildServer, targets: java.util.List[bsp4j.BuildTargetIdentifier]) = {
-    val tests = bloop.buildTargetScalaTestClasses(new bsp4j.ScalaTestClassesParams(targets)).get()
-    val testClassesUnfiltered: List[String] = tests.getItems().asScala.flatMap(_.getClasses.asScala).toList
-
-    val testClasses = testSuitesExclude.map { exclude =>
-      val filtered = testClassesUnfiltered
-        .filter(fromBuildCls => exclude.toList.find(fromCliCls => isSameSuite(fromBuildCls, fromCliCls)).isDefined)
-      if (filtered.nonEmpty) testClassesUnfiltered.diff(filtered) else List.empty
-    }
-
-    val testParams = new bsp4j.TestParams(targets)
-
-    val hasSuites: Boolean =
-      testClasses match {
-        case None =>
-          testSuitesOnly
-            .map { classes =>
-              val testClassesData = new bsp4j.ScalaTestSuites(
-                intersectTestSuites(testClassesUnfiltered, classes.toList)
-                  .map(cls => new bsp4j.ScalaTestSuiteSelection(cls, List.empty[String].asJava))
-                  .asJava,
-                List.empty[String].asJava,
-                List.empty[String].asJava
-              )
-              testParams.setData(testClassesData)
-              testParams.setDataKind(bsp4j.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
-
-              !testClassesData.getSuites().isEmpty
-            }
-            .getOrElse(true)
-        case Some(value) =>
-          if (value.isEmpty) false
-          else {
-            val testClassesData = new bsp4j.ScalaTestSuites(
-              value.map(suite => new bsp4j.ScalaTestSuiteSelection(suite, List.empty[String].asJava)).asJava,
-              List.empty[String].asJava,
-              List.empty[String].asJava
-            )
-            testParams.setData(testClassesData)
-            testParams.setDataKind(bsp4j.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
-            true
-          }
-      }
-
-    if (hasSuites) {
-      runTests(started, bloop, testParams)
-    } else {
-      Left(new TestSuitesNotFound(testSuitesOnly.map(_.toList).getOrElse(List.empty[String])))
-    }
-  }
-
   override def watchableProjects(started: Started): TransitiveProjects =
     TransitiveProjects(started.build, projects)
 
@@ -102,12 +27,87 @@ case class Test(
 
   override def runWithServer(started: Started, bloop: BuildServer): Either[BleepException, Unit] =
     DoSourceGen(started, bloop, watchableProjects(started)).flatMap { _ =>
-      val targets = BleepCommandRemote.buildTargets(started.buildPaths, projects)
-      (testSuitesExclude, testSuitesOnly) match {
-        case (None, None) =>
-          runTests(started, bloop, new bsp4j.TestParams(targets))
-        case _ =>
-          runWithFilters(started, bloop, targets)
+      val allTargets = BleepCommandRemote.buildTargets(started.buildPaths, projects)
+
+      val maybeTestParams: Either[BleepException, bsp4j.TestParams] =
+        (testSuitesExclude, testSuitesOnly) match {
+          case (None, None) =>
+            Right(new bsp4j.TestParams(allTargets))
+          case _ =>
+            val allTestSuitesResult: bsp4j.ScalaTestClassesResult =
+              bloop.buildTargetScalaTestClasses(new bsp4j.ScalaTestClassesParams(allTargets)).get()
+
+            Test
+              .testParamsWithFilter(allTestSuitesResult, testSuitesOnly, testSuitesExclude)
+              .toRight(Test.NoTestSuitesFound)
+        }
+
+      maybeTestParams.flatMap { testParams =>
+        bloop.buildTargetTest(testParams).get().getStatusCode match {
+          case bsp4j.StatusCode.OK =>
+            started.logger.info("Tests succeeded")
+            Right(())
+          case errorCode =>
+            Left(new BspCommandFailed("tests", projects, BspCommandFailed.StatusCode(errorCode)))
+        }
       }
     }
+}
+
+object Test {
+  object NoTestSuitesFound extends BleepException(s"No tests found in projects")
+
+  private implicit class MapSyntax[K, V](m: Map[K, List[V]]) {
+    // use this to avoid asking bloop to run tests for projects we know we won't run tests from
+    def keepNonEmpty: Map[K, NonEmptyList[V]] = m.flatMap { case (k, v) => NonEmptyList.fromList(v).map(k -> _) }
+  }
+
+  def testParamsWithFilter(
+      allTestSuitesResult: bsp4j.ScalaTestClassesResult,
+      testSuitesOnly: Option[NonEmptyList[String]],
+      testSuitesExclude: Option[NonEmptyList[String]]
+  ): Option[bsp4j.TestParams] = {
+
+    val allTests: Map[bsp4j.BuildTargetIdentifier, NonEmptyList[String]] =
+      allTestSuitesResult.getItems.asScala
+        .map(x => (x.getTarget, x.getClasses.asScala.toList))
+        .toMap
+        .keepNonEmpty
+
+    val afterTestOnly: Map[bsp4j.BuildTargetIdentifier, NonEmptyList[String]] =
+      testSuitesOnly match {
+        case Some(includes) =>
+          allTests.map { case (target, testSuites) => (target, testSuites.filter(amongSuite(includes))) }.keepNonEmpty
+        case None =>
+          allTests
+      }
+
+    val afterExcludes: Map[bsp4j.BuildTargetIdentifier, NonEmptyList[String]] =
+      testSuitesExclude match {
+        case Some(excludes) =>
+          afterTestOnly.map { case (target, testSuites) => (target, testSuites.filterNot(amongSuite(excludes))) }.keepNonEmpty
+        case None =>
+          afterTestOnly
+      }
+
+    if (afterExcludes.isEmpty) None
+    else {
+      val asBspTestSuites: util.List[ScalaTestSuiteSelection] =
+        afterExcludes.valuesIterator
+          .flatMap(_.iterator)
+          .map(cls => new ScalaTestSuiteSelection(cls, List.empty[String].asJava))
+          .toList
+          .asJava
+      val testParams = new bsp4j.TestParams(afterExcludes.keys.toList.asJava)
+      testParams.setData(new bsp4j.ScalaTestSuites(asBspTestSuites, List.empty[String].asJava, List.empty[String].asJava))
+      testParams.setDataKind(bsp4j.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
+      Some(testParams)
+    }
+  }
+
+  def amongSuite(testSuites: NonEmptyList[String])(testSuite: String): Boolean =
+    testSuites.exists(isSameSuite(testSuite))
+
+  def isSameSuite(one: String)(two: String): Boolean =
+    one.equalsIgnoreCase(two) || one.split('.').last.equalsIgnoreCase(two.split('.').last)
 }

--- a/bleep-model/src/scala/bleep/BleepException.scala
+++ b/bleep-model/src/scala/bleep/BleepException.scala
@@ -20,8 +20,6 @@ abstract class BleepException(
 object BleepException {
   class BuildNotFound(cwd: Path) extends BleepException(s"Couldn't find ${BuildLoader.BuildFileName} in directories in or above $cwd")
 
-  class TestSuitesNotFound(suites: List[String]) extends BleepException(s"None of the given test suites: ${suites.mkString(", ")} were found in the project")
-
   class TargetFolderNotDetermined(projectName: model.CrossProjectName)
       extends BleepException(s"Couldn't determine original output directory of project ${projectName.name}")
 

--- a/bleep-model/src/scala/bleep/BleepException.scala
+++ b/bleep-model/src/scala/bleep/BleepException.scala
@@ -20,6 +20,8 @@ abstract class BleepException(
 object BleepException {
   class BuildNotFound(cwd: Path) extends BleepException(s"Couldn't find ${BuildLoader.BuildFileName} in directories in or above $cwd")
 
+  class TestSuitesNotFound(suites: List[String]) extends BleepException(s"None of the given test suites: ${suites.mkString(", ")} were found in the project")
+
   class TargetFolderNotDetermined(projectName: model.CrossProjectName)
       extends BleepException(s"Couldn't determine original output directory of project ${projectName.name}")
 


### PR DESCRIPTION
So this is a very crude implementation that should work once https://github.com/scalacenter/bloop/pull/2360 is merged and bleep uses mainline bloop. 

However the cli interface is not great as it will look like bleep test project -o TestSuiteOne -o TestSuiteTwo ... and so on. I don't think it's possible to combine Option and arguments in decline? So I'm guessing here we have to use arguments and just do some parsing to make it look nice?

Update:

It is now possible to specify which test suites to run using the -o or
--only syntax.

The tests can be specified using the class name of the test suite or by
using the fully qualified name.

Example:
bleep test app-tests -o TestSuiteOne --only TestSuiteTwo
fully qualified:
bleep test app-tests -o com.foo.TestSuiteThree

