### PR TITLE
Add support for scalafix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Temporarily save package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ matrix.artifact_name }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -48,3 +48,6 @@
     url = git@github.com:bleep-build/librarymanagement.git
     branch = develop
     update = merge
+[submodule "liberated/mill-scalafix"]
+	path = liberated/mill-scalafix
+	url = git@github.com:bleep-build/mill-scalafix.git

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,7 @@
+rules = [OrganizeImports]
+
+OrganizeImports {
+    preset = INTELLIJ_2020_3
+    removeUnused = false
+    targetDialect = Scala3
+}

--- a/bleep-cli/src/scala/bleep/commands/BuildNormalize.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildNormalize.scala
@@ -7,7 +7,7 @@ import bleep.rewrites.normalizeBuild
 object BuildNormalize extends BleepBuildCommand {
   override def run(started: Started): Either[BleepException, Unit] = {
     val build = started.build.requireFileBacked(ctx = "command normalize")
-    val build1 = normalizeBuild(build)
+    val build1 = normalizeBuild(build, started.buildPaths)
     Right(writeYamlLogged(started.logger, "Wrote update build", build1.file, started.buildPaths.bleepYamlFile))
   }
 }

--- a/bleep-cli/src/scala/bleep/commands/BuildReapplyTemplates.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildReapplyTemplates.scala
@@ -8,9 +8,9 @@ import bleep.templates.templatesReapply
 object BuildReapplyTemplates extends BleepBuildCommand {
   override def run(started: Started): Either[BleepException, Unit] = {
     val build = started.build.requireFileBacked(ctx = "command templates-reapply")
-    val build1 = normalizeBuild(build)
+    val build1 = normalizeBuild(build, started.buildPaths)
     val build2 = templatesReapply(build1)
-    val build3 = normalizeBuild(build2)
+    val build3 = normalizeBuild(build2, started.buildPaths)
     Right(writeYamlLogged(started.logger, "Wrote update build", build3.file, started.buildPaths.bleepYamlFile))
   }
 }

