### PR TITLE
fix: remove errors from completions

### DIFF
--- a/bleep-cli/src/scala/bleep/commands/InstallBashTabCompletions.scala
+++ b/bleep-cli/src/scala/bleep/commands/InstallBashTabCompletions.scala
@@ -17,7 +17,7 @@ case class InstallBashTabCompletions(logger: Logger, stdout: Boolean) extends Bl
 
     val completionScript =
       s"""_${programName}_completions() {
-        |  COMPREPLY=($$(bleep _complete "$${COMP_LINE}" "$${COMP_CWORD}" "$${COMP_POINT}"))
+        |  COMPREPLY=($$(bleep _complete "$${COMP_LINE}" "$${COMP_CWORD}" "$${COMP_POINT}" 2>/dev/null))
         |}
         |
         |complete -F _${programName}_completions $programName""".stripMargin

--- a/bleep-cli/src/scala/bleep/commands/InstallZshTabCompletions.scala
+++ b/bleep-cli/src/scala/bleep/commands/InstallZshTabCompletions.scala
@@ -21,7 +21,7 @@ case class InstallZshTabCompletions(userPaths: UserPaths, logger: Logger, stdout
       s"""#compdef _$programName $programName
          |
          |function _$programName {
-         |  eval "$$($programName _complete-zsh $$CURRENT $$words[@])"
+         |  eval "$$($programName _complete-zsh $$CURRENT $$words[@] 2>/dev/null)"
          |}
          |""".stripMargin
 


### PR DESCRIPTION
Remove warnings related to usage of unsafe when using completion. This is more a workaround since it does not fix the underlying problem, however it makes the completions usable agian.