### PR TITLE
HOTFIX - Fix to logic in schema valiation

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -291,27 +291,16 @@
       "dependencies": {
         "jsSplitStyle": ["jsKind"]
       },
-      "anyOf": [
-        {
-          "if": {
-            "properties": {
-              "name": { "const": "js" },
-              "jsKind": { "const": "esmodule" }
-            },
-            "required": ["name", "jsKind"]
-          },
-          "then": {
-            "required": ["jsSplitStyle"]
-          }
+      "if": {
+        "properties": {
+          "name": { "const": "js" },
+          "jsKind": { "const": "esmodule" }
         },
-        {
-          "not": {
-            "properties": {
-              "name": { "const": "js" }
-            }
-          }
-        }
-      ]
+        "required": ["name", "jsKind"]
+      },
+      "then": {
+        "required": ["jsSplitStyle"]
+      }
     },
     "CompileSetup": {
       "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -285,12 +285,28 @@
       "dependencies": {
         "jsSplitStyle": ["jsKind"]
       },
-      "allOf": [{
-        "if": {
-          "properties": { "jsKind": { "const": "esmodule" } }
-        },
-        "then": { "required": ["jsSplitStyle"] }
-      }]
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "platform": {
+                "properties": {
+                  "name": { "const": "js" },
+                  "jsKind": { "const": "esmodule" }
+                },
+                "required": ["name", "jsKind"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "platform": {
+                "required": ["jsSplitStyle"]
+              }
+            }
+          }
+        }
+      ]
     },
     "CompileSetup": {
       "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -245,13 +245,13 @@
               "items": {
                 "type": "string"
               }
-            }
-          },
-          "required": ["splitStyle"],
-          "if": {
-            "properties": { "splitStyle": { "const": "SmallModulesFor" } }
-          },
-          "then": { "required": ["packages"] }
+            },
+            "required": ["splitStyle"],
+            "if": {
+              "properties": { "splitStyle": { "const": "SmallModulesFor" } }
+            },
+            "then": { "required": ["packages"] }
+          }
         },
         "jsEmitSourceMaps": {
           "type": "boolean"
@@ -289,21 +289,13 @@
         {
           "if": {
             "properties": {
-              "platform": {
-                "properties": {
-                  "name": { "const": "js" },
-                  "jsKind": { "const": "esmodule" }
-                },
-                "required": ["name", "jsKind"]
-              }
-            }
+              "name": { "const": "js" },
+              "jsKind": { "const": "esmodule" }
+            },
+            "required": ["name", "jsKind"]
           },
           "then": {
-            "properties": {
-              "platform": {
-                "required": ["jsSplitStyle"]
-              }
-            }
+            "required": ["jsSplitStyle"]
           }
         }
       ]

--- a/schema.json
+++ b/schema.json
@@ -245,13 +245,19 @@
               "items": {
                 "type": "string"
               }
-            },
-            "required": ["splitStyle"],
-            "if": {
-              "properties": { "splitStyle": { "const": "SmallModulesFor" } }
-            },
-            "then": { "required": ["packages"] }
-          }
+            }
+          },
+          "required": ["splitStyle"],
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "splitStyle": { "const": "SmallModulesFor" }
+                }
+              },
+              "then": { "required": ["packages"] }
+            }
+          ]
         },
         "jsEmitSourceMaps": {
           "type": "boolean"

--- a/schema.json
+++ b/schema.json
@@ -285,7 +285,7 @@
       "dependencies": {
         "jsSplitStyle": ["jsKind"]
       },
-      "allOf": [
+      "anyOf": [
         {
           "if": {
             "properties": {
@@ -296,6 +296,13 @@
           },
           "then": {
             "required": ["jsSplitStyle"]
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "name": { "const": "js" }
+            }
           }
         }
       ]


### PR DESCRIPTION
Last commit introduced a slight bug where it would complain about missing jsSplitStyle even when it should not be set. e.g it would complain for
platform:
  name: jvm
  