--- a/bleep-cli/src/scala/bleep/commands/BuildReinferTemplates.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildReinferTemplates.scala
@@ -11,7 +11,7 @@ case class BuildReinferTemplates(ignoreWhenInferringTemplates: Set[model.Project
     val build0 = started.build.requireFileBacked(ctx = "command templates-generate-new")
 
     // normalize to make results of template inference better. drop existing file/template structure
-    val normalizedBuild = normalizeBuild(build0.dropBuildFile.dropTemplates)
+    val normalizedBuild = normalizeBuild(build0.dropBuildFile.dropTemplates, started.buildPaths)
 
     val newBuildFile = templatesInfer(
       logger = new BleepTemplateLogger(started.logger),
@@ -21,7 +21,7 @@ case class BuildReinferTemplates(ignoreWhenInferringTemplates: Set[model.Project
 
     // fail if we have done illegal rewrites during templating
     model.Build.diffProjects(
-      before = Defaults.add(normalizedBuild),
+      before = Defaults.add(normalizedBuild, started.buildPaths),
       after = model.Build.FileBacked(newBuildFile).dropBuildFile.dropTemplates
     ) match {
       case empty if empty.isEmpty => ()

--- a/bleep-cli/src/scala/bleep/commands/BuildUpdateDeps.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildUpdateDeps.scala
@@ -38,8 +38,8 @@ case object BuildUpdateDeps extends BleepBuildCommand {
         else Some(tuple -> bleepDep.withVersion(latest))
       }
 
-    val newBuild = UpgradeDependencies(new UpgradeLogger(started.logger), upgrades)(build)
-    val newBuild1 = normalizeBuild(newBuild)
+    val newBuild = UpgradeDependencies(new UpgradeLogger(started.logger), upgrades)(build, started.buildPaths)
+    val newBuild1 = normalizeBuild(newBuild, started.buildPaths)
     Right(writeYamlLogged(started.logger, "Wrote update build", newBuild1.file, started.buildPaths.bleepYamlFile))
   }
 

--- a/bleep-cli/src/scala/bleep/sbtimport/buildFromBloopFiles.scala
+++ b/bleep-cli/src/scala/bleep/sbtimport/buildFromBloopFiles.scala
@@ -5,7 +5,7 @@ import bleep.internal.conversions
 import bleep.logging.Logger
 import bleep.nosbt.librarymanagement
 import bloop.config.Config
-import coursier.core.{Classifier, Configuration, Extension, Module, ModuleName, Organization, Publication, Type}
+import coursier.core.*
 import org.typelevel.sbt.tpolecat.{DevMode, TpolecatPlugin}
 
 import java.net.URI

--- a/bleep-cli/src/scala/bleep/sbtimport/generateBuild.scala
+++ b/bleep-cli/src/scala/bleep/sbtimport/generateBuild.scala
@@ -21,7 +21,7 @@ object generateBuild {
   ): Map[Path, String] = {
 
     val build0 = buildFromBloopFiles(logger, sbtBuildDir, destinationPaths, inputData, bleepVersion)
-    val normalizedBuild = normalizeBuild(build0)
+    val normalizedBuild = normalizeBuild(build0, destinationPaths)
 
     val buildFile = templatesInfer(new BleepTemplateLogger(logger), normalizedBuild, options.ignoreWhenInferringTemplates)
 
@@ -32,7 +32,7 @@ object generateBuild {
       }
 
     // complain if we have done illegal rewrites during templating
-    model.Build.diffProjects(Defaults.add(normalizedBuild), model.Build.FileBacked(buildFile1).dropBuildFile.dropTemplates) match {
+    model.Build.diffProjects(Defaults.add(normalizedBuild, destinationPaths), model.Build.FileBacked(buildFile1).dropBuildFile.dropTemplates) match {
       case empty if empty.isEmpty => ()
       case diffs =>
         logger.error("Project templating did illegal rewrites. Please report this as a bug")

--- a/bleep-core/src/scala/bleep/BleepConfigOps.scala
+++ b/bleep-core/src/scala/bleep/BleepConfigOps.scala
@@ -1,6 +1,6 @@
 package bleep
 
-import bleep.internal.{writeYamlLogged, FileUtils}
+import bleep.internal.{FileUtils, writeYamlLogged}
 import bleep.logging.Logger
 
 import java.nio.file.Files

--- a/bleep-core/src/scala/bleep/BleepConfigOps.scala
+++ b/bleep-core/src/scala/bleep/BleepConfigOps.scala
@@ -1,6 +1,6 @@
 package bleep
 
-import bleep.internal.{FileUtils, writeYamlLogged}
+import bleep.internal.{writeYamlLogged, FileUtils}
 import bleep.logging.Logger
 
 import java.nio.file.Files

--- a/bleep-core/src/scala/bleep/GenBloopFiles.scala
+++ b/bleep-core/src/scala/bleep/GenBloopFiles.scala
@@ -3,7 +3,7 @@ package bleep
 import bleep.internal.{conversions, rewriteDependentData}
 import bleep.rewrites.Defaults
 import bloop.config.{Config, ConfigCodecs}
-import com.github.plokhotnyuk.jsoniter_scala.core.{writeToString, WriterConfig}
+import com.github.plokhotnyuk.jsoniter_scala.core.{WriterConfig, writeToString}
 import coursier.Classifier
 import coursier.core.{Configuration, Extension}
 import org.typelevel.sbt.tpolecat.{DevMode, TpolecatPlugin}

--- a/bleep-core/src/scala/bleep/GenBloopFiles.scala
+++ b/bleep-core/src/scala/bleep/GenBloopFiles.scala
@@ -3,7 +3,7 @@ package bleep
 import bleep.internal.{conversions, rewriteDependentData}
 import bleep.rewrites.Defaults
 import bloop.config.{Config, ConfigCodecs}
-import com.github.plokhotnyuk.jsoniter_scala.core.{WriterConfig, writeToString}
+import com.github.plokhotnyuk.jsoniter_scala.core.{writeToString, WriterConfig}
 import coursier.Classifier
 import coursier.core.{Configuration, Extension}
 import org.typelevel.sbt.tpolecat.{DevMode, TpolecatPlugin}

--- a/bleep-core/src/scala/bleep/bootstrap.scala
+++ b/bleep-core/src/scala/bleep/bootstrap.scala
@@ -1,6 +1,6 @@
 package bleep
 
-import bleep.internal.{FileUtils, bleepLoggers, fatal}
+import bleep.internal.{bleepLoggers, fatal, FileUtils}
 import bleep.rewrites.BuildRewrite
 
 import scala.concurrent.ExecutionContext

--- a/bleep-core/src/scala/bleep/bootstrap.scala
+++ b/bleep-core/src/scala/bleep/bootstrap.scala
@@ -1,6 +1,6 @@
 package bleep
 
-import bleep.internal.{bleepLoggers, fatal, FileUtils}
+import bleep.internal.{FileUtils, bleepLoggers, fatal}
 import bleep.rewrites.BuildRewrite
 
 import scala.concurrent.ExecutionContext
@@ -53,7 +53,7 @@ object bootstrap {
       try
         pre.existingBuild.buildFile.forceGet.map { buildFile =>
           val resolver = resolverFactory(pre, config, buildFile)
-          val build = rewrites.foldLeft[model.Build](model.Build.FileBacked(buildFile)) { case (b, rewrite) => rewrite(b) }
+          val build = rewrites.foldLeft[model.Build](model.Build.FileBacked(buildFile)) { case (b, rewrite) => rewrite(b, pre.buildPaths) }
           val bleepExecutable = Lazy(BleepExecutable.getCommand(resolver, pre, forceJvm = false))
 
           val activeProjects: Option[Array[model.CrossProjectName]] =

--- a/bleep-core/src/scala/bleep/bsp/BspProjectSelection.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspProjectSelection.scala
@@ -1,7 +1,7 @@
 package bleep
 package bsp
 
-import bleep.internal.{FileUtils, writeYamlLogged}
+import bleep.internal.{writeYamlLogged, FileUtils}
 import bleep.logging.Logger
 
 import java.nio.file.Files

--- a/bleep-core/src/scala/bleep/bsp/BspProjectSelection.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspProjectSelection.scala
@@ -1,7 +1,7 @@
 package bleep
 package bsp
 
-import bleep.internal.{writeYamlLogged, FileUtils}
+import bleep.internal.{FileUtils, writeYamlLogged}
 import bleep.logging.Logger
 
 import java.nio.file.Files

--- a/bleep-core/src/scala/bleep/bsp/BuildChangeTracker.scala
+++ b/bleep-core/src/scala/bleep/bsp/BuildChangeTracker.scala
@@ -1,7 +1,7 @@
 package bleep
 package bsp
 
-import bleep.rewrites.{keepSelectedProjects, BuildRewrite}
+import bleep.rewrites.{BuildRewrite, keepSelectedProjects}
 import bloop.config.Config
 import ch.epfl.scala.bsp4j
 

--- a/bleep-core/src/scala/bleep/bsp/BuildChangeTracker.scala
+++ b/bleep-core/src/scala/bleep/bsp/BuildChangeTracker.scala
@@ -1,7 +1,7 @@
 package bleep
 package bsp
 
-import bleep.rewrites.{BuildRewrite, keepSelectedProjects}
+import bleep.rewrites.{keepSelectedProjects, BuildRewrite}
 import bloop.config.Config
 import ch.epfl.scala.bsp4j
 

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -2,7 +2,7 @@ package bleep
 package commands
 
 import bleep.bsp.BspCommandFailed
-import bleep.internal.{bleepLoggers, jvmRunCommand, DoSourceGen, Throwables, TransitiveProjects}
+import bleep.internal.{DoSourceGen, Throwables, TransitiveProjects, bleepLoggers, jvmRunCommand}
 import bloop.rifle.BuildServer
 import ch.epfl.scala.bsp4j
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -2,7 +2,7 @@ package bleep
 package commands
 
 import bleep.bsp.BspCommandFailed
-import bleep.internal.{DoSourceGen, Throwables, TransitiveProjects, bleepLoggers, jvmRunCommand}
+import bleep.internal.{bleepLoggers, jvmRunCommand, DoSourceGen, Throwables, TransitiveProjects}
 import bloop.rifle.BuildServer
 import ch.epfl.scala.bsp4j
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException

--- a/bleep-core/src/scala/bleep/commands/Script.scala
+++ b/bleep-core/src/scala/bleep/commands/Script.scala
@@ -1,7 +1,7 @@
 package bleep
 package commands
 
-import bleep.internal.{traverseish, TransitiveProjects}
+import bleep.internal.{TransitiveProjects, traverseish}
 import bloop.rifle.BuildServer
 
 case class Script(name: model.ScriptName, args: List[String], watch: Boolean) extends BleepCommandRemote(watch) {

--- a/bleep-core/src/scala/bleep/commands/Script.scala
+++ b/bleep-core/src/scala/bleep/commands/Script.scala
@@ -1,7 +1,7 @@
 package bleep
 package commands
 
-import bleep.internal.{TransitiveProjects, traverseish}
+import bleep.internal.{traverseish, TransitiveProjects}
 import bloop.rifle.BuildServer
 
 case class Script(name: model.ScriptName, args: List[String], watch: Boolean) extends BleepCommandRemote(watch) {

--- a/bleep-core/src/scala/bleep/commands/SetupDevScript.scala
+++ b/bleep-core/src/scala/bleep/commands/SetupDevScript.scala
@@ -1,7 +1,7 @@
 package bleep
 package commands
 
-import bleep.internal.{jvmRunCommand, FileUtils}
+import bleep.internal.{FileUtils, jvmRunCommand}
 
 class SetupDevScript(started: Started, project: model.CrossProjectName, overrideMainClass: Option[String]) extends BleepCommand {
   override def run(): Either[BleepException, Unit] =

--- a/bleep-core/src/scala/bleep/commands/SetupDevScript.scala
+++ b/bleep-core/src/scala/bleep/commands/SetupDevScript.scala
@@ -1,7 +1,7 @@
 package bleep
 package commands
 
-import bleep.internal.{FileUtils, jvmRunCommand}
+import bleep.internal.{jvmRunCommand, FileUtils}
 
 class SetupDevScript(started: Started, project: model.CrossProjectName, overrideMainClass: Option[String]) extends BleepCommand {
   override def run(): Either[BleepException, Unit] =

--- a/bleep-core/src/scala/bleep/commands/SourceGen.scala
+++ b/bleep-core/src/scala/bleep/commands/SourceGen.scala
@@ -1,7 +1,7 @@
 package bleep
 package commands
 
-import bleep.internal.{TransitiveProjects, traverseish}
+import bleep.internal.{traverseish, TransitiveProjects}
 import bloop.rifle.BuildServer
 
 case class SourceGen(watch: Boolean, projectNames: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) {

--- a/bleep-core/src/scala/bleep/commands/SourceGen.scala
+++ b/bleep-core/src/scala/bleep/commands/SourceGen.scala
@@ -1,7 +1,7 @@
 package bleep
 package commands
 
-import bleep.internal.{traverseish, TransitiveProjects}
+import bleep.internal.{TransitiveProjects, traverseish}
 import bloop.rifle.BuildServer
 
 case class SourceGen(watch: Boolean, projectNames: Array[model.CrossProjectName]) extends BleepCommandRemote(watch) {

--- a/bleep-core/src/scala/bleep/depcheck/SbtUpdateReport.scala
+++ b/bleep-core/src/scala/bleep/depcheck/SbtUpdateReport.scala
@@ -3,7 +3,7 @@ package bleep.depcheck
 import bleep.logging.Logger
 import bleep.nosbt.librarymanagement
 import coursier.cache.CacheUrl
-import coursier.core.{Classifier, Configuration, Extension, MinimizedExclusions, Publication, Type}
+import coursier.core.*
 import coursier.maven.MavenAttributes
 import coursier.util.Artifact
 import coursier.{Attributes, Dependency, Module, Project, Resolution}

--- a/bleep-model/src/scala/bleep/rewrites/BuildRewrite.scala
+++ b/bleep-model/src/scala/bleep/rewrites/BuildRewrite.scala
@@ -13,21 +13,21 @@ import scala.collection.immutable
 trait BuildRewrite {
   val name: model.BuildRewriteName
 
-  protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project]
+  protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project]
 
-  final def apply(oldBuild: model.Build): model.Build =
+  final def apply(oldBuild: model.Build, buildPaths: BuildPaths): model.Build =
     oldBuild match {
-      case oldBuild: model.Build.Exploded   => apply(oldBuild)
-      case oldBuild: model.Build.FileBacked => apply(oldBuild)
+      case oldBuild: model.Build.Exploded   => apply(oldBuild, buildPaths)
+      case oldBuild: model.Build.FileBacked => apply(oldBuild, buildPaths)
     }
 
-  final def apply(oldBuild: model.Build.Exploded): model.Build.Exploded = {
-    val newProjects = newExplodedProjects(oldBuild)
+  final def apply(oldBuild: model.Build.Exploded, buildPaths: BuildPaths): model.Build.Exploded = {
+    val newProjects = newExplodedProjects(oldBuild, buildPaths)
     oldBuild.copy(explodedProjects = newProjects)
   }
 
-  final def apply(oldBuild: model.Build.FileBacked): model.Build.FileBacked = {
-    val newProjects = newExplodedProjects(oldBuild)
+  final def apply(oldBuild: model.Build.FileBacked, buildPaths: BuildPaths): model.Build.FileBacked = {
+    val newProjects = newExplodedProjects(oldBuild, buildPaths)
     BuildRewrite.withProjects(oldBuild, newProjects)
   }
 }

--- a/bleep-model/src/scala/bleep/rewrites/Defaults.scala
+++ b/bleep-model/src/scala/bleep/rewrites/Defaults.scala
@@ -33,7 +33,7 @@ object Defaults {
   object remove extends BuildRewrite {
     override val name = model.BuildRewriteName("defaults-remove")
 
-    protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] =
+    protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] =
       oldBuild.explodedProjects.map { case (name, p) => (name, project(p)) }
 
     def project(proj: model.Project): model.Project =
@@ -50,7 +50,7 @@ object Defaults {
   object add extends BuildRewrite {
     override val name = model.BuildRewriteName("defaults-add")
 
-    protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] =
+    protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] =
       oldBuild.explodedProjects.map { case (name, p) => (name, project(p)) }
 
     def project(proj: model.Project): model.Project =

--- a/bleep-model/src/scala/bleep/rewrites/UpgradeDependencies.scala
+++ b/bleep-model/src/scala/bleep/rewrites/UpgradeDependencies.scala
@@ -6,7 +6,7 @@ import bleep.rewrites.UpgradeDependencies.{ContextualDep, UpgradeLogger}
 case class UpgradeDependencies(logger: UpgradeLogger, upgrades: Map[ContextualDep, model.Dep]) extends BuildRewrite {
   override val name = model.BuildRewriteName("upgrade-dependencies")
 
-  override protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] = {
+  override protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] = {
     val newProjects = oldBuild.explodedProjects.map { case (crossName, p) =>
       val versionCombo = model.VersionCombo.fromExplodedProject(p).orThrowTextWithContext(crossName)
       val newDeps = p.dependencies.map { dep =>

--- a/bleep-model/src/scala/bleep/rewrites/deduplicateDependencies.scala
+++ b/bleep-model/src/scala/bleep/rewrites/deduplicateDependencies.scala
@@ -8,7 +8,7 @@ import coursier.core.Configuration
 object deduplicateDependencies extends BuildRewrite {
   override val name = model.BuildRewriteName("deduplicate-dependencies")
 
-  protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] =
+  protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] =
     rewriteDependentData(oldBuild.explodedProjects).eager[model.Project] { (projectName, p, eval) =>
       val shortenedDeps: Map[model.CrossProjectName, model.Project] =
         oldBuild.transitiveDependenciesFor(projectName).map { case (pn, _) => (pn, eval(pn).forceGet(pn.value)) }

--- a/bleep-model/src/scala/bleep/rewrites/keepSelectedProjects.scala
+++ b/bleep-model/src/scala/bleep/rewrites/keepSelectedProjects.scala
@@ -6,7 +6,7 @@ import bleep.internal.TransitiveProjects
 case class keepSelectedProjects(selectedProjectGlobs: List[String]) extends BuildRewrite {
   override val name = model.BuildRewriteName("keep-selected-projects")
 
-  protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] = {
+  protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] = {
     val globs = new model.ProjectGlobs(None, oldBuild.explodedProjects)
     val selectedProjectNames = selectedProjectGlobs.toArray.flatMap(str => globs.projectNameMap.getOrElse(str, Array.empty[model.CrossProjectName]))
     val withTransitive = TransitiveProjects(oldBuild, selectedProjectNames).all.toSet

--- a/bleep-model/src/scala/bleep/rewrites/normalizeBuild.scala
+++ b/bleep-model/src/scala/bleep/rewrites/normalizeBuild.scala
@@ -13,6 +13,6 @@ object normalizeBuild extends BuildRewrite {
       deduplicateDependencies
     )
 
-  protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] =
-    Pipeline.foldLeft(oldBuild.dropBuildFile)((acc, f) => f(acc)).explodedProjects
+  protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] =
+    Pipeline.foldLeft(oldBuild.dropBuildFile)((acc, f) => f(acc, buildPaths)).explodedProjects
 }

--- a/bleep-model/src/scala/bleep/rewrites/semanticDb.scala
+++ b/bleep-model/src/scala/bleep/rewrites/semanticDb.scala
@@ -1,17 +1,26 @@
 package bleep
 package rewrites
 
-case class semanticDb(buildPaths: BuildPaths) extends BuildRewrite {
+/** Adds SemanticDB support to a build
+  *
+  * @param semanticDbVersion
+  *   the version for `org.scalameta:::semanticdb-scalac`
+  */
+class semanticDb(semanticDbVersion: String = "4.9.9") extends BuildRewrite {
   override val name = model.BuildRewriteName("semanticdb")
 
-  protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] =
-    oldBuild.explodedProjects.map { case (name, p) => (name, apply(name, p)) }
+  protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] =
+    oldBuild.explodedProjects.map { case (name, p) => (name, apply(name, p, buildPaths)) }
 
-  def apply(name: model.CrossProjectName, explodedProject: model.Project): model.Project =
+  def apply(name: model.CrossProjectName, explodedProject: model.Project, buildPaths: BuildPaths): model.Project =
     explodedProject.scala match {
       case Some(s @ model.Scala(Some(version), _, _, _, _)) =>
         val projectPaths = buildPaths.project(name, explodedProject)
-        val addedScalacOptions = List(Some(compilerOption(version)), targetRootOptions(version, projectPaths), sourceRootOptions(version)).flatten
+        val addedScalacOptions = List(
+          Some(compilerOption(version)),
+          targetRootOptions(version, projectPaths),
+          Some(sourceRootOptions(version, buildPaths))
+        ).flatten
         val compilerPlugins =
           compilerPlugin(version) match {
             case Some(compilerPlugin) => model.JsonSet(s.compilerPlugins.values + compilerPlugin)
@@ -25,7 +34,7 @@ case class semanticDb(buildPaths: BuildPaths) extends BuildRewrite {
 
   def compilerPlugin(version: model.VersionScala): Option[model.Dep.ScalaDependency] =
     if (version.is3) None
-    else Some(model.Dep.ScalaFullVersion("org.scalameta", "semanticdb-scalac", "4.5.0"))
+    else Some(model.Dep.ScalaFullVersion("org.scalameta", "semanticdb-scalac", semanticDbVersion))
 
   def compilerOption(version: model.VersionScala): model.Options.Opt = {
     val sv = version.scalaVersion
@@ -38,15 +47,13 @@ case class semanticDb(buildPaths: BuildPaths) extends BuildRewrite {
 
   def targetRootOptions(version: model.VersionScala, projectPaths: ProjectPaths): Option[model.Options.Opt] =
     if (version.is3) {
-      // this is copied from sbt, but wrong. semanticdbTarget ends up as empty string,
-      // and the .semanticdb files ends up in the source folders.
-      // the right thing seems to happen without the flag set at all, so that's where we'll leave it.
-      // Some(Options.Opt.WithArgs("-semanticdb-target", List(projectPaths.classes.toString)))
-      None
+      Some(model.Options.Opt.WithArgs("-semanticdb-target", List(projectPaths.classes.toString)))
     } else
       Some(model.Options.Opt.Flag(s"-P:semanticdb:targetroot:${projectPaths.classes}"))
 
-  def sourceRootOptions(version: model.VersionScala): Option[model.Options.Opt] =
-    if (version.is3) { None }
-    else Some(model.Options.Opt.Flag(s"-P:semanticdb:sourceroot:${buildPaths.buildDir}"))
+  def sourceRootOptions(version: model.VersionScala, buildPaths: BuildPaths): model.Options.Opt =
+    if (version.is3)
+      model.Options.Opt.WithArgs(s"-sourceroot", List(buildPaths.buildDir.toString))
+    else
+      model.Options.Opt.Flag(s"-P:semanticdb:sourceroot:${buildPaths.buildDir}")
 }

--- a/bleep-model/src/scala/bleep/rewrites/unifyDeps.scala
+++ b/bleep-model/src/scala/bleep/rewrites/unifyDeps.scala
@@ -26,7 +26,7 @@ object unifyDeps extends BuildRewrite {
 
   val OnlyJvm = Set(model.PlatformId.Jvm)
 
-  protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] = {
+  protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] = {
     val replacements: Map[model.Dep, model.Dep] =
       findReplacements(oldBuild.explodedProjects.flatMap(_._2.dependencies.values))
 

--- a/bleep-nosbt/src/scala/bleep/nosbt/io/IO.scala
+++ b/bleep-nosbt/src/scala/bleep/nosbt/io/IO.scala
@@ -1,6 +1,6 @@
 package bleep.nosbt.io
 
-import bleep.nosbt.Using.{fileInputStream, OpenFile}
+import bleep.nosbt.Using.{OpenFile, fileInputStream}
 
 import java.io.{BufferedOutputStream, File, FileOutputStream, IOException}
 import java.util.Properties

--- a/bleep-nosbt/src/scala/bleep/nosbt/io/IO.scala
+++ b/bleep-nosbt/src/scala/bleep/nosbt/io/IO.scala
@@ -1,6 +1,6 @@
 package bleep.nosbt.io
 
-import bleep.nosbt.Using.{OpenFile, fileInputStream}
+import bleep.nosbt.Using.{fileInputStream, OpenFile}
 
 import java.io.{BufferedOutputStream, File, FileOutputStream, IOException}
 import java.util.Properties

--- a/bleep-tests/src/scala/bleep/CreateNewSnapshotTests.scala
+++ b/bleep-tests/src/scala/bleep/CreateNewSnapshotTests.scala
@@ -2,7 +2,6 @@ package bleep
 
 import bleep.commands.BuildCreateNew
 import bleep.internal.FileUtils
-
 import bleep.testing.SnapshotTest
 import cats.data.NonEmptyList
 

--- a/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
@@ -1,7 +1,6 @@
 package bleep
 
 import bleep.internal.FileUtils
-
 import bleep.testing.SnapshotTest
 import bloop.config.Config
 import io.circe.parser.decode

--- a/bleep-tests/src/scala/bleep/IntegrationTests.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationTests.scala
@@ -3,7 +3,6 @@ package bleep
 import bleep.internal.FileUtils
 import bleep.logging.TypedLogger.Stored
 import bleep.logging.{LogLevel, Loggers, TypedLogger}
-
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.Assertion
 import org.scalatest.funsuite.AnyFunSuite

--- a/bleep-tests/src/scala/bleep/RewriteSnapshotTest.scala
+++ b/bleep-tests/src/scala/bleep/RewriteSnapshotTest.scala
@@ -14,7 +14,7 @@ class RewriteSnapshotTest extends SnapshotTest {
   object DropFeatureFlag extends BuildRewrite {
     override val name = model.BuildRewriteName("drop-feature-flag")
 
-    override protected def newExplodedProjects(oldBuild: model.Build): Map[model.CrossProjectName, model.Project] =
+    override protected def newExplodedProjects(oldBuild: model.Build, buildPaths: BuildPaths): Map[model.CrossProjectName, model.Project] =
       oldBuild.explodedProjects.map { case (name, p) =>
         val newP = p.copy(scala = p.scala.map { s =>
           s.copy(options = s.options.copy(values = s.options.values - model.Options.Opt.Flag("-feature")))
@@ -45,7 +45,7 @@ class RewriteSnapshotTest extends SnapshotTest {
     test(testName) {
       val logger = logger0.withPath(testName)
       val build = model.Build.FileBacked(existingBuild.buildFile.forceGet.orThrow)
-      val rewritten = rewrite(build)
+      val rewritten = rewrite(build, null)
       val destinationPath = outFolder / rewrite.name.value / buildName / s"bleep.yaml"
       val rewrittenYamlString = yaml.encodeShortened(rewritten.file)
       writeAndCompare(destinationPath, Map(destinationPath -> rewrittenYamlString), logger)

--- a/bleep-tests/src/scala/bleep/TemplateTest.scala
+++ b/bleep-tests/src/scala/bleep/TemplateTest.scala
@@ -1,7 +1,6 @@
 package bleep
 
 import bleep.internal.{BleepTemplateLogger, ShortenAndSortJson}
-
 import bleep.rewrites.Defaults
 import bleep.templates.{templatesInfer, TemplateDef}
 import bleep.testing.SnapshotTest
@@ -91,7 +90,7 @@ class TemplateTest extends SnapshotTest {
 
     // complain if we have done illegal rewrites during templating
     val post = model.Build.FileBacked(buildFile).dropBuildFile.dropTemplates
-    model.Build.diffProjects(Defaults.add(pre), post) match {
+    model.Build.diffProjects(Defaults.add(pre, null), post) match {
       case empty if empty.isEmpty => ()
       case diffs =>
         diffs.foreach { case (projectName, msg) => System.err.println(s"$projectName: $msg") }

--- a/bleep-tests/src/scala/bleep/model/JsonTest.scala
+++ b/bleep-tests/src/scala/bleep/model/JsonTest.scala
@@ -1,10 +1,10 @@
 package bleep
 package model
 
+import io.circe.syntax.*
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.Assertion
 import org.scalatest.funsuite.AnyFunSuite
-import io.circe.syntax.*
 
 class JsonTest extends AnyFunSuite with TripleEqualsSupport {
   def roundtrip(vc: VersionCombo): Assertion = {

--- a/bleep-tests/src/scala/bleep/testing/SnapshotTest.scala
+++ b/bleep-tests/src/scala/bleep/testing/SnapshotTest.scala
@@ -2,7 +2,6 @@ package bleep
 package testing
 
 import bleep.logging.{LogLevel, Logger, Loggers}
-
 import coursier.paths.CoursierPaths
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.Assertion

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 0.0.6
+$version: 0.0.7
 jvm:
   name: graalvm-community:21.0.2
 projects:
@@ -31,9 +31,6 @@ projects:
     - bleep-nosbt
     extends: template-cross-all
     sources: ../liberated/sbt-tpolecat/plugin/src/main/scala
-  bleep-libdaemon-jvm:
-    extends: template-cross-all
-    sources: ../liberated/libdaemon-jvm/library/src
   bleep-model:
     dependencies:
     - io.circe::circe-core:0.14.4
@@ -114,6 +111,11 @@ projects:
     sources:
     - ../liberated/sbt-pgp/gpg-library/src/main/scala
     - ../liberated/sbt-pgp/sbt-pgp/src/main/scala
+  bleep-plugin-scalafix:
+    dependencies: ch.epfl.scala:scalafix-interfaces:0.12.1
+    dependsOn: bleep-core
+    extends: template-cross-all
+    sources: ../liberated/mill-scalafix/mill-scalafix/src
   bleep-plugin-sonatype:
     dependencies:
     - com.lumidion::sonatype-central-client-sttp-core:0.3.0
@@ -139,6 +141,7 @@ projects:
     - bleep-plugin-ci-release
     - bleep-plugin-mdoc
     - bleep-plugin-native-image
+    - bleep-plugin-scalafix
     extends:
     - template-common
     - template-scala-3
@@ -165,6 +168,9 @@ scripts:
     project: scripts
   publish:
     main: bleep.scripts.Publish
+    project: scripts
+  scalafix:
+    main: bleep.scripts.Scalafix
     project: scripts
 templates:
   template-common:

--- a/scripts/src/scala/bleep/scripts/Scalafix.scala
+++ b/scripts/src/scala/bleep/scripts/Scalafix.scala
@@ -1,0 +1,25 @@
+package bleep
+package scripts
+
+import bleep.plugin.scalafix.ScalafixPlugin
+import bleep.rewrites.semanticDb
+
+object Scalafix extends BleepScript("Scalafix") {
+  override val rewrites = List(new semanticDb)
+
+  def run(started: Started, commands: Commands, args: List[String]): Unit = {
+    val projects = started.globs.projectNameMap.get("jvm3").toList.flatten
+
+    commands.compile(projects)
+
+    new ScalafixPlugin(
+      started,
+      scalafixIvyDeps = List(
+//        model.Dep.Scala("com.github.xuwei-k", "scalafix-rules", "0.3.0")
+      )
+    ).fix(
+      projects = projects,
+      args = args
+    )
+  }
+}


### PR DESCRIPTION
- liberated `mill-scalafix`
- fix `semanticDb` build rewrite for scala 3, and make `semanticDbVersion` configurable (it was wayy outdated)
- needed `BuildRewrite` to get `BuildPaths` as a parameter to avoid a circular dependency (`BuildRewrite`s are used to calculate `BuildVariant`, which is part of `BuildPaths`)
- Add a sample script `scripts/Scalafix.scala` which runs `OptimizeImports`. This is specified in `.scalafix.conf` for now, ideally it should all be
- Run `OptimizeImports` across codebase to celebrate