### PR TITLE
Add extract-info command for IDE integration

### DIFF
--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -290,6 +290,9 @@ object Main {
           ),
           Opts.subcommand("extract-info", "JSON output for IDE integration")(
             List(
+              Opts.subcommand("all", "output all info in a single JSON object")(
+                Opts(commands.ExtractInfo.All)
+              ),
               Opts.subcommand("project-graph", "output all projects with their dependencies")(
                 Opts(commands.ExtractInfo.ProjectGraph)
               ),


### PR DESCRIPTION
## Summary
- Adds `bleep extract-info` command with subcommands for IDE integration
- Subcommands: `project-graph`, `project-groups`, `scripts`, `sourcegen`, `all`
- Outputs JSON for easy parsing by IDEs and tooling
- The `all` subcommand returns aggregated data in a single call for efficiency

## Test plan
- [x] Run `bleep extract-info project-graph` and verify JSON output
- [x] Run `bleep extract-info all` and verify it contains all data
- [x] Integration with IntelliJ plugin (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)