### PR TITLE
allow prefixes separated by `/` in `model.ProjectName`.

### DIFF
--- a/bleep-core/src/scala/bleep/packaging/CoordinatesFor.scala
+++ b/bleep-core/src/scala/bleep/packaging/CoordinatesFor.scala
@@ -7,10 +7,17 @@ trait CoordinatesFor {
 
 object CoordinatesFor {
   case class Default(groupId: String, version: String) extends CoordinatesFor {
-    override def apply(crossName: model.CrossProjectName, explodedProject: model.Project): model.Dep =
-      explodedProject.scala match {
-        case Some(_) => model.Dep.Scala(org = groupId, name = crossName.name.value, version = version)
-        case None    => model.Dep.Java(org = groupId, name = crossName.name.value, version = version)
+    override def apply(crossName: model.CrossProjectName, explodedProject: model.Project): model.Dep = {
+      // move prefixes separated by slash in the name to groupId
+      val (org, name) = crossName.name.value.split('/') match {
+        case Array(name) => (groupId, name)
+        case more        => (groupId + more.init.map("." + _).mkString, more.last)
       }
+
+      explodedProject.scala match {
+        case Some(_) => model.Dep.Scala(org = org, name = name, version = version)
+        case None    => model.Dep.Java(org = org, name = name, version = version)
+      }
+    }
   }
 }

--- a/bleep-model/src/scala/bleep/BuildPaths.scala
+++ b/bleep-model/src/scala/bleep/BuildPaths.scala
@@ -28,7 +28,7 @@ case class BuildPaths(cwd: Path, bleepYamlFile: Path, variant: model.BuildVarian
   lazy val digestFile: Path = bleepBloopDir / "bloop-digest"
   lazy val logFile: Path = buildVariantDir / "last.log"
 
-  def bloopFile(projectName: model.CrossProjectName): Path = bleepBloopDir / (projectName.value + ".json")
+  def bloopFile(projectName: model.CrossProjectName): Path = bleepBloopDir / (projectName.value.replace('/', '-') + ".json")
 
   final def project(crossName: model.CrossProjectName, p: model.Project): ProjectPaths = {
     val dir = buildDir / p.folder.getOrElse(RelPath.force(crossName.name.value))


### PR DESCRIPTION
- when publishing, move leading prefixes to `groupId` by default