### PR TITLE
Support for defining NativeBuildTarget

### DIFF
--- a/bleep-core/src/scala/bleep/BleepCommandRemote.scala
+++ b/bleep-core/src/scala/bleep/BleepCommandRemote.scala
@@ -11,7 +11,6 @@ import ryddig.Throwables
 import java.io.IOException
 import java.nio.file.Files
 import java.util
-import scala.annotation.tailrec
 import scala.util.Try
 import scala.util.control.NonFatal
 

--- a/bleep-core/src/scala/bleep/GenBloopFiles.scala
+++ b/bleep-core/src/scala/bleep/GenBloopFiles.scala
@@ -248,7 +248,8 @@ object GenBloopFiles {
               linkStubs = empty.linkStubs,
               check = empty.check,
               dump = empty.dump,
-              output = empty.output
+              output = empty.output,
+              buildTarget = empty.buildTarget
             ),
             platform.mainClass
           )

--- a/bleep-core/src/scala/bleep/internal/conversions.scala
+++ b/bleep-core/src/scala/bleep/internal/conversions.scala
@@ -3,6 +3,7 @@ package bleep.internal
 import bleep.model
 import bloop.config.Config
 import bloop.config.Config.ModuleSplitStyleJS.{FewestModules, SmallModulesFor, SmallestModules}
