### PR TITLE
ci: Upgrade ubuntu runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             file_name: bleep
             artifact_name: bleep-x86_64-pc-linux
           - os: macos-13
@@ -146,7 +146,7 @@ jobs:
 
   release:
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ build, build-native-image, yaml-ls-check ]
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:


### PR DESCRIPTION
Ubuntu 20.04 is now officially deprecated in github actions