### PR TITLE
feat: add .javafmt.conf configuration support for Java formatting

### DIFF
--- a/bleep-cli/src/scala/bleep/commands/Fmt.scala
+++ b/bleep-cli/src/scala/bleep/commands/Fmt.scala
@@ -2,23 +2,13 @@ package bleep
 package commands
 
 import bleep.internal.FileUtils
+import com.typesafe.config.ConfigFactory
 
-import java.nio.file.{Files, Path}
+import java.nio.file.{FileSystems, Files, Path}
+import scala.jdk.CollectionConverters._
 import scala.jdk.StreamConverters.StreamHasToScala
 
 object Fmt {
-  val defaultScalafmtConfig =
-    """version=3.5.9
-      |maxColumn = 160
-      |runner.dialect = scala213
-      |""".stripMargin
-
-  def getScalafmtVersion(configStr: String): Option[String] =
-    configStr
-      .lines()
-      .map(_.split("=").map(_.trim))
-      .toScala(List)
-      .collectFirst { case Array("version", version) => version.stripPrefix("\"").stripSuffix("\"") }
 
   def findSourceFiles(dirs: Set[Path], extension: String): List[Path] =
     dirs.toList.flatMap { dir =>
@@ -28,6 +18,149 @@ object Fmt {
         }
       } else Nil
     }