+import bloop.config.Config.NativeBuildTarget.{Application, LibraryDynamic, LibraryStatic}
 
 object conversions {
   trait Bijection[T1, T2] {
@@ -64,6 +65,22 @@ object conversions {
       case model.ModuleSplitStyleJS.FewestModules             => Config.ModuleSplitStyleJS.FewestModules
       case model.ModuleSplitStyleJS.SmallModulesFor(packages) => Config.ModuleSplitStyleJS.SmallModulesFor(packages)
       case model.ModuleSplitStyleJS.SmallestModules           => Config.ModuleSplitStyleJS.SmallestModules
+    }
+
+  }
+
+  object nativeBuildTarget extends Bijection[Config.NativeBuildTarget, model.NativeBuildTarget] {
+
+    override def to(t1: Config.NativeBuildTarget): model.NativeBuildTarget = t1 match {
+      case Application    => model.NativeBuildTarget.Application
+      case LibraryDynamic => model.NativeBuildTarget.LibraryDynamic
+      case LibraryStatic  => model.NativeBuildTarget.LibraryStatic
+    }
+
+    override def from(t2: model.NativeBuildTarget): Config.NativeBuildTarget = t2 match {
+      case model.NativeBuildTarget.Application    => Config.NativeBuildTarget.Application
+      case model.NativeBuildTarget.LibraryDynamic => Config.NativeBuildTarget.LibraryDynamic
+      case model.NativeBuildTarget.LibraryStatic  => Config.NativeBuildTarget.LibraryStatic
     }
 
   }

--- a/bleep-model/src/scala/bleep/model/NativeBuildTarget.scala
+++ b/bleep-model/src/scala/bleep/model/NativeBuildTarget.scala
@@ -1,0 +1,28 @@
+package bleep.model
+
+import io.circe.*
+
+sealed abstract class NativeBuildTarget(val id: String)
+object NativeBuildTarget {
+  case object Application extends NativeBuildTarget("application")
+  case object LibraryDynamic extends NativeBuildTarget("dynamic")
+  case object LibraryStatic extends NativeBuildTarget("static")
+
+  val All: List[String] =
+    List(Application.id, LibraryDynamic.id, LibraryStatic.id)
+
+  implicit val encodeNativeBuildTarget: Encoder[NativeBuildTarget] = Encoder.instance {
+    case NativeBuildTarget.Application    => Json.obj(("nativeBuildTarget", Json.fromString("application")))
+    case NativeBuildTarget.LibraryDynamic => Json.obj(("nativeBuildTarget", Json.fromString("dynamic")))
+    case NativeBuildTarget.LibraryStatic  => Json.obj(("nativeBuildTarget", Json.fromString("static")))
+  }
+
+  implicit val decodeNativeBuildTarget: Decoder[NativeBuildTarget] = Decoder.instance { h =>
+    h.get[String]("nativeBuildTarget").flatMap {
+      case "application" => Right(NativeBuildTarget.Application)
+      case "dynamic"     => Right(NativeBuildTarget.LibraryDynamic)
+      case "static"      => Right(NativeBuildTarget.LibraryStatic)
+      case _             => Left(DecodingFailure("NativeBuildTarget", h.history))
+    }
+  }
+}

--- a/bleep-model/src/scala/bleep/model/Platform.scala
+++ b/bleep-model/src/scala/bleep/model/Platform.scala
@@ -25,7 +25,8 @@ case class Platform(
     //        resources: Option[List[Path]]
     nativeVersion: Option[VersionScalaNative],
     nativeMode: Option[LinkerMode],
-    nativeGc: Option[String]
+    nativeGc: Option[String],
+    nativeBuildTarget: Option[NativeBuildTarget]
     //      targetTriple: Option[String],
     //      clang: Path,
     //      clangpp: Path,
@@ -54,7 +55,8 @@ case class Platform(
       jvmRuntimeOptions = jvmRuntimeOptions.intersect(other.jvmRuntimeOptions),
       nativeVersion = if (nativeVersion == other.nativeVersion) nativeVersion else None,
       nativeMode = if (nativeMode == other.nativeMode) nativeMode else None,
-      nativeGc = if (nativeGc == other.nativeGc) nativeGc else None
+      nativeGc = if (nativeGc == other.nativeGc) nativeGc else None,
+      nativeBuildTarget = if (nativeBuildTarget == other.nativeBuildTarget) nativeBuildTarget else None
     )
 
   override def removeAll(other: Platform): Platform =
@@ -73,7 +75,8 @@ case class Platform(
       jvmRuntimeOptions = jvmRuntimeOptions.removeAll(other.jvmRuntimeOptions),
       nativeVersion = if (nativeVersion == other.nativeVersion) None else nativeVersion,
       nativeMode = if (nativeMode == other.nativeMode) None else nativeMode,
-      nativeGc = if (nativeGc == other.nativeGc) None else nativeGc
+      nativeGc = if (nativeGc == other.nativeGc) None else nativeGc,
+      nativeBuildTarget = if (nativeBuildTarget == other.nativeBuildTarget) None else nativeBuildTarget
     )
 
   override def union(other: Platform): Platform =
@@ -92,13 +95,14 @@ case class Platform(
       jvmRuntimeOptions = jvmRuntimeOptions.union(other.jvmRuntimeOptions),
       nativeVersion = nativeVersion.orElse(other.nativeVersion),
       nativeMode = nativeMode.orElse(other.nativeMode),
-      nativeGc = nativeGc.orElse(other.nativeGc)
+      nativeGc = nativeGc.orElse(other.nativeGc),
+      nativeBuildTarget = nativeBuildTarget.orElse(other.nativeBuildTarget)
     )
 
   override def isEmpty: Boolean =
     name.isEmpty && mainClass.isEmpty && jsVersion.isEmpty && jsMode.isEmpty && jsKind.isEmpty && jsEmitSourceMaps.isEmpty && jsJsdom.isEmpty && jsNodeVersion.isEmpty &&
       jvmOptions.isEmpty && jvmRuntimeOptions.isEmpty &&
-      nativeVersion.isEmpty && nativeMode.isEmpty && nativeGc.isEmpty
+      nativeVersion.isEmpty && nativeMode.isEmpty && nativeGc.isEmpty && nativeBuildTarget.isEmpty
 }
 
 object Platform {
@@ -118,7 +122,8 @@ object Platform {
         jvmRuntimeOptions = jvmRuntimeOptions,
         nativeVersion = None,
         nativeMode = None,
-        nativeGc = None
+        nativeGc = None,
+        nativeBuildTarget = None
       )
 
     def unapply(x: Platform): Option[Platform] =
@@ -154,7 +159,8 @@ object Platform {
         jvmRuntimeOptions = Options.empty,
         nativeVersion = None,
         nativeMode = None,
-        nativeGc = None
+        nativeGc = None,
+        nativeBuildTarget = None
       )
 
     def unapply(x: Platform): Option[Platform] =
@@ -180,7 +186,8 @@ object Platform {
         jvmRuntimeOptions = Options.empty,
         nativeVersion = Some(nativeVersion),
         nativeMode = nativeMode,
-        nativeGc = nativeGc
+        nativeGc = nativeGc,
+        nativeBuildTarget = None
       )
 
     def unapply(x: Platform): Option[Platform] =

--- a/bleep-model/src/scala/bleep/rewrites/Defaults.scala
+++ b/bleep-model/src/scala/bleep/rewrites/Defaults.scala
@@ -27,7 +27,8 @@ object Defaults {
       jvmRuntimeOptions = model.Options.empty,
       nativeVersion = None,
       nativeMode = None,
-      nativeGc = None
+      nativeGc = None,
+      nativeBuildTarget = None
     )
 
   object remove extends BuildRewrite {

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -20,8 +20,7 @@ projects:
       mainClass: bleep.Main
   bleep-core:
     dependencies:
-    - for3Use213: true
-      module: ch.epfl.scala::bloop-config:2.1.0
+    - ch.epfl.scala::bloop-config:2.2.0
     - for3Use213: true
       module: ch.epfl.scala::bloop-rifle:2.0.5
     - com.olvind.ryddig::ryddig:0.0.6

--- a/schema.json
+++ b/schema.json
@@ -284,6 +284,14 @@
             "release"
           ]
         },
+        "nativeBuildTarget": {
+          "type": "string",
+          "enum": [
+            "application",
+            "dynamic",
+            "static"
+          ]
+        },
         "nativeGc": {
           "type": "string"
         }


### PR DESCRIPTION
When linking SN projects the user can specify to link as an application ,the most common and the default, or the user can specify a dynamic or static library.

This is a new configuration option that has been added to bloop-config for better support for linking without a main class when building SN libraries