### PR TITLE
Add Java annotation processor support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,3 +383,7 @@ This maintenance process ensures our liberated projects stay current while prese
 ## Developer Tips and Notes
 
 - You can just compile with "bleep". To use that script you're referring to we need to create it with bleep setup-dev-script or something like that, and compile and then run. It's useful for testing bleep itself
+
+## Design Principles
+
+- **Never Use Default Parameters**: When defining methods or functions, always explicitly specify parameters

--- a/bleep-core/src/scala/bleep/commands/Clean.scala
+++ b/bleep-core/src/scala/bleep/commands/Clean.scala
@@ -12,7 +12,7 @@ case class Clean(projects: Array[model.CrossProjectName]) extends BleepBuildComm
       projects
         .flatMap { projectName =>
           val paths = started.projectPaths(projectName)
-          List(paths.targetDir) ++ paths.sourcesDirs.generated.values ++ paths.resourcesDirs.generated.values
+          List(paths.targetDir) ++ paths.sourcesDirs.cleanable ++ paths.resourcesDirs.cleanable
         }
         .filter(Files.exists(_))
 

--- a/bleep-model/src/scala/bleep/BuildPaths.scala
+++ b/bleep-model/src/scala/bleep/BuildPaths.scala
@@ -53,14 +53,15 @@ case class BuildPaths(cwd: Path, bleepYamlFile: Path, variant: model.BuildVarian
       val fromSourceLayout = sourceLayout.sources(scalaVersion, maybePlatformId, p.`sbt-scope`).values.map(dir / _)
       val fromJson = p.sources.values.map(relPath => (relPath, dir / replacements.fill.relPath(relPath))).toMap
       val generated = p.sourcegen.values.iterator.map(sourceGen => (sourceGen, generatedSourcesDir(crossName, sourceGen.folderName))).toMap
-      ProjectPaths.DirsByOrigin(fromSourceLayout, fromJson, generated)
+      val annotationProcessing = p.java.flatMap(_.annotationProcessing).filter(_.enabled).map(_ => generatedSourcesDir(crossName, "annotations"))
+      ProjectPaths.DirsByOrigin(fromSourceLayout, fromJson, generated, annotationProcessing)
     }
 
     val resources = {
       val fromSourceLayout = sourceLayout.resources(scalaVersion, maybePlatformId, p.`sbt-scope`).values.map(dir / _)
       val fromJson = p.resources.values.iterator.map(relPath => (relPath, dir / replacements.fill.relPath(relPath))).toMap
       val generated = p.sourcegen.values.iterator.map(sourceGen => (sourceGen, generatedResourcesDir(crossName, sourceGen.folderName))).toMap
-      ProjectPaths.DirsByOrigin(fromSourceLayout, fromJson, generated)
+      ProjectPaths.DirsByOrigin(fromSourceLayout, fromJson, generated, None)
     }
 
     ProjectPaths(dir = dir, targetDir = targetDir, sourcesDirs = sources, resourcesDirs = resources)

