### PR TITLE
Integrate Sonatype Central Portal support in sbt-sonatype

### DIFF
--- a/scripts/src/scala/bleep/scripts/Publish.scala
+++ b/scripts/src/scala/bleep/scripts/Publish.scala
@@ -24,7 +24,7 @@ object Publish extends BleepScript("Publish") {
       interactionService = InteractionService.DoesNotMaskYourPasswordExclamationOneOne
     ) {
       // pick one of the keys from `gpg --list-keys`
-      override def pgpSigningKey() = Some("0BC13EB20EDBE20BE51010A04F1C4835C3551931")
+      override def pgpSigningKey() = Some("9979E0BA41F01ADE0BBAEF6012374915FB3D4C63")
     }
     val sonatype = new Sonatype(
       logger = started.logger,

--- a/scripts/src/scala/bleep/scripts/Publish.scala
+++ b/scripts/src/scala/bleep/scripts/Publish.scala
@@ -31,8 +31,7 @@ object Publish extends BleepScript("Publish") {
       sonatypeBundleDirectory = started.buildPaths.dotBleepDir / "sonatype-bundle",
       sonatypeProfileName = groupId,
       bundleName = "bleep",
-      version = dynVer.version,
-      sonatypeCredentialHost = Sonatype.sonatype01
+      version = dynVer.version
     )
     val ciRelease = new CiReleasePlugin(started.logger, sonatype, dynVer, pgp)
 


### PR DESCRIPTION
## Summary
- Integrated missing Sonatype Central Portal functionality that was previously simplified in the bleep port
- Added proper routing between Central Portal and legacy OSSRH infrastructure
- All staging repository operations now handle Central Portal appropriately

## Changes

### Core Central Portal Support
- Added `withSonatypeCentralService` method for Central Portal API interactions
- Added `sonatypeCentralUpload` method for user-managed publishing
- Added `sonatypeCentralRelease` method for automatic publishing
- Made `SonatypeCentralClient` and `SonatypeCentralService` public (removed private[sonatype])

### Bundle Operations Routing
- Updated `sonatypeBundleRelease` to route between Central Portal and legacy OSSRH
- Updated `sonatypeBundleUpload` to support both infrastructures
- Updated static `bundleRelease` method in Sonatype object with full Central Portal implementation

### Staging Repository Operations
All staging repository operations now check for Central Portal and respond appropriately:
- Operations that require staging (`sonatypePrepare`, `sonatypeOpen`, `sonatypeClose`, `sonatypePromote`, `sonatypeDrop`, `sonatypeRelease`) throw `UnsupportedOperationException`
- Query/cleanup operations (`sonatypeReleaseAll`, `sonatypeDropAll`, `sonatypeLog`, `sonatypeStagingRepositoryProfiles`, `sonatypeStagingProfiles`, `sonatypeClean`) log informative messages

### Technical Details
- Added necessary imports: `DeploymentName`, `PublishingType`, `GENERIC_ERROR`
- SNAPSHOT version validation for Central Portal deployments
- Proper error handling and messaging throughout

## Impact
Users using Sonatype Central Portal (central.sonatype.com) will no longer see confusing messages about staging repositories, which don't exist in the new infrastructure. Instead, they'll get clear guidance about which operations are available.

The implementation maintains full backward compatibility with legacy OSSRH while adding complete Central Portal support.

## Testing
The code compiles successfully and has been formatted with scalafmt.

🤖 Generated with [Claude Code](https://claude.ai/code)