### PR TITLE
deps: bloop-config 2.3.0->2.3.1, bloop-rifle 2.0.5->2.0.7

### DIFF
--- a/bleep.yaml
+++ b/bleep.yaml
@@ -20,9 +20,9 @@ projects:
       mainClass: bleep.Main
   bleep-core:
     dependencies:
-    - ch.epfl.scala::bloop-config:2.3.0
+    - ch.epfl.scala::bloop-config:2.3.1
     - for3Use213: true
-      module: ch.epfl.scala::bloop-rifle:2.0.5
+      module: ch.epfl.scala::bloop-rifle:2.0.7
     - com.olvind.ryddig::ryddig:0.0.6
     - com.swoval:file-tree-views:2.1.12
     - org.typelevel::scalac-options:0.1.7

--- a/scripts/src/scala/bleep/scripts/GenNativeImage.scala
+++ b/scripts/src/scala/bleep/scripts/GenNativeImage.scala
@@ -10,7 +10,7 @@ object GenNativeImage extends BleepScript("GenNativeImage") {
     val jvm3 = model.CrossId("jvm3")
     val projectName = model.CrossProjectName(model.ProjectName("bleep-cli"), crossId = Some(jvm3))
     val project = started.bloopProject(projectName)
-    commands.compile(List(projectName))
+    // commands.compile(List(projectName))
 
     // this is here to pick up the graalvm installed by `graalvm/setup-graalvm@v1` in github actions *on windows*
     // the one we install ourselves does not work


### PR DESCRIPTION
Bloop version with support for linking through bsp