--- a/bleep-model/src/scala/bleep/ProjectPaths.scala
+++ b/bleep-model/src/scala/bleep/ProjectPaths.scala
@@ -12,7 +12,13 @@ case class ProjectPaths(dir: Path, targetDir: Path, sourcesDirs: ProjectPaths.Di
 }
 
 object ProjectPaths {
-  case class DirsByOrigin(fromSourceLayout: SortedSet[Path], fromJson: Map[RelPath, Path], generated: Map[model.ScriptDef, Path]) {
-    val all: SortedSet[Path] = fromSourceLayout ++ fromJson.values ++ generated.values
+  case class DirsByOrigin(
+      fromSourceLayout: SortedSet[Path],
+      fromJson: Map[RelPath, Path],
+      generated: Map[model.ScriptDef, Path],
+      annotationProcessing: Option[Path]
+  ) {
+    val all: SortedSet[Path] = fromSourceLayout ++ fromJson.values ++ generated.values ++ annotationProcessing
+    val cleanable: Iterable[Path] = generated.values ++ annotationProcessing
   }
 }

--- a/bleep-model/src/scala/bleep/model/AnnotationProcessing.scala
+++ b/bleep-model/src/scala/bleep/model/AnnotationProcessing.scala
@@ -1,0 +1,11 @@
+package bleep.model
+
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+
+case class AnnotationProcessing(enabled: Boolean = false)
+
+object AnnotationProcessing {
+  implicit val decodes: Decoder[AnnotationProcessing] = deriveDecoder
+  implicit val encodes: Encoder[AnnotationProcessing] = deriveEncoder
+}

--- a/bleep-model/src/scala/bleep/model/Java.scala
+++ b/bleep-model/src/scala/bleep/model/Java.scala
@@ -3,19 +3,34 @@ package bleep.model
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 
-case class Java(options: Options) extends SetLike[Java] {
+case class Java(options: Options, annotationProcessing: Option[AnnotationProcessing] = None) extends SetLike[Java] {
   override def intersect(other: Java): Java =
-    Java(options = options.intersect(other.options))
+    Java(
+      options = options.intersect(other.options),
+      annotationProcessing = (annotationProcessing, other.annotationProcessing) match {
+        case (Some(a), Some(b)) => Some(AnnotationProcessing(a.enabled && b.enabled))
+        case _                  => None
+      }
+    )
 
   override def removeAll(other: Java): Java =
-    Java(options = options.removeAll(other.options))
+    Java(
+      options = options.removeAll(other.options),
+      annotationProcessing = (annotationProcessing, other.annotationProcessing) match {
+        case (Some(a), Some(b)) if a == b => None
+        case _                            => annotationProcessing
+      }
+    )
 
   override def union(other: Java): Java =
-    Java(options = options.union(other.options))
+    Java(
+      options = options.union(other.options),
+      annotationProcessing = other.annotationProcessing.orElse(annotationProcessing)
+    )
 
   def isEmpty: Boolean =
     this match {
-      case Java(options) => options.isEmpty
+      case Java(options, annotationProcessing) => options.isEmpty && annotationProcessing.isEmpty
     }
 }
 

--- a/bleep-site-in/usage/annotation-processing.mdx
+++ b/bleep-site-in/usage/annotation-processing.mdx
@@ -1,0 +1,217 @@
+---
+title: Java Annotation Processing
+---
+
+Bleep supports Java annotation processors, allowing you to use tools like Lombok, MapStruct, Dagger, and other compile-time code generators.
+
+## Overview
+
+Annotation processing in Bleep is:
+- **Disabled by default** - Must be explicitly enabled
+- **Simple to configure** - Just one boolean flag
+- **Automatic discovery** - Uses Java's ServiceLoader mechanism
+- **Clean separation** - Generated sources go to a dedicated directory
+
+## Basic Configuration
+
+To enable annotation processing, add the `annotationProcessing` configuration to your project's `java` section:
+
+```yaml
+projects:
+  my-app:
+    dependencies:
+      - org.projectlombok:lombok:1.18.30
+    java:
+      annotationProcessing:
+        enabled: true
+```
+
+That's it! Bleep will automatically discover and run annotation processors found in your dependencies.
+
+## Common Use Cases
+
+### Lombok
+
+[Lombok](https://projectlombok.org/) reduces boilerplate code by generating getters, setters, constructors, and more:
+
+```yaml
+projects:
+  my-app:
+    dependencies:
+      - org.projectlombok:lombok:1.18.30
+    source-layout: java
+    java:
+      annotationProcessing:
+        enabled: true
+```
+
+Example Java code:
+```java
+import lombok.Data;
+
+@Data
+public class Person {
+    private String name;
+    private int age;
+}
+```
+
+### MapStruct
+
+[MapStruct](https://mapstruct.org/) generates type-safe mappers between Java beans:
+
+```yaml
+projects:
+  my-app:
+    dependencies:
+      - org.mapstruct:mapstruct:1.6.0
+      - org.mapstruct:mapstruct-processor:1.6.0
+    java:
+      annotationProcessing:
+        enabled: true
+```
+
+### Dagger
+
+[Dagger](https://dagger.dev/) is a compile-time dependency injection framework:
+
+```yaml
+projects:
+  my-app:
+    dependencies:
+      - com.google.dagger:dagger:2.51
+      - com.google.dagger:dagger-compiler:2.51
+    java:
+      annotationProcessing:
+        enabled: true
+```
+
+### Multiple Processors
+
+You can use multiple annotation processors in the same project:
+
+```yaml
+projects:
+  my-app:
+    dependencies:
+      - org.projectlombok:lombok:1.18.30
+      - org.mapstruct:mapstruct:1.6.0
+      - org.mapstruct:mapstruct-processor:1.6.0
+      - com.google.dagger:dagger:2.51
+      - com.google.dagger:dagger-compiler:2.51
+    java:
+      annotationProcessing:
+        enabled: true
+```
+
+## Generated Sources
+
+When annotation processing is enabled, generated Java sources are placed in:
+```
+.bleep/generated-sources/{project-name}/annotations/
+```
+
+This directory is:
+- Automatically created when needed
+- Added to the project's source paths
+- Cleaned on `bleep clean`
+- Excluded from version control (via `.gitignore`)
+
+## How It Works
+
+When `annotationProcessing.enabled = true`:
+- Bleep adds `-s .bleep/generated-sources/{project}/annotations/` to javac options
+- The Java compiler discovers processors via ServiceLoader
+- Generated sources are compiled along with your code
+
+When `annotationProcessing.enabled = false` (default):
+- Bleep adds `-proc:none` to javac options
+- Annotation processors are not run, even if present on classpath
+- No generated sources directory is created
+
+## Validation
+
+Bleep validates your configuration to prevent conflicts. You cannot manually specify `-proc:*` or `-s` javac options when using the `annotationProcessing` configuration:
+
+```yaml
+# This will fail with an error
+projects:
+  my-app:
+    java:
+      options: -proc:only -s target/generated  # ❌ Conflicts!
+      annotationProcessing:
+        enabled: true
+```
+
+## Troubleshooting
+
+### Processors Not Running
+
+If your annotation processors aren't running:
+1. Ensure `annotationProcessing.enabled: true` is set
+2. Check that processor dependencies are included
+3. Verify processors use standard ServiceLoader registration
+
+### IDE Integration
+
+Most IDEs will automatically recognize the generated sources directory. If not:
+- In IntelliJ IDEA: Mark `.bleep/generated-sources/{project}/annotations/` as "Generated Sources Root"
+- In VS Code with Metals: Sources should be recognized automatically
+
+### Compilation Errors
+
+If you see compilation errors related to generated code:
+1. Run `bleep clean` to remove stale generated files
+2. Ensure all required processor dependencies are included
+3. Check processor-specific documentation for configuration requirements
+
+## Migration from Other Build Tools
+
+### From Maven
+
+Maven typically runs annotation processors automatically. In Bleep, you must explicitly enable them:
+
+```xml
+<!-- Maven (runs automatically) -->
+<dependency>
+    <groupId>org.projectlombok</groupId>
+    <artifactId>lombok</artifactId>
+    <version>1.18.30</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+```yaml
+# Bleep (must enable explicitly)
+projects:
+  my-app:
+    dependencies:
+      - org.projectlombok:lombok:1.18.30
+    java:
+      annotationProcessing:
+        enabled: true
+```
+
+### From Gradle
+
+Gradle uses `annotationProcessor` configuration. In Bleep, use regular dependencies:
+
+```gradle
+// Gradle
+dependencies {
+    implementation 'com.google.dagger:dagger:2.51'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.51'
+}
+```
+
+```yaml
+# Bleep
+projects:
+  my-app:
+    dependencies:
+      - com.google.dagger:dagger:2.51
+      - com.google.dagger:dagger-compiler:2.51
+    java:
+      annotationProcessing:
+        enabled: true
+```

--- a/bleep-site/sidebars.js
+++ b/bleep-site/sidebars.js
@@ -40,6 +40,11 @@ const sidebars = {
                 },
                 {
                     type: "doc",
+                    label: "Java Annotation Processing",
+                    id: "usage/annotation-processing",
+                },
+                {
+                    type: "doc",
                     label: "Selecting projects",
                     id: "usage/selecting-projects",
                 },

--- a/bleep-tests/src/scala/bleep/model/JavaTest.scala
+++ b/bleep-tests/src/scala/bleep/model/JavaTest.scala
@@ -1,0 +1,50 @@
+package bleep
+package model
+
+import io.circe.syntax.*
+import org.scalactic.TripleEqualsSupport
+import org.scalatest.Assertion
+import org.scalatest.funsuite.AnyFunSuite
+
+class JavaTest extends AnyFunSuite with TripleEqualsSupport {
+  def roundtrip(java: Java): Assertion = {
+    val json = java.asJson
+    val java2 = json.as[Java].orThrowWithError("Failed to parse json")
+    assert(java === java2)
+  }
+
+  test("Java model with annotation processing") {
+    // Test default case (no annotation processing)
+    roundtrip(Java(Options.empty))
+
+    // Test with annotation processing disabled explicitly
+    roundtrip(Java(Options.empty, Some(AnnotationProcessing(false))))
+
+    // Test with annotation processing enabled
+    roundtrip(Java(Options.empty, Some(AnnotationProcessing(true))))
+
+    // Test with options and annotation processing
+    val opts = Options.parse(List("-Xlint:all", "-Werror"), maybeRelativize = None)
+    roundtrip(Java(opts, Some(AnnotationProcessing(true))))
+  }
+
+  test("Java model setlike operations") {
+    val java1 = Java(Options.parse(List("-Xlint:all"), maybeRelativize = None), Some(AnnotationProcessing(true)))
+    val java2 = Java(Options.parse(List("-Werror"), maybeRelativize = None), Some(AnnotationProcessing(false)))
+
+    // Test union
+    val union = java1.union(java2)
+    assert(union.options.render === List("-Werror", "-Xlint:all"))
+    assert(union.annotationProcessing === Some(AnnotationProcessing(false))) // java2's value wins
+
+    // Test intersect
+    val intersect = java1.intersect(java2)
+    assert(intersect.options.isEmpty)
+    assert(intersect.annotationProcessing === Some(AnnotationProcessing(false))) // true && false = false
+
+    // Test removeAll
+    val removed = java1.removeAll(java1)
+    assert(removed.options.isEmpty)
+    assert(removed.annotationProcessing === None) // Same values result in None
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -38,6 +38,16 @@
         }
       ]
     },
+    "AnnotationProcessing": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable annotation processing for Java sources"
+        }
+      }
+    },
     "ProjectName": {
       "type": "string"
     },
@@ -163,6 +173,9 @@
       "properties": {
         "options": {
           "$ref": "#/$defs/Options"
+        },
+        "annotationProcessing": {
+          "$ref": "#/$defs/AnnotationProcessing"
         }
       }
     },

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/benchmarks.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/benchmarks.json
@@ -203,7 +203,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-backend-test.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-backend-test.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-backend.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-backend.json
@@ -163,7 +163,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-cli.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-cli.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-docs.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-docs.json
@@ -269,7 +269,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-frontend-it.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-frontend-it.json
@@ -191,7 +191,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-frontend-test.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-frontend-test.json
@@ -193,7 +193,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-frontend.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-frontend.json
@@ -186,7 +186,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-js-bridge-0-6-test.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-js-bridge-0-6-test.json
@@ -209,7 +209,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-js-bridge-0-6.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-js-bridge-0-6.json
@@ -200,7 +200,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-js-bridge-1.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-js-bridge-1.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-native-bridge-0-4.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-native-bridge-0-4.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-native-bridge-0-5.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-native-bridge-0-5.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-rifle-test.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-rifle-test.json
@@ -82,7 +82,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-rifle.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-rifle.json
@@ -77,7 +77,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-shared.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/bloop-shared.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/buildpress.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/buildpress.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/buildpressconfig.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/buildpressconfig.json
@@ -66,7 +66,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/sbt-bloop.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/sbt-bloop.json
@@ -151,7 +151,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
+++ b/snapshot-tests/bloop/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/cli.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/cli.json
@@ -242,7 +242,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/core.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/core.json
@@ -100,7 +100,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/import-scalajs-definitions.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/import-scalajs-definitions.json
@@ -242,7 +242,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/importer-portable.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/importer-portable.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/importer-test.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/importer-test.json
@@ -267,7 +267,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/importer.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/importer.json
@@ -249,7 +249,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/logging.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/logging.json
@@ -85,7 +85,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/phases.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/phases.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/sbt-converter.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/sbt-converter.json
@@ -251,7 +251,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/scalajs.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/scalajs.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/ts.json
+++ b/snapshot-tests/converter/bootstrapped/.bleep/builds/normal/.bloop/ts.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@js213.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@js213.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@js3.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@js3.json
@@ -80,7 +80,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@jvm213.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@jvm213.json
@@ -94,7 +94,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@jvm3.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/myapp@jvm3.json
@@ -76,7 +76,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@js213.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@js213.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@js3.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@js3.json
@@ -99,7 +99,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm213.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm3.json
+++ b/snapshot-tests/create-new-build/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm3.json
@@ -94,7 +94,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm212.json
@@ -125,7 +125,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm213.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm3.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core-test@jvm212.json
@@ -128,7 +128,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core-test@jvm213.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core-test@jvm3.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core@jvm212.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core@jvm213.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-core@jvm3.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free-test@jvm212.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free-test@jvm213.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free-test@jvm3.json
@@ -99,7 +99,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free@jvm212.json
@@ -101,7 +101,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free@jvm213.json
@@ -100,7 +100,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-free@jvm3.json
@@ -84,7 +84,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe-test@jvm212.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe-test@jvm213.json
@@ -129,7 +129,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe-test@jvm3.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe@jvm212.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe@jvm213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-circe@jvm3.json
@@ -96,7 +96,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-test@jvm212.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-test@jvm213.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2-test@jvm3.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2@jvm212.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2@jvm213.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-h2@jvm3.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari-test@jvm212.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari-test@jvm213.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari-test@jvm3.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari@jvm212.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari@jvm213.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-hikari@jvm3.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-log4cats@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-log4cats@jvm212.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-log4cats@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-log4cats@jvm213.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-log4cats@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-log4cats@jvm3.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit-test@jvm212.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit-test@jvm213.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit-test@jvm3.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit@jvm212.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit@jvm213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-munit@jvm3.json
@@ -94,7 +94,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql-test@jvm212.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql-test@jvm213.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql-test@jvm3.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql@jvm212.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql@jvm213.json
@@ -107,7 +107,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-mysql@jvm3.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe-test@jvm212.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe-test@jvm213.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe-test@jvm3.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe@jvm212.json
@@ -119,7 +119,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe@jvm213.json
@@ -117,7 +117,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-circe@jvm3.json
@@ -100,7 +100,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-test@jvm212.json
@@ -138,7 +138,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-test@jvm213.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres-test@jvm3.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres@jvm212.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres@jvm213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-postgres@jvm3.json
@@ -96,7 +96,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined-test@jvm212.json
@@ -127,7 +127,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined-test@jvm213.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined-test@jvm3.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined@jvm212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined@jvm213.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-refined@jvm3.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest-test@jvm212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest-test@jvm213.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest-test@jvm3.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest@jvm212.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest@jvm213.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-scalatest@jvm3.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2-test@jvm212.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2-test@jvm213.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2-test@jvm3.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2@jvm212.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2@jvm213.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-specs2@jvm3.json
@@ -94,7 +94,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver-test@jvm212.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver-test@jvm213.json
@@ -128,7 +128,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver-test@jvm3.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver@jvm212.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver@jvm213.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/doobie-weaver@jvm3.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example-test@jvm212.json
@@ -168,7 +168,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example-test@jvm213.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example-test@jvm3.json
@@ -148,7 +148,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example@jvm212.json
@@ -149,7 +149,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example@jvm213.json
@@ -147,7 +147,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/example@jvm3.json
@@ -129,7 +129,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils-test@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils-test@jvm212.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils-test@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils-test@jvm213.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils-test@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils-test@jvm3.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils@jvm212.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils@jvm212.json
@@ -91,7 +91,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils@jvm213.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils@jvm213.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils@jvm3.json
+++ b/snapshot-tests/doobie/bootstrapped/.bleep/builds/normal/.bloop/testutils@jvm3.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-bench@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-bench@jvm213.json
@@ -110,7 +110,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-bench@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-bench@jvm3.json
@@ -111,7 +111,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@js213.json
@@ -147,7 +147,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@js3.json
@@ -148,7 +148,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@jvm213.json
@@ -137,7 +137,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@jvm3.json
@@ -137,7 +137,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@native213.json
@@ -151,7 +151,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe-test@native3.json
@@ -152,7 +152,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@js213.json
@@ -113,7 +113,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@js3.json
@@ -114,7 +114,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@jvm213.json
@@ -102,7 +102,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@jvm3.json
@@ -102,7 +102,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@native213.json
@@ -116,7 +116,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-circe@native3.json
@@ -117,7 +117,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@js213.json
@@ -149,7 +149,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@js3.json
@@ -148,7 +148,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@jvm213.json
@@ -147,7 +147,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@jvm3.json
@@ -145,7 +145,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@native213.json
@@ -153,7 +153,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-test@native3.json
@@ -152,7 +152,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@js213.json
@@ -151,7 +151,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@js3.json
@@ -150,7 +150,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@jvm213.json
@@ -150,7 +150,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@jvm3.json
@@ -148,7 +148,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@native213.json
@@ -155,7 +155,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit-test@native3.json
@@ -154,7 +154,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@js213.json
@@ -126,7 +126,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@js3.json
@@ -125,7 +125,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@jvm213.json
@@ -127,7 +127,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@jvm3.json
@@ -125,7 +125,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@native213.json
@@ -130,7 +130,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client-testkit@native3.json
@@ -129,7 +129,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@js213.json
@@ -115,7 +115,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@js3.json
@@ -114,7 +114,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@jvm213.json
@@ -104,7 +104,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@jvm3.json
@@ -102,7 +102,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@native213.json
@@ -118,7 +118,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-client@native3.json
@@ -117,7 +117,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core-test@jvm213.json
@@ -118,7 +118,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core-test@jvm3.json
@@ -116,7 +116,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@js213.json
@@ -115,7 +115,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@js3.json
@@ -114,7 +114,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@jvm213.json
@@ -104,7 +104,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@jvm3.json
@@ -102,7 +102,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@native213.json
@@ -118,7 +118,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-core@native3.json
@@ -117,7 +117,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@js213.json
@@ -138,7 +138,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@js3.json
@@ -139,7 +139,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@jvm213.json
@@ -128,7 +128,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@jvm3.json
@@ -128,7 +128,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@native213.json
@@ -142,7 +142,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl-test@native3.json
@@ -143,7 +143,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@js213.json
@@ -106,7 +106,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@js3.json
@@ -107,7 +107,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@jvm213.json
@@ -95,7 +95,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@jvm3.json
@@ -95,7 +95,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@native213.json
@@ -109,7 +109,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-dsl@native3.json
@@ -110,7 +110,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@js213.json
@@ -161,7 +161,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@js3.json
@@ -160,7 +160,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@jvm213.json
@@ -160,7 +160,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@jvm3.json
@@ -158,7 +158,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@native213.json
@@ -165,7 +165,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client-test@native3.json
@@ -164,7 +164,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@js213.json
@@ -121,7 +121,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@js3.json
@@ -120,7 +120,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@jvm213.json
@@ -110,7 +110,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@jvm3.json
@@ -108,7 +108,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@native213.json
@@ -124,7 +124,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-client@native3.json
@@ -123,7 +123,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@js213.json
@@ -147,7 +147,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@js3.json
@@ -146,7 +146,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@jvm213.json
@@ -137,7 +137,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@jvm3.json
@@ -135,7 +135,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@native213.json
@@ -151,7 +151,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core-test@native3.json
@@ -150,7 +150,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@js213.json
@@ -115,7 +115,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@js3.json
@@ -114,7 +114,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@jvm213.json
@@ -104,7 +104,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@jvm3.json
@@ -102,7 +102,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@native213.json
@@ -118,7 +118,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-core@native3.json
@@ -117,7 +117,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@js213.json
@@ -163,7 +163,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@js3.json
@@ -162,7 +162,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@jvm213.json
@@ -168,7 +168,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@jvm3.json
@@ -166,7 +166,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@native213.json
@@ -167,7 +167,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server-test@native3.json
@@ -166,7 +166,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@js213.json
@@ -120,7 +120,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@js3.json
@@ -119,7 +119,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@jvm213.json
@@ -109,7 +109,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@jvm3.json
@@ -107,7 +107,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@native213.json
@@ -123,7 +123,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-ember-server@native3.json
@@ -122,7 +122,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples-docker@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples-docker@jvm213.json
@@ -102,7 +102,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples-docker@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples-docker@jvm3.json
@@ -103,7 +103,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples-ember@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples-ember@jvm213.json
@@ -122,7 +122,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples-ember@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples-ember@jvm3.json
@@ -122,7 +122,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples@jvm213.json
@@ -109,7 +109,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-examples@jvm3.json
@@ -109,7 +109,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@js213.json
@@ -138,7 +138,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@js3.json
@@ -139,7 +139,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@jvm213.json
@@ -128,7 +128,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@jvm3.json
@@ -128,7 +128,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@native213.json
@@ -142,7 +142,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn-test@native3.json
@@ -143,7 +143,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@js213.json
@@ -108,7 +108,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@js3.json
@@ -109,7 +109,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@jvm213.json
@@ -97,7 +97,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@jvm3.json
@@ -97,7 +97,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@native213.json
@@ -111,7 +111,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-jawn@native3.json
@@ -112,7 +112,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-js-artifact-size+test-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-js-artifact-size+test-test@js213.json
@@ -122,7 +122,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-js-artifact-size+test-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-js-artifact-size+test-test@js3.json
@@ -124,7 +124,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@js213.json
@@ -125,7 +125,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@js3.json
@@ -126,7 +126,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@jvm213.json
@@ -116,7 +116,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@jvm3.json
@@ -116,7 +116,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@native213.json
@@ -129,7 +129,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-laws@native3.json
@@ -130,7 +130,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-scalafix-internal@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-scalafix-internal@jvm213.json
@@ -98,7 +98,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-scalafix-internal@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-scalafix-internal@jvm3.json
@@ -76,7 +76,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@js213.json
@@ -149,7 +149,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@js3.json
@@ -148,7 +148,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@jvm213.json
@@ -139,7 +139,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@jvm3.json
@@ -137,7 +137,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@native213.json
@@ -153,7 +153,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server-test@native3.json
@@ -152,7 +152,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@js213.json
@@ -115,7 +115,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@js3.json
@@ -114,7 +114,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@jvm213.json
@@ -104,7 +104,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@jvm3.json
@@ -102,7 +102,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@native213.json
@@ -118,7 +118,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-server@native3.json
@@ -117,7 +117,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@js213.json
@@ -142,7 +142,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@js3.json
@@ -141,7 +141,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@jvm213.json
@@ -132,7 +132,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@jvm3.json
@@ -130,7 +130,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@native213.json
@@ -146,7 +146,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests-test@native3.json
@@ -145,7 +145,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@js213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@js213.json
@@ -136,7 +136,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@js3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@js3.json
@@ -135,7 +135,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@jvm213.json
@@ -127,7 +127,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@jvm3.json
@@ -125,7 +125,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@native213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@native213.json
@@ -141,7 +141,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@native3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/http4s-tests@native3.json
@@ -140,7 +140,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternalinput@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternalinput@jvm213.json
@@ -90,7 +90,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternalinput@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternalinput@jvm3.json
@@ -91,7 +91,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaloutput@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaloutput@jvm213.json
@@ -90,7 +90,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaloutput@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaloutput@jvm3.json
@@ -91,7 +91,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaltests-test@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaltests-test@jvm213.json
@@ -136,7 +136,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaltests-test@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaltests-test@jvm3.json
@@ -82,7 +82,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaltests@jvm213.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaltests@jvm213.json
@@ -99,7 +99,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaltests@jvm3.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scalafixinternaltests@jvm3.json
@@ -78,7 +78,8 @@
         "8",
         "-Xlint:all",
         "-encoding",
-        "utf8"
+        "utf8",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
+++ b/snapshot-tests/http4s/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/actions-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/actions-test@jvm212.json
@@ -178,6 +178,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/actions-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/actions-test@jvm213.json
@@ -179,6 +179,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/actions@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/actions@jvm212.json
@@ -154,6 +154,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/actions@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/actions@jvm213.json
@@ -155,6 +155,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/collections-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/collections-test@jvm212.json
@@ -103,6 +103,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/collections-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/collections-test@jvm213.json
@@ -102,6 +102,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/collections@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/collections@jvm212.json
@@ -79,6 +79,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/collections@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/collections@jvm213.json
@@ -78,6 +78,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/command-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/command-test@jvm212.json
@@ -170,6 +170,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/command-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/command-test@jvm213.json
@@ -171,6 +171,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/command@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/command@jvm212.json
@@ -145,6 +145,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/command@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/command@jvm213.json
@@ -146,6 +146,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/completion-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/completion-test@jvm212.json
@@ -127,6 +127,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/completion-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/completion-test@jvm213.json
@@ -128,6 +128,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/completion@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/completion@jvm212.json
@@ -102,6 +102,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/completion@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/completion@jvm213.json
@@ -102,6 +102,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/core-macros@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/core-macros@jvm212.json
@@ -80,6 +80,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/core-macros@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/core-macros@jvm213.json
@@ -80,6 +80,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/logic-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/logic-test@jvm212.json
@@ -107,6 +107,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/logic-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/logic-test@jvm213.json
@@ -106,6 +106,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/logic@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/logic@jvm212.json
@@ -80,6 +80,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/logic@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/logic@jvm213.json
@@ -79,6 +79,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-settings-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-settings-test@jvm212.json
@@ -179,6 +179,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-settings-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-settings-test@jvm213.json
@@ -180,6 +180,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-settings@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-settings@jvm212.json
@@ -153,6 +153,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-settings@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-settings@jvm213.json
@@ -154,6 +154,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-test@jvm212.json
@@ -205,6 +205,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main-test@jvm213.json
@@ -206,6 +206,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main@jvm212.json
@@ -182,6 +182,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/main@jvm213.json
@@ -183,6 +183,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/protocol@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/protocol@jvm212.json
@@ -101,6 +101,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/protocol@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/protocol@jvm213.json
@@ -101,6 +101,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/run-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/run-test@jvm212.json
@@ -129,6 +129,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/run-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/run-test@jvm213.json
@@ -130,6 +130,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/run@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/run@jvm212.json
@@ -106,6 +106,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/run@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/run@jvm213.json
@@ -106,6 +106,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt-client@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt-client@jvm212.json
@@ -139,6 +139,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt-client@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt-client@jvm213.json
@@ -140,6 +140,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt-dependency-tree.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt-dependency-tree.json
@@ -203,6 +203,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt-test.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt-test.json
@@ -207,6 +207,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/sbt.json
@@ -182,6 +182,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripted-plugin@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripted-plugin@jvm212.json
@@ -70,6 +70,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripted-plugin@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripted-plugin@jvm213.json
@@ -68,6 +68,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripted-sbt-redux.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripted-sbt-redux.json
@@ -187,6 +187,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripted-sbt.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripted-sbt.json
@@ -188,6 +188,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/servertestproj-test.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/servertestproj-test.json
@@ -212,6 +212,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/servertestproj.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/servertestproj.json
@@ -210,6 +210,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/task-system-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/task-system-test@jvm212.json
@@ -131,6 +131,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/task-system-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/task-system-test@jvm213.json
@@ -132,6 +132,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/task-system@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/task-system@jvm212.json
@@ -104,6 +104,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/task-system@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/task-system@jvm213.json
@@ -104,6 +104,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/tasks-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/tasks-test@jvm212.json
@@ -107,6 +107,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/tasks-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/tasks-test@jvm213.json
@@ -106,6 +106,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/tasks@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/tasks@jvm212.json
@@ -81,6 +81,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/tasks@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/tasks@jvm213.json
@@ -80,6 +80,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/test-agent.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/test-agent.json
@@ -65,6 +65,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/testing@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/testing@jvm212.json
@@ -106,6 +106,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/testing@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/testing@jvm213.json
@@ -107,6 +107,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-cache-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-cache-test@jvm212.json
@@ -95,6 +95,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-cache-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-cache-test@jvm213.json
@@ -93,6 +93,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-cache@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-cache@jvm212.json
@@ -79,6 +79,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-cache@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-cache@jvm213.json
@@ -77,6 +77,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-control@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-control@jvm212.json
@@ -71,6 +71,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-control@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-control@jvm213.json
@@ -69,6 +69,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-interface.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-interface.json
@@ -67,6 +67,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-logging-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-logging-test@jvm212.json
@@ -121,6 +121,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-logging-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-logging-test@jvm213.json
@@ -121,6 +121,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-logging@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-logging@jvm212.json
@@ -97,6 +97,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-logging@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-logging@jvm213.json
@@ -96,6 +96,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-position-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-position-test@jvm212.json
@@ -89,6 +89,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-position-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-position-test@jvm213.json
@@ -87,6 +87,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-position@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-position@jvm212.json
@@ -72,6 +72,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-position@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-position@jvm213.json
@@ -70,6 +70,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-relation-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-relation-test@jvm212.json
@@ -72,6 +72,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-relation-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-relation-test@jvm213.json
@@ -70,6 +70,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-relation@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-relation@jvm212.json
@@ -70,6 +70,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-relation@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-relation@jvm213.json
@@ -68,6 +68,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-scripted@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-scripted@jvm212.json
@@ -97,6 +97,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-scripted@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-scripted@jvm213.json
@@ -97,6 +97,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-tracking-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-tracking-test@jvm212.json
@@ -97,6 +97,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-tracking-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-tracking-test@jvm213.json
@@ -95,6 +95,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-tracking@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-tracking@jvm212.json
@@ -80,6 +80,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-tracking@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/util-tracking@jvm213.json
@@ -78,6 +78,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/zinc-lm-integration-test@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/zinc-lm-integration-test@jvm212.json
@@ -140,6 +140,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/zinc-lm-integration-test@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/zinc-lm-integration-test@jvm213.json
@@ -141,6 +141,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/zinc-lm-integration@jvm212.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/zinc-lm-integration@jvm212.json
@@ -113,6 +113,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/zinc-lm-integration@jvm213.json
+++ b/snapshot-tests/sbt/bootstrapped/.bleep/builds/normal/.bloop/zinc-lm-integration@jvm213.json
@@ -114,6 +114,7 @@
       "options": [
         "-Xlint",
         "-Xlint:-serial",
+        "-proc:none",
         "-source",
         "1.8",
         "-target",

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm211.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm212.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/bench@jvm213.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@js212.json
@@ -72,7 +72,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@js213.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@jvm211.json
@@ -68,7 +68,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@jvm212.json
@@ -67,7 +67,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@jvm213.json
@@ -70,7 +70,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@native212.json
@@ -76,7 +76,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/common@native213.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest-test@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest-test@jvm211.json
@@ -70,7 +70,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest-test@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest-test@jvm212.json
@@ -70,7 +70,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest-test@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest-test@jvm213.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest@jvm211.json
@@ -68,7 +68,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest@jvm212.json
@@ -68,7 +68,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/communitytest@jvm213.json
@@ -71,7 +71,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@js212.json
@@ -68,7 +68,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@js213.json
@@ -71,7 +71,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@jvm211.json
@@ -64,7 +64,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@jvm212.json
@@ -63,7 +63,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@jvm213.json
@@ -66,7 +66,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@native212.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/io@native213.json
@@ -76,7 +76,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.11.12.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.11.12.json
@@ -76,7 +76,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.12.17.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.12.17.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.12.18.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.12.18.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.12.19.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.12.19.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.12.20.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.12.20.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.13.13.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.13.13.json
@@ -81,7 +81,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.13.14.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.13.14.json
@@ -81,7 +81,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.13.15.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.13.15.json
@@ -81,7 +81,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.13.16.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/metac@jvm2.13.16.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@js212.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@js213.json
@@ -93,7 +93,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@jvm211.json
@@ -86,7 +86,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@jvm212.json
@@ -84,7 +84,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@jvm213.json
@@ -88,7 +88,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@jvm3.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@jvm3.json
@@ -82,7 +82,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@native212.json
@@ -93,7 +93,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/parsers@native213.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scala3treeliftscodegen.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scala3treeliftscodegen.json
@@ -59,7 +59,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scala3treeliftsmacro.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scala3treeliftsmacro.json
@@ -58,7 +58,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta-docs.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta-docs.json
@@ -154,7 +154,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@js212.json
@@ -82,7 +82,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@js213.json
@@ -85,7 +85,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@jvm211.json
@@ -78,7 +78,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@jvm212.json
@@ -77,7 +77,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@jvm213.json
@@ -80,7 +80,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@jvm3.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@jvm3.json
@@ -82,7 +82,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@native212.json
@@ -87,7 +87,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scalameta@native213.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.11.12.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.11.12.json
@@ -76,7 +76,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.12.17.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.12.17.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.12.18.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.12.18.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.12.19.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.12.19.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.12.20.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.12.20.json
@@ -75,7 +75,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.13.13.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.13.13.json
@@ -81,7 +81,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.13.14.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.13.14.json
@@ -81,7 +81,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.13.15.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.13.15.json
@@ -81,7 +81,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.13.16.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metacp@jvm2.13.16.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.11.12.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.11.12.json
@@ -74,7 +74,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.12.17.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.12.17.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.12.18.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.12.18.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.12.19.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.12.19.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.12.20.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.12.20.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.13.13.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.13.13.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.13.14.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.13.14.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.13.15.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.13.15.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.13.16.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-metap@jvm2.13.16.json
@@ -77,7 +77,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.11.12.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.11.12.json
@@ -74,7 +74,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.12.17.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.12.17.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.12.18.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.12.18.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.12.19.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.12.19.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.12.20.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.12.20.json
@@ -73,7 +73,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.13.13.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.13.13.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.13.14.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.13.14.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.13.15.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.13.15.json
@@ -79,7 +79,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.13.16.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-scalac-core@jvm2.13.16.json
@@ -77,7 +77,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@js212.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@js213.json
@@ -96,7 +96,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@jvm211.json
@@ -88,7 +88,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@jvm212.json
@@ -87,7 +87,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@jvm213.json
@@ -91,7 +91,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@native212.json
@@ -96,7 +96,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdb-shared@native213.json
@@ -100,7 +100,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegration@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegration@jvm211.json
@@ -55,7 +55,8 @@
     },
     "java": {
       "options": [
-        "-parameters"
+        "-parameters",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegration@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegration@jvm212.json
@@ -54,7 +54,8 @@
     },
     "java": {
       "options": [
-        "-parameters"
+        "-parameters",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegration@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegration@jvm213.json
@@ -56,7 +56,8 @@
     },
     "java": {
       "options": [
-        "-parameters"
+        "-parameters",
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegrationmacros@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegrationmacros@jvm211.json
@@ -52,7 +52,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegrationmacros@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegrationmacros@jvm212.json
@@ -51,7 +51,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegrationmacros@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/semanticdbintegrationmacros@jvm213.json
@@ -54,7 +54,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@js212.json
@@ -80,7 +80,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@js213.json
@@ -83,7 +83,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@jvm211.json
@@ -78,7 +78,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@jvm212.json
@@ -77,7 +77,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@jvm213.json
@@ -80,7 +80,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@jvm3.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@jvm3.json
@@ -83,7 +83,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@native212.json
@@ -85,7 +85,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testkit@native213.json
@@ -88,7 +88,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@js212.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@js213.json
@@ -125,7 +125,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@jvm211.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@jvm212.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@jvm213.json
@@ -127,7 +127,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@jvm3.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@jvm3.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@native212.json
@@ -128,7 +128,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests-test@native213.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@js212.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@js213.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm211.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm212.json
@@ -119,7 +119,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm213.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm3.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@jvm3.json
@@ -129,7 +129,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@native212.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/tests@native213.json
@@ -129,7 +129,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb-test@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb-test@jvm211.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb-test@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb-test@jvm212.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb-test@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb-test@jvm213.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb@jvm211.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb@jvm212.json
@@ -125,7 +125,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/testssemanticdb@jvm213.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@js212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@js212.json
@@ -93,7 +93,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@js213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@js213.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@jvm211.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@jvm211.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@jvm212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@jvm212.json
@@ -88,7 +88,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@jvm213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@jvm213.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@native212.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@native212.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@native213.json
+++ b/snapshot-tests/scalameta/bootstrapped/.bleep/builds/normal/.bloop/trees@native213.json
@@ -101,7 +101,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/iron-examples.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/iron-examples.json
@@ -167,7 +167,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sbt-openapi-codegen.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sbt-openapi-codegen.json
@@ -194,7 +194,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/scripts.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server-test@jvm212.json
@@ -290,7 +290,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server-test@jvm213.json
@@ -292,7 +292,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server-test@jvm3.json
@@ -269,7 +269,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server@jvm212.json
@@ -118,7 +118,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server@jvm213.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/sttp-mock-server@jvm3.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-grpc-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-grpc-server@jvm212.json
@@ -144,7 +144,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-grpc-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-grpc-server@jvm213.json
@@ -146,7 +146,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-http-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-http-server-test@jvm212.json
@@ -195,7 +195,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-http-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-http-server-test@jvm213.json
@@ -197,7 +197,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-http-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-http-server@jvm212.json
@@ -118,7 +118,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-http-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-akka-http-server@jvm213.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@js212.json
@@ -175,7 +175,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@js213.json
@@ -176,7 +176,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@js3.json
@@ -157,7 +157,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@jvm212.json
@@ -161,7 +161,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@jvm213.json
@@ -163,7 +163,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs-test@jvm3.json
@@ -140,7 +140,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@js212.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@js213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@js3.json
@@ -95,7 +95,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@jvm212.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@jvm213.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-apispec-docs@jvm3.json
@@ -85,7 +85,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats-test@jvm212.json
@@ -237,7 +237,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats-test@jvm213.json
@@ -239,7 +239,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats-test@jvm3.json
@@ -216,7 +216,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats@jvm212.json
@@ -174,7 +174,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats@jvm213.json
@@ -176,7 +176,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-cats@jvm3.json
@@ -155,7 +155,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-test@jvm212.json
@@ -231,7 +231,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-test@jvm213.json
@@ -233,7 +233,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-test@jvm3.json
@@ -210,7 +210,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio-test@jvm212.json
@@ -246,7 +246,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio-test@jvm213.json
@@ -248,7 +248,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio-test@jvm3.json
@@ -225,7 +225,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio@jvm212.json
@@ -168,7 +168,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio@jvm213.json
@@ -170,7 +170,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server-zio@jvm3.json
@@ -149,7 +149,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server@jvm212.json
@@ -155,7 +155,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server@jvm213.json
@@ -157,7 +157,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-armeria-server@jvm3.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs-test@jvm212.json
@@ -176,7 +176,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs-test@jvm213.json
@@ -178,7 +178,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs-test@jvm3.json
@@ -154,7 +154,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs@jvm212.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs@jvm213.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-asyncapi-docs@jvm3.json
@@ -87,7 +87,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-test@jvm212.json
@@ -182,7 +182,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-test@jvm213.json
@@ -184,7 +184,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-test@jvm3.json
@@ -161,7 +161,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-tests-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-tests-test@jvm212.json
@@ -196,7 +196,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-tests-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-tests-test@jvm213.json
@@ -198,7 +198,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-tests@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-tests@jvm212.json
@@ -184,7 +184,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-tests@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk-tests@jvm213.json
@@ -186,7 +186,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk@jvm212.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk@jvm213.json
@@ -147,7 +147,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-cdk@jvm3.json
@@ -125,7 +125,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-examples@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-examples@js212.json
@@ -165,7 +165,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-examples@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-examples@js213.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-examples@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-examples@jvm212.json
@@ -152,7 +152,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-examples@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-examples@jvm213.json
@@ -154,7 +154,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-cats-effect-tests-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-cats-effect-tests-test@jvm212.json
@@ -196,7 +196,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-cats-effect-tests-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-cats-effect-tests-test@jvm213.json
@@ -198,7 +198,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-cats-effect-tests@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-cats-effect-tests@jvm212.json
@@ -184,7 +184,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-cats-effect-tests@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-cats-effect-tests@jvm213.json
@@ -186,7 +186,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core-test@jvm212.json
@@ -159,7 +159,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core-test@jvm213.json
@@ -161,7 +161,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core-test@jvm3.json
@@ -138,7 +138,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@js212.json
@@ -127,7 +127,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@js213.json
@@ -128,7 +128,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@jvm212.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@jvm213.json
@@ -117,7 +117,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-core@jvm3.json
@@ -95,7 +95,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-test@jvm212.json
@@ -177,7 +177,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-test@jvm213.json
@@ -179,7 +179,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-test@jvm3.json
@@ -156,7 +156,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio-tests-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio-tests-test@jvm212.json
@@ -239,7 +239,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio-tests-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio-tests-test@jvm213.json
@@ -241,7 +241,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio-tests@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio-tests@jvm212.json
@@ -227,7 +227,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio-tests@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio-tests@jvm213.json
@@ -229,7 +229,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio@jvm212.json
@@ -164,7 +164,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio@jvm213.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda-zio@jvm3.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@js212.json
@@ -160,7 +160,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@js213.json
@@ -161,7 +161,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@jvm212.json
@@ -140,7 +140,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@jvm213.json
@@ -142,7 +142,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-lambda@jvm3.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam-test@jvm212.json
@@ -160,7 +160,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam-test@jvm213.json
@@ -162,7 +162,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam-test@jvm3.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam@jvm212.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam@jvm213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-sam@jvm3.json
@@ -91,7 +91,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-terraform-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-terraform-test@jvm212.json
@@ -161,7 +161,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-terraform-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-terraform-test@jvm213.json
@@ -163,7 +163,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-terraform@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-terraform@jvm212.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-terraform@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-aws-terraform@jvm213.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@js212.json
@@ -117,7 +117,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@js213.json
@@ -118,7 +118,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@js3.json
@@ -99,7 +99,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@jvm212.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@jvm213.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-effect@jvm3.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@js212.json
@@ -147,7 +147,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@js213.json
@@ -148,7 +148,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@js3.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@jvm212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@jvm213.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@jvm3.json
@@ -121,7 +121,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats-test@native3.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@js212.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@js213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@js3.json
@@ -94,7 +94,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@jvm212.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@jvm213.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@jvm3.json
@@ -85,7 +85,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-cats@native3.json
@@ -99,7 +99,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@js212.json
@@ -156,7 +156,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@js213.json
@@ -157,7 +157,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@js3.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@jvm212.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@jvm213.json
@@ -147,7 +147,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client-tests@jvm3.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@js212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@js213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@js3.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@jvm212.json
@@ -102,7 +102,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@jvm213.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@jvm3.json
@@ -83,7 +83,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-client@native3.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-codegen.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-codegen.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@js212.json
@@ -140,7 +140,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@js213.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@js3.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@jvm212.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@jvm213.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@jvm3.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@native212.json
@@ -146,7 +146,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@native213.json
@@ -147,7 +147,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core-test@native3.json
@@ -129,7 +129,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@js212.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@js213.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@js3.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@jvm212.json
@@ -103,7 +103,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@jvm213.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@jvm3.json
@@ -83,7 +83,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@native212.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@native213.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-core@native3.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics-test@jvm212.json
@@ -156,7 +156,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics-test@jvm213.json
@@ -158,7 +158,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics-test@jvm3.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics@jvm212.json
@@ -119,7 +119,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics@jvm213.json
@@ -121,7 +121,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-datadog-metrics@jvm3.json
@@ -100,7 +100,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-derevo-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-derevo-test@jvm212.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-derevo-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-derevo-test@jvm213.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-derevo@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-derevo@jvm212.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-derevo@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-derevo@jvm213.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@js212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@js213.json
@@ -142,7 +142,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@js3.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@jvm212.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@jvm213.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum-test@jvm3.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@js212.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@js213.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@js3.json
@@ -95,7 +95,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@jvm212.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@jvm213.json
@@ -107,7 +107,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-enumeratum@jvm3.json
@@ -85,7 +85,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-examples.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-examples.json
@@ -505,7 +505,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files-test@jvm212.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files-test@jvm213.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files-test@jvm3.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@js212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@js213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@js3.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@jvm212.json
@@ -102,7 +102,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@jvm213.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@jvm3.json
@@ -83,7 +83,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-files@native3.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-examples@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-examples@jvm212.json
@@ -163,7 +163,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-examples@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-examples@jvm213.json
@@ -165,7 +165,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-protobuf-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-protobuf-test@jvm212.json
@@ -148,7 +148,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-protobuf-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-protobuf-test@jvm213.json
@@ -150,7 +150,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-protobuf@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-protobuf@jvm212.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-protobuf@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-grpc-protobuf@jvm213.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client-test@jvm212.json
@@ -181,7 +181,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client-test@jvm213.json
@@ -183,7 +183,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client-test@jvm3.json
@@ -160,7 +160,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client@jvm212.json
@@ -125,7 +125,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client@jvm213.json
@@ -127,7 +127,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-client@jvm3.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-test@jvm212.json
@@ -198,7 +198,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-test@jvm213.json
@@ -200,7 +200,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-test@jvm3.json
@@ -177,7 +177,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio-test@jvm212.json
@@ -212,7 +212,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio-test@jvm213.json
@@ -214,7 +214,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio-test@jvm3.json
@@ -192,7 +192,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio@jvm212.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio@jvm213.json
@@ -147,7 +147,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server-zio@jvm3.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server@jvm212.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server@jvm213.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-http4s-server@jvm3.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron-test@js3.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron-test@jvm3.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron-test@native3.json
@@ -129,7 +129,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron@js3.json
@@ -93,7 +93,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron@jvm3.json
@@ -84,7 +84,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-iron@native3.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jdkhttp-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jdkhttp-server-test@jvm213.json
@@ -189,7 +189,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jdkhttp-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jdkhttp-server-test@jvm3.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jdkhttp-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jdkhttp-server@jvm213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jdkhttp-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jdkhttp-server@jvm3.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe-test@jvm212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe-test@jvm213.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe-test@jvm3.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@js212.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@js213.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@js3.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@jvm212.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@jvm213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@jvm3.json
@@ -91,7 +91,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-circe@native3.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s-test@jvm212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s-test@jvm213.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s@jvm212.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s@jvm213.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-json4s@jvm3.json
@@ -87,7 +87,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-pickler-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-pickler-test@js3.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-pickler-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-pickler-test@jvm3.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-pickler@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-pickler@js3.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-pickler@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-pickler@jvm3.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@js212.json
@@ -142,7 +142,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@js213.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@js3.json
@@ -125,7 +125,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@jvm212.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@jvm213.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play-test@jvm3.json
@@ -119,7 +119,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@js212.json
@@ -144,7 +144,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@js213.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@js3.json
@@ -127,7 +127,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@jvm212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@jvm213.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29-test@jvm3.json
@@ -121,7 +121,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@js212.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@js213.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@js3.json
@@ -96,7 +96,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@jvm212.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@jvm213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play29@jvm3.json
@@ -91,7 +91,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@js212.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@js213.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@js3.json
@@ -95,7 +95,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@jvm212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@jvm213.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-play@jvm3.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray-test@jvm212.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray-test@jvm213.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray-test@jvm3.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray@jvm212.json
@@ -103,7 +103,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray@jvm213.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-spray@jvm3.json
@@ -84,7 +84,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys-test@jvm212.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys-test@jvm213.json
@@ -138,7 +138,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys-test@jvm3.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys@jvm212.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys@jvm213.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-tethys@jvm3.json
@@ -86,7 +86,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@js212.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@js213.json
@@ -146,7 +146,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@js3.json
@@ -128,7 +128,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@jvm212.json
@@ -138,7 +138,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@jvm213.json
@@ -140,7 +140,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@jvm3.json
@@ -118,7 +118,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle-test@native3.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@js212.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@js213.json
@@ -117,7 +117,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@js3.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@jvm212.json
@@ -108,7 +108,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@jvm213.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@jvm3.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-upickle@native3.json
@@ -103,7 +103,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@js212.json
@@ -148,7 +148,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@js213.json
@@ -149,7 +149,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@js3.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@jvm212.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@jvm213.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@jvm3.json
@@ -119,7 +119,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@native212.json
@@ -152,7 +152,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@native213.json
@@ -153,7 +153,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio-test@native3.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@js212.json
@@ -119,7 +119,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@js213.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@js3.json
@@ -101,7 +101,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@jvm212.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@jvm213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@jvm3.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@native212.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@native213.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-json-zio@native3.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@js212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@js213.json
@@ -142,7 +142,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@js3.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@jvm212.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@jvm213.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@jvm3.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala-test@native3.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@js212.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@js213.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@js3.json
@@ -93,7 +93,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@jvm212.json
@@ -103,7 +103,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@jvm213.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@jvm3.json
@@ -84,7 +84,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-jsoniter-scala@native3.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@js212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@js213.json
@@ -142,7 +142,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@js3.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@jvm212.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@jvm213.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype-test@jvm3.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@js212.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@js213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@js3.json
@@ -93,7 +93,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@jvm212.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@jvm213.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-monix-newtype@jvm3.json
@@ -84,7 +84,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats-test@jvm212.json
@@ -231,7 +231,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats-test@jvm213.json
@@ -233,7 +233,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats-test@jvm3.json
@@ -210,7 +210,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats@jvm212.json
@@ -168,7 +168,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats@jvm213.json
@@ -170,7 +170,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-cats@jvm3.json
@@ -149,7 +149,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-sync-test.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-sync-test.json
@@ -211,7 +211,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-sync.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-sync.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-test@jvm212.json
@@ -227,7 +227,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-test@jvm213.json
@@ -229,7 +229,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-test@jvm3.json
@@ -206,7 +206,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio-test@jvm212.json
@@ -242,7 +242,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio-test@jvm213.json
@@ -244,7 +244,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio-test@jvm3.json
@@ -222,7 +222,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio@jvm212.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio@jvm213.json
@@ -168,7 +168,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server-zio@jvm3.json
@@ -159,7 +159,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server@jvm212.json
@@ -153,7 +153,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server@jvm213.json
@@ -155,7 +155,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-netty-server@jvm3.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype-test@js212.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype-test@js213.json
@@ -142,7 +142,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype-test@jvm212.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype-test@jvm213.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype@js212.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype@js213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype@jvm212.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-newtype@jvm213.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-nima-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-nima-server-test@jvm213.json
@@ -213,7 +213,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-nima-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-nima-server-test@jvm3.json
@@ -190,7 +190,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-nima-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-nima-server@jvm213.json
@@ -136,7 +136,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-nima-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-nima-server@jvm3.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-codegen-core-test.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-codegen-core-test.json
@@ -169,7 +169,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-codegen-core.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-codegen-core.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs-test@jvm212.json
@@ -173,7 +173,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs-test@jvm213.json
@@ -175,7 +175,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs-test@jvm3.json
@@ -148,7 +148,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@js212.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@js213.json
@@ -117,7 +117,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@js3.json
@@ -99,7 +99,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@jvm212.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@jvm213.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-docs@jvm3.json
@@ -89,7 +89,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@js212.json
@@ -185,7 +185,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@js213.json
@@ -186,7 +186,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@js3.json
@@ -167,7 +167,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@jvm212.json
@@ -175,7 +175,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@jvm213.json
@@ -177,7 +177,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier-test@jvm3.json
@@ -150,7 +150,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@js212.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@js213.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@js3.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@jvm212.json
@@ -129,7 +129,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@jvm213.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-openapi-verifier@jvm3.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics-test@jvm212.json
@@ -150,7 +150,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics-test@jvm213.json
@@ -152,7 +152,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics-test@jvm3.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics@jvm212.json
@@ -107,7 +107,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics@jvm213.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-metrics@jvm3.json
@@ -88,7 +88,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing-test@jvm212.json
@@ -150,7 +150,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing-test@jvm213.json
@@ -152,7 +152,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing-test@jvm3.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing@jvm212.json
@@ -107,7 +107,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing@jvm213.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-opentelemetry-tracing@jvm3.json
@@ -88,7 +88,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-otel4s-tracing-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-otel4s-tracing-test@jvm213.json
@@ -175,7 +175,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-otel4s-tracing-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-otel4s-tracing-test@jvm3.json
@@ -153,7 +153,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-otel4s-tracing@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-otel4s-tracing@jvm213.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-otel4s-tracing@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-otel4s-tracing@jvm3.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-examples@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-examples@jvm212.json
@@ -165,7 +165,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-examples@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-examples@jvm213.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-server@jvm212.json
@@ -146,7 +146,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-server@jvm213.json
@@ -147,7 +147,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-grpc-server@jvm3.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server-test@jvm212.json
@@ -195,7 +195,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server-test@jvm213.json
@@ -196,7 +196,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server-test@jvm3.json
@@ -173,7 +173,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server@jvm212.json
@@ -118,7 +118,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server@jvm213.json
@@ -119,7 +119,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-pekko-http-server@jvm3.json
@@ -98,7 +98,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-perf-tests-test.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-perf-tests-test.json
@@ -420,7 +420,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-perf-tests.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-perf-tests.json
@@ -297,7 +297,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-client-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-client-test@jvm213.json
@@ -177,7 +177,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-client-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-client-test@jvm3.json
@@ -154,7 +154,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-client@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-client@jvm213.json
@@ -121,7 +121,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-client@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-client@jvm3.json
@@ -100,7 +100,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-server-test@jvm213.json
@@ -231,7 +231,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-server-test@jvm3.json
@@ -208,7 +208,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-server@jvm213.json
@@ -157,7 +157,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play-server@jvm3.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-client-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-client-test@jvm213.json
@@ -178,7 +178,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-client-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-client-test@jvm3.json
@@ -155,7 +155,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-client@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-client@jvm213.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-client@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-client@jvm3.json
@@ -101,7 +101,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-server-test@jvm213.json
@@ -231,7 +231,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-server-test@jvm3.json
@@ -217,7 +217,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-server@jvm213.json
@@ -157,7 +157,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-play29-server@jvm3.json
@@ -144,7 +144,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics-test@jvm212.json
@@ -152,7 +152,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics-test@jvm213.json
@@ -154,7 +154,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics-test@jvm3.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics@jvm212.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics@jvm213.json
@@ -117,7 +117,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-prometheus-metrics@jvm3.json
@@ -96,7 +96,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-protobuf-pbdirect@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-protobuf-pbdirect@jvm212.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-protobuf-pbdirect@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-protobuf-pbdirect@jvm213.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle-test@jvm212.json
@@ -199,7 +199,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle-test@jvm213.json
@@ -201,7 +201,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle-test@jvm3.json
@@ -174,7 +174,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle@jvm212.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle@jvm213.json
@@ -134,7 +134,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc-bundle@jvm3.json
@@ -107,7 +107,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@js212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@js213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@js3.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@jvm212.json
@@ -102,7 +102,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@jvm213.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-redoc@jvm3.json
@@ -83,7 +83,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@js212.json
@@ -158,7 +158,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@js213.json
@@ -160,7 +160,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@js3.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@jvm212.json
@@ -146,7 +146,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@jvm213.json
@@ -150,7 +150,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined-test@jvm3.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@js212.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@js213.json
@@ -117,7 +117,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@js3.json
@@ -93,7 +93,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@jvm212.json
@@ -107,7 +107,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@jvm213.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-refined@jvm3.json
@@ -84,7 +84,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@js212.json
@@ -144,7 +144,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@js213.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@js3.json
@@ -127,7 +127,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@jvm212.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@jvm213.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@jvm3.json
@@ -117,7 +117,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@native212.json
@@ -150,7 +150,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@native213.json
@@ -151,7 +151,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-test@native3.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-tests@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-tests@jvm212.json
@@ -168,7 +168,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-tests@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-tests@jvm213.json
@@ -170,7 +170,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-tests@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server-tests@jvm3.json
@@ -147,7 +147,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@js212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@js213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@js3.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@jvm212.json
@@ -102,7 +102,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@jvm213.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@jvm3.json
@@ -83,7 +83,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@native212.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@native213.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-server@native3.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@js212.json
@@ -189,7 +189,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@js213.json
@@ -190,7 +190,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@js3.json
@@ -172,7 +172,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@jvm212.json
@@ -216,7 +216,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@jvm213.json
@@ -218,7 +218,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client-test@jvm3.json
@@ -186,7 +186,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@js212.json
@@ -206,7 +206,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@js213.json
@@ -207,7 +207,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@js3.json
@@ -189,7 +189,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@jvm212.json
@@ -202,7 +202,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@jvm213.json
@@ -204,7 +204,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4-test@jvm3.json
@@ -172,7 +172,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@js212.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@js213.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@js3.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@jvm212.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@jvm213.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client4@jvm3.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@js212.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@js213.json
@@ -132,7 +132,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@js3.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@jvm212.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@jvm213.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-client@jvm3.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server-test@jvm212.json
@@ -164,7 +164,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server-test@jvm213.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server-test@jvm3.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server@jvm212.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server@jvm213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub-server@jvm3.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@js212.json
@@ -177,7 +177,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@js213.json
@@ -178,7 +178,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@js3.json
@@ -160,7 +160,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@jvm212.json
@@ -164,7 +164,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@jvm213.json
@@ -166,7 +166,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server-test@jvm3.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@js212.json
@@ -118,7 +118,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@js213.json
@@ -119,7 +119,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@js3.json
@@ -100,7 +100,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@jvm212.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@jvm213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-sttp-stub4-server@jvm3.json
@@ -90,7 +90,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle-test@jvm212.json
@@ -202,7 +202,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle-test@jvm213.json
@@ -204,7 +204,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle-test@jvm3.json
@@ -177,7 +177,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle@jvm212.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle@jvm213.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-bundle@jvm3.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-test@jvm212.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-test@jvm213.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui-test@jvm3.json
@@ -115,7 +115,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui@jvm212.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui@jvm213.json
@@ -107,7 +107,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-swagger-ui@jvm3.json
@@ -86,7 +86,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@js212.json
@@ -157,7 +157,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@js213.json
@@ -158,7 +158,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@js3.json
@@ -140,7 +140,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@jvm212.json
@@ -146,7 +146,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@jvm213.json
@@ -148,7 +148,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@jvm3.json
@@ -125,7 +125,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing-test@native3.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@js212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@js213.json
@@ -111,7 +111,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@js3.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@jvm212.json
@@ -102,7 +102,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@jvm213.json
@@ -104,7 +104,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@jvm3.json
@@ -83,7 +83,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-testing@native3.json
@@ -97,7 +97,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@js212.json
@@ -154,7 +154,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@js213.json
@@ -155,7 +155,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@js3.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@jvm212.json
@@ -143,7 +143,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@jvm213.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-tests@jvm3.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats-test@jvm212.json
@@ -207,7 +207,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats-test@jvm213.json
@@ -209,7 +209,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats-test@jvm3.json
@@ -186,7 +186,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats@jvm212.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats@jvm213.json
@@ -141,7 +141,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-cats@jvm3.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-test@jvm212.json
@@ -202,7 +202,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-test@jvm213.json
@@ -204,7 +204,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-test@jvm3.json
@@ -181,7 +181,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio-test@jvm212.json
@@ -217,7 +217,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio-test@jvm213.json
@@ -219,7 +219,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio-test@jvm3.json
@@ -197,7 +197,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio@jvm212.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio@jvm213.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server-zio@jvm3.json
@@ -116,7 +116,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server@jvm212.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server@jvm213.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-vertx-server@jvm3.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server-test@jvm212.json
@@ -225,7 +225,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server-test@jvm213.json
@@ -227,7 +227,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server-test@jvm3.json
@@ -205,7 +205,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server@jvm212.json
@@ -146,7 +146,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server@jvm213.json
@@ -148,7 +148,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-http-server@jvm3.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics-test@jvm212.json
@@ -151,7 +151,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics-test@jvm213.json
@@ -153,7 +153,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics-test@jvm3.json
@@ -131,7 +131,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics@jvm212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics@jvm213.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-metrics@jvm3.json
@@ -91,7 +91,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@js212.json
@@ -151,7 +151,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@js213.json
@@ -152,7 +152,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@js3.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@jvm212.json
@@ -142,7 +142,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@jvm213.json
@@ -144,7 +144,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@jvm3.json
@@ -121,7 +121,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@native212.json
@@ -155,7 +155,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@native213.json
@@ -156,7 +156,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude-test@native3.json
@@ -137,7 +137,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@js212.json
@@ -122,7 +122,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@js213.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@js3.json
@@ -103,7 +103,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@jvm212.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@jvm213.json
@@ -114,7 +114,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@jvm3.json
@@ -92,7 +92,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@native212.json
@@ -125,7 +125,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@native213.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-prelude@native3.json
@@ -106,7 +106,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@js212.json
@@ -139,7 +139,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@js213.json
@@ -140,7 +140,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@js3.json
@@ -121,7 +121,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@jvm212.json
@@ -128,7 +128,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@jvm213.json
@@ -130,7 +130,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@jvm3.json
@@ -109,7 +109,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@native212.json
@@ -144,7 +144,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@native213.json
@@ -145,7 +145,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio-test@native3.json
@@ -126,7 +126,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "test": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@js212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@js212.json
@@ -120,7 +120,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@js213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@js213.json
@@ -121,7 +121,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@js3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@js3.json
@@ -102,7 +102,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@jvm212.json
@@ -110,7 +110,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@jvm213.json
@@ -112,7 +112,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@jvm3.json
@@ -91,7 +91,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@native212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@native212.json
@@ -123,7 +123,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@native213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@native213.json
@@ -124,7 +124,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@native3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/tapir-zio@native3.json
@@ -105,7 +105,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/testing-server@jvm212.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/testing-server@jvm212.json
@@ -133,7 +133,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/testing-server@jvm213.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/testing-server@jvm213.json
@@ -135,7 +135,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {

--- a/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/testing-server@jvm3.json
+++ b/snapshot-tests/tapir/bootstrapped/.bleep/builds/normal/.bloop/testing-server@jvm3.json
@@ -113,7 +113,7 @@
     },
     "java": {
       "options": [
-        
+        "-proc:none"
       ]
     },
     "platform": {


### PR DESCRIPTION
## Summary
Implements Java annotation processor support in bleep with an explicit opt-in design. Annotation processing is disabled by default and must be explicitly enabled.

## Design Principles
- **Disabled by default** - No automatic discovery of processors
- **Explicit opt-in** - Must set `enabled: true` to use processors
- **Simple configuration** - Just one boolean flag
- **Clean generated sources** - Fixed location in `.bleep/generated-sources/{project-name}/annotations/`

## Usage
```yaml
# Enable annotation processing (auto-discovery via ServiceLoader)
projects:
  my-app:
    dependencies:
      - org.projectlombok:lombok:1.18.30
    java:
      annotationProcessing:
        enabled: true
```

## Implementation
- When enabled: Adds `-s .bleep/generated-sources/{project-name}/annotations/` to javac
- When disabled (default): Adds `-proc:none` to javac
- Generated sources automatically added to project sources
- Validates against manual `-proc:*` or `-s` options

## Future Extensibility
The JSON schema design allows us to add a full specification later where users can explicitly specify which processors they want to run, without breaking existing configurations. The current boolean flag can be extended to support more detailed processor configuration when needed.

## Testing
- Unit tests for Java model configuration
- Integration tests verify annotation processor behavior

Based on design document: `/Users/oyvind/bleep-annotation-processor-design.md`

🤖 Generated with [Claude Code](https://claude.ai/code)