### PR TITLE
Update README to link to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A bleeping fast scala build tool!
 
-[![Join the chat at https://gitter.im/oyvindberg/bleep](https://badges.gitter.im/oyvindberg/bleep.svg)](https://gitter.im/oyvindberg/bleep?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Scala Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/scala)](https://discord.gg/scala) Chat in the [#tooling channel](https://discord.com/channels/632150470000902164/635669047588945930) of the Scala Discord
 
 See documentation at [https://bleep.build](https://bleep.build/docs/)
 


### PR DESCRIPTION
Fixes #437 

The badge itself links to the invite link for the Scala Discord as a whole, the "#tooling channel" text links to the specific channel