### PR TITLE
bugfix: fix missing generation of bloop config modulesplitstyle

### DIFF
--- a/bleep-core/src/scala/bleep/GenBloopFiles.scala
+++ b/bleep-core/src/scala/bleep/GenBloopFiles.scala
@@ -217,7 +217,8 @@ object GenBloopFiles {
               jsdom = platform.jsJsdom,
               output = None,
               nodePath = platform.jsNodeVersion.map(pre.fetchNode.apply),
-              toolchain = Nil
+              toolchain = Nil,
+              moduleSplitStyle = platform.jsSplitStyle.map(conversions.moduleSplitStyleJS.from)
             ),
             platform.mainClass
           )


### PR DESCRIPTION
Tested on a JS project, setting the different split styles now works. 