+
+  /** Scala formatting support via scalafmt */
+  object ScalaFmt {
+    val defaultConfig: String =
+      """version=3.5.9
+        |maxColumn = 160
+        |runner.dialect = scala213
+        |""".stripMargin
+
+    def getVersion(configStr: String): Option[String] =
+      configStr
+        .lines()
+        .map(_.split("=").map(_.trim))
+        .toScala(List)
+        .collectFirst { case Array("version", version) => version.stripPrefix("\"").stripSuffix("\"") }
+  }
+
+  /** Java formatting support via google-java-format */
+  object JavaFmt {
+
+    /** Configuration for Java code formatting via google-java-format.
+      *
+      * @param enabled
+      *   Whether Java formatting is enabled
+      * @param version
+      *   Version of google-java-format to use
+      * @param style
+      *   Formatting style: "google" (2-space indent) or "aosp" (4-space indent)
+      * @param skipSortingImports
+      *   Don't sort import statements
+      * @param skipRemovingUnusedImports
+      *   Keep unused import statements
+      * @param fixImportsOnly
+      *   Only fix imports, don't reformat code
+      * @param skipReflowingLongStrings
+      *   Don't reformat long strings
+      * @param skipJavadocFormatting
+      *   Don't reformat Javadoc comments
+      * @param excludePaths
+      *   Glob patterns for files to exclude from formatting
+      */
+    case class JavaFmtConfig(
+        enabled: Boolean,
+        version: String,
+        style: String,
+        skipSortingImports: Boolean,
+        skipRemovingUnusedImports: Boolean,
+        fixImportsOnly: Boolean,
+        skipReflowingLongStrings: Boolean,
+        skipJavadocFormatting: Boolean,
+        excludePaths: List[String]
+    )
+
+    object JavaFmtConfig {
+      val default: JavaFmtConfig = JavaFmtConfig(
+        enabled = true,
+        version = FetchGoogleJavaFormat.DefaultVersion,
+        style = "google",
+        skipSortingImports = false,
+        skipRemovingUnusedImports = false,
+        fixImportsOnly = false,
+        skipReflowingLongStrings = false,
+        skipJavadocFormatting = false,
+        excludePaths = Nil
+      )
+    }
+
+    private val defaultHocon: String =
+      s"""|enabled = true
+          |version = "${FetchGoogleJavaFormat.DefaultVersion}"
+          |style = "google"
+          |skipSortingImports = false
+          |skipRemovingUnusedImports = false
+          |fixImportsOnly = false
+          |skipReflowingLongStrings = false
+          |skipJavadocFormatting = false
+          |excludePaths = []
+          |""".stripMargin
+
+    /** Parses a .javafmt.conf file using HOCON and returns a JavaFmtConfig. */
+    def parseConfig(configStr: String): JavaFmtConfig = {
+      val hocon = ConfigFactory.parseString(configStr).withFallback(ConfigFactory.parseString(defaultHocon)).resolve()
+
+      JavaFmtConfig(
+        enabled = hocon.getBoolean("enabled"),
+        version = hocon.getString("version"),
+        style = hocon.getString("style"),
+        skipSortingImports = hocon.getBoolean("skipSortingImports"),
+        skipRemovingUnusedImports = hocon.getBoolean("skipRemovingUnusedImports"),
+        fixImportsOnly = hocon.getBoolean("fixImportsOnly"),
+        skipReflowingLongStrings = hocon.getBoolean("skipReflowingLongStrings"),
+        skipJavadocFormatting = hocon.getBoolean("skipJavadocFormatting"),
+        excludePaths = hocon.getStringList("excludePaths").asScala.toList
+      )
+    }
+
+    /** Reads and parses .javafmt.conf from the build directory, returning default config if not found. */
+    def getConfig(buildDir: Path): JavaFmtConfig = {
+      val configPath = buildDir.resolve(".javafmt.conf")
+      if (FileUtils.exists(configPath)) {
+        parseConfig(Files.readString(configPath))
+      } else {
+        JavaFmtConfig.default
+      }
+    }
+
+    /** Checks if a path matches any of the exclusion glob patterns. */
+    def matchesExcludePattern(path: Path, buildDir: Path, patterns: List[String]): Boolean = {
+      val fs = FileSystems.getDefault
+      val relativePath = buildDir.relativize(path)
+      patterns.exists { pattern =>
+        val globPattern = pattern.stripPrefix("glob:")
+        val matcher = fs.getPathMatcher(s"glob:$globPattern")
+        matcher.matches(relativePath) || matcher.matches(path)
+      }
+    }
+
+    /** Builds CLI flags for google-java-format based on config. */
+    def buildFlags(config: JavaFmtConfig): List[String] = {
+      val flags = List.newBuilder[String]
+
+      if (config.style.toLowerCase == "aosp") {
+        flags += "--aosp"
+      }
+      if (config.skipSortingImports) {
+        flags += "--skip-sorting-imports"
+      }
+      if (config.skipRemovingUnusedImports) {
+        flags += "--skip-removing-unused-imports"
+      }
+      if (config.fixImportsOnly) {
+        flags += "--fix-imports-only"
+      }
+      if (config.skipReflowingLongStrings) {
+        flags += "--skip-reflowing-long-strings"
+      }
+      if (config.skipJavadocFormatting) {
+        flags += "--skip-javadoc-formatting"
+      }
+
+      flags.result()
+    }
+  }
 }
 
 case class Fmt(check: Boolean) extends BleepBuildCommand {
@@ -78,12 +211,12 @@ case class Fmt(check: Boolean) extends BleepBuildCommand {
       if (FileUtils.exists(configPath)) {
         Files.readString(configPath)
       } else {
-        FileUtils.writeString(started.logger, Some("Creating example scalafmt configuration"), configPath, Fmt.defaultScalafmtConfig)
-        Fmt.defaultScalafmtConfig
+        FileUtils.writeString(started.logger, Some("Creating example scalafmt configuration"), configPath, Fmt.ScalaFmt.defaultConfig)
+        Fmt.ScalaFmt.defaultConfig
       }
 
-    val version = Fmt
-      .getScalafmtVersion(configStr)
+    val version = Fmt.ScalaFmt
+      .getVersion(configStr)
       .getOrElse(throw new BleepException.Text(s"Couldn't naively extract scalafmt version from $configPath"))
 
     val scalafmt = FetchScalafmt(started.pre.cacheLogger, started.executionContext, version)
@@ -105,32 +238,56 @@ case class Fmt(check: Boolean) extends BleepBuildCommand {
   }
 
   private def formatJava(started: Started, javaFiles: List[Path]): Unit = {
-    val googleJavaFormat = FetchGoogleJavaFormat(started.pre.cacheLogger, started.executionContext, FetchGoogleJavaFormat.DefaultVersion)
+    val config = Fmt.JavaFmt.getConfig(started.buildPaths.buildDir)
 
-    started.logger.withContext("google-java-format", googleJavaFormat).debug("Using google-java-format")
+    if (!config.enabled) {
+      started.logger.debug("Java formatting disabled via .javafmt.conf")
+    } else {
+      // Filter files based on exclude patterns from config
+      val filteredFiles = if (config.excludePaths.nonEmpty) {
+        javaFiles.filterNot(path => Fmt.JavaFmt.matchesExcludePattern(path, started.buildPaths.buildDir, config.excludePaths))
+      } else {
+        javaFiles
+      }
 
-    val javaCmd = started.jvmCommand.toString
+      if (filteredFiles.isEmpty) {
+        started.logger.info("No Java files to format after applying exclusions")
+      } else {
+        started.logger.info(s"Using google-java-format version ${config.version}")
 
-    val jvmFlags = List(
-      "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-      "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-      "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-      "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-      "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-      "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-    )
+        val googleJavaFormat = FetchGoogleJavaFormat(started.pre.cacheLogger, started.executionContext, config.version)
 
-    val cmd =
-      List(javaCmd) ++ jvmFlags ++ List("-jar", googleJavaFormat.toString) ++
-        (if (check) List("--dry-run", "--set-exit-if-changed") else List("--replace")) ++
-        javaFiles.map(_.toString)
+        started.logger
+          .withContext("google-java-format", googleJavaFormat)
+          .withContext("style", config.style)
+          .debug("Using google-java-format")
 
-    cli(
-      "google-java-format",
-      started.buildPaths.cwd,
-      cmd,
-      logger = started.logger,
-      out = cli.Out.ViaLogger(started.logger)
-    ).discard()
+        val javaCmd = started.jvmCommand.toString
+
+        val jvmFlags = List(
+          "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        )
+
+        val configFlags = Fmt.JavaFmt.buildFlags(config)
+        val modeFlags = if (check) List("--dry-run", "--set-exit-if-changed") else List("--replace")
+
+        val cmd =
+          List(javaCmd) ++ jvmFlags ++ List("-jar", googleJavaFormat.toString) ++
+            configFlags ++ modeFlags ++ filteredFiles.map(_.toString)
+
+        cli(
+          "google-java-format",
+          started.buildPaths.cwd,
+          cmd,
+          logger = started.logger,
+          out = cli.Out.ViaLogger(started.logger)
+        ).discard()
+      }
+    }
   }
 }

--- a/bleep-site-in/usage/fmt.mdx
+++ b/bleep-site-in/usage/fmt.mdx
@@ -1,0 +1,67 @@
+
+# Code Formatting
+
+Bleep provides a unified `fmt` command that formats both Scala and Java source files in your project.
+
+## Basic Usage
+
+```shell
+# Format all source files
+bleep fmt
+
+# Check formatting without making changes (useful for CI)
+bleep fmt --check
+```
+
+## Scala Formatting
+
+Bleep uses [scalafmt](https://scalameta.org/scalafmt/) for Scala code formatting.
+
+Configuration is done via `.scalafmt.conf` in your build directory. If no config exists, bleep creates a default one.
+
+For full configuration options, see the [scalafmt documentation](https://scalameta.org/scalafmt/docs/configuration.html).
+
+**Example `.scalafmt.conf`:**
+```hocon
+version = 3.8.6
+maxColumn = 120
+runner.dialect = scala3
+```
+
+## Java Formatting
+
+Bleep uses [google-java-format](https://github.com/google/google-java-format) for Java code formatting.
+
+Configuration is optional via `.javafmt.conf` in your build directory. If no config file exists, defaults are used.
+
+### Configuration Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `enabled` | boolean | `true` | Whether Java formatting is enabled |
+| `version` | string | `1.33.0` | Version of google-java-format to use |
+| `style` | string | `google` | Formatting style: `google` (2-space indent) or `aosp` (4-space indent) |
+| `skipSortingImports` | boolean | `false` | Don't sort import statements |
+| `skipRemovingUnusedImports` | boolean | `false` | Keep unused import statements |
+| `fixImportsOnly` | boolean | `false` | Only fix imports, don't reformat code |
+| `skipReflowingLongStrings` | boolean | `false` | Don't reformat long strings |
+| `skipJavadocFormatting` | boolean | `false` | Don't reformat Javadoc comments |
+| `excludePaths` | list | `[]` | Glob patterns for files to exclude |
+
+**Example `.javafmt.conf`:**
+```hocon
+version = 1.33.0
+style = aosp
+
+# Skip Javadoc formatting
+skipJavadocFormatting = true
+
+# Exclude generated files
+excludePaths = ["glob:**/generated/**", "glob:**/build/**"]
+```
+
+### Notes
+
+- Line length is fixed at 100 characters (google-java-format design decision)
+- Indentation is fixed per style (2-space for Google, 4-space for AOSP)
+- Files in `liberated/` directories are automatically excluded

--- a/bleep-tests/src/scala/bleep/JavaFmtTest.scala
+++ b/bleep-tests/src/scala/bleep/JavaFmtTest.scala
@@ -1,0 +1,92 @@
+package bleep
+
+import bleep.commands.Fmt
+import org.scalactic.TripleEqualsSupport
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.file.Paths
+
+class JavaFmtTest extends AnyFunSuite with TripleEqualsSupport {
+
+  test("parseConfig returns default config for empty input") {
+    val config = Fmt.JavaFmt.parseConfig("")
+    assert(config === Fmt.JavaFmt.JavaFmtConfig.default)
+    assert(config.enabled === true)
+  }
+
+  test("parseConfig parses enabled = false") {
+    val input = "enabled = false"
+    val config = Fmt.JavaFmt.parseConfig(input)
+    assert(config.enabled === false)
+  }
+
+  test("parseConfig parses all options") {
+    val input =
+      """enabled = true
+        |version = 1.20.0
+        |style = aosp
+        |skipJavadocFormatting = true
+        |excludePaths = ["glob:**/generated/**", "glob:**/build/**"]
+        |""".stripMargin
+    val config = Fmt.JavaFmt.parseConfig(input)
+    assert(config.enabled === true)
+    assert(config.version === "1.20.0")
+    assert(config.style === "aosp")
+    assert(config.skipJavadocFormatting === true)
+    assert(config.excludePaths === List("glob:**/generated/**", "glob:**/build/**"))
+  }
+
+  test("parseConfig parses multi-line arrays") {
+    val input =
+      """excludePaths = [
+        |  "glob:**/generated-and-checked-in/**",
+        |  "glob:**/build/**"
+        |]
+        |""".stripMargin
+    val config = Fmt.JavaFmt.parseConfig(input)
+    assert(config.excludePaths === List("glob:**/generated-and-checked-in/**", "glob:**/build/**"))
+  }
+
+  test("matchesExcludePattern filters files in generated directory") {
+    val buildDir = Paths.get("/project")
+    val patterns = List("glob:**/generated/**")
+
+    val generated = Paths.get("/project/src/generated/Foo.java")
+    val normal = Paths.get("/project/src/main/Foo.java")
+
+    assert(Fmt.JavaFmt.matchesExcludePattern(generated, buildDir, patterns) === true)
+    assert(Fmt.JavaFmt.matchesExcludePattern(normal, buildDir, patterns) === false)
+  }
+
+  test("matchesExcludePattern supports multiple patterns") {
+    val buildDir = Paths.get("/project")
+    val patterns = List("glob:**/generated/**", "glob:**/build/**")
+
+    val inGenerated = Paths.get("/project/src/generated/Foo.java")
+    val inBuild = Paths.get("/project/build/Bar.java")
+    val inMain = Paths.get("/project/src/main/Baz.java")
+
+    assert(Fmt.JavaFmt.matchesExcludePattern(inGenerated, buildDir, patterns) === true)
+    assert(Fmt.JavaFmt.matchesExcludePattern(inBuild, buildDir, patterns) === true)
+    assert(Fmt.JavaFmt.matchesExcludePattern(inMain, buildDir, patterns) === false)
+  }
+
+  test("matchesExcludePattern works with and without glob: prefix") {
+    val buildDir = Paths.get("/project")
+    val path = Paths.get("/project/src/generated/Foo.java")
+
+    assert(Fmt.JavaFmt.matchesExcludePattern(path, buildDir, List("glob:**/generated/**")) === true)
+    assert(Fmt.JavaFmt.matchesExcludePattern(path, buildDir, List("**/generated/**")) === true)
+  }
+
+  test("buildFlags maps config options to CLI flags") {
+    val config = Fmt.JavaFmt.JavaFmtConfig.default.copy(
+      style = "aosp",
+      skipJavadocFormatting = true
+    )
+    val flags = Fmt.JavaFmt.buildFlags(config)
+    assert(flags.contains("--aosp"))
+    assert(flags.contains("--skip-javadoc-formatting"))
+  }
+
+}

--- a/bleep-tests/src/scala/bleep/ScalafmtTest.scala
+++ b/bleep-tests/src/scala/bleep/ScalafmtTest.scala
@@ -6,19 +6,19 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ScalafmtTest extends AnyFunSuite with TripleEqualsSupport {
 
-  test("Fmt.getScalafmtVersion parses Fmt.defaultScalafmtConfig") {
-    val actual = Fmt.getScalafmtVersion(Fmt.defaultScalafmtConfig)
+  test("Fmt.ScalaFmt.getVersion parses Fmt.ScalaFmt.defaultConfig") {
+    val actual = Fmt.ScalaFmt.getVersion(Fmt.ScalaFmt.defaultConfig)
     val expected = Some("3.5.9")
     assert(actual === expected)
   }
 
-  test("Fmt.getScalafmtVersion parses config with spaces and double-quotes") {
+  test("Fmt.ScalaFmt.getVersion parses config with spaces and double-quotes") {
     val input =
       """version = "3.5.9"
         |maxColumn = 160
         |runner.dialect = scala213
         |""".stripMargin
-    val actual = Fmt.getScalafmtVersion(input)
+    val actual = Fmt.ScalaFmt.getVersion(input)
     val expected = Some("3.5.9")
     assert(actual === expected)
   }

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -7,6 +7,7 @@ projects:
     dependencies:
     - com.lihaoyi::pprint:0.9.6
     - com.monovore::decline:2.5.0
+    - com.typesafe:config:1.4.5
     - org.gnieh::diffson-circe:4.6.1
     - org.scalameta:svm-subs:101.0.0
       # note: weird binary incompatibility when bumping this for scala3


### PR DESCRIPTION
Add configuration file support for google-java-format, allowing users to customize Java formatting behavior via .javafmt.conf in the build directory.

Supported options:
- version: google-java-format version to use
- style: google (2-space) or aosp (4-space) indentation
- skipSortingImports, skipRemovingUnusedImports, fixImportsOnly
- skipReflowingLongStrings, skipJavadocFormatting
- excludePaths: glob patterns for file exclusions

Also refactors Fmt.scala to organize Scala and Java formatting code into separate nested objects (ScalaFmt and JavaFmt).