### PR TITLE
Add way to disable warning when using external JVM.

### DIFF
--- a/bleep-core/src/scala/bleep/Prebootstrapped.scala
+++ b/bleep-core/src/scala/bleep/Prebootstrapped.scala
@@ -28,7 +28,7 @@ case class Prebootstrapped(
           )
           model.Jvm.system
         }
-        fetchJvm(jvm)
+        fetchJvm(if (jvm.name.equalsIgnoreCase("managed")) model.Jvm.system else jvm)
     }
 
   /** Will only reload if there are changes in the json structure, as indicated in the `Option`

--- a/bleep-site-in/usage/stable-builds.mdx
+++ b/bleep-site-in/usage/stable-builds.mdx
@@ -23,7 +23,15 @@ jvm:
   name: graalvm-java17:22.2.0
 ```
 
-If you don't, Bleep will fallback to what is discovered through `JAVA_HOME`.
+If you don't, Bleep will fallback to what is discovered through `JAVA_HOME`. Bleep will issue a warning when the JVM is managed externally.
+To disable this warning you can use the managed value for the name key.
+
+```yaml
+jvm:
+  name: managed
+```
+
+This is useful for projects that use other ways of managing the build environment.
 
 ## Bleep manages Node
 


### PR DESCRIPTION
This does not interfere with the build model, yet provides a simple way of disabling the warning when the JVM version is managed outside of bleep.

Especially useful for Nix users and the likes, where dynamically linked software can not be run without extra effort.