### PR TITLE
Add 'java' project glob for Java-only projects

### DIFF
--- a/bleep-model/src/scala/bleep/model/ProjectGlobs.scala
+++ b/bleep-model/src/scala/bleep/model/ProjectGlobs.scala
@@ -21,8 +21,15 @@ class ProjectGlobs(activeProjectsFromPath: Option[Array[CrossProjectName]], expl
           }
         }
         .collect { case (Some(crossId), names) => (crossId.value, names) }
+    val javaProjects: Map[String, Array[CrossProjectName]] = {
+      val javaOnly = projects.filter { name =>
+        val p = explodedProjects(name)
+        p.scala.flatMap(_.version).isEmpty
+      }
+      if (javaOnly.nonEmpty) Map("java" -> javaOnly) else Map.empty
+    }
 
-    crossIds ++ projectNames ++ crossNames
+    javaProjects ++ crossIds ++ projectNames ++ crossNames
   }
 
   def exactProjectMap: Map[String, CrossProjectName] =


### PR DESCRIPTION
## Summary
- Adds a new grouping key `"java"` in `ProjectGlobs` that matches all projects without a Scala version
- Similar to how `jvm3`, `jvm213`, etc. group projects by cross ID, this allows targeting Java-only projects
- Enables commands like `bleep compile java` to compile all Java-only projects at once

## Test plan
- [ ] Verify `bleep projects` shows `java` as a valid glob when Java projects exist
- [ ] Test `bleep compile java` targets only projects without Scala

🤖 Generated with [Claude Code](https://claude.com/claude-code)