### PR TITLE
Show full test output with stack trace cycle detection

### DIFF
--- a/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
@@ -1479,8 +1479,10 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
           df += "status" -> Json.fromString(e.status.wireValue)
           e.message.foreach(m => df += "message" -> Json.fromString(stripAnsi(m)))
           e.throwable.foreach { t =>
-            if (includeThrowables) df += "throwable" -> Json.fromString(stripAnsi(t))
-            else df += "throwable" -> Json.fromString("present. Use bleep.status for full stack trace")
+            if (includeThrowables) {
+              val collapsed = bleep.testing.StackTraceCycles.collapse(stripAnsi(t)).mkString("\n")
+              df += "throwable" -> Json.fromString(collapsed)
+            } else df += "throwable" -> Json.fromString("present. Use bleep.status for full stack trace")
           }
           Json.obj(df.result()*)
         }

--- a/bleep-cli/src/scala-3/bleep/mcp/McpEventFilter.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/McpEventFilter.scala
@@ -55,7 +55,10 @@ object McpEventFilter {
         fields += "status" -> e.status.asJson
         fields += "durationMs" -> Json.fromLong(e.durationMs)
         e.message.foreach(m => fields += "message" -> Json.fromString(m))
-        e.throwable.foreach(t => fields += "throwable" -> Json.fromString(t))
+        e.throwable.foreach { t =>
+          val collapsed = bleep.testing.StackTraceCycles.collapse(t).mkString("\n")
+          fields += "throwable" -> Json.fromString(collapsed)
+        }
         Some(Json.obj(fields.result()*))
 
       case e: E.SuiteFinished =>

--- a/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
@@ -275,16 +275,11 @@ object BuildSummary {
             }
             failure.throwable.foreach { stack =>
               lines += s"  ${C.CYAN}Stack trace:${C.RESET}"
-              stack.split("\n").take(20).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
-              val stackLines = stack.split("\n").length
-              if (stackLines > 20)
-                lines += s"  ${C.YELLOW}|${C.RESET} ... and ${stackLines - 20} more lines"
+              StackTraceCycles.collapse(stack).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
             }
             if (failure.output.nonEmpty) {
               lines += s"  ${C.CYAN}Output:${C.RESET}"
-              failure.output.take(30).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
-              if (failure.output.size > 30)
-                lines += s"  ${C.YELLOW}|${C.RESET} ... and ${failure.output.size - 30} more lines"
+              failure.output.foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
             }
             lines += ""
           }
@@ -301,10 +296,7 @@ object BuildSummary {
             }
             failure.throwable.foreach { stack =>
               lines += s"  ${C.CYAN}Stack trace:${C.RESET}"
-              stack.split("\n").take(20).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
-              val stackLines = stack.split("\n").length
-              if (stackLines > 20)
-                lines += s"  ${C.YELLOW}|${C.RESET} ... and ${stackLines - 20} more lines"
+              StackTraceCycles.collapse(stack).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
             }
             lines += ""
           }
@@ -334,16 +326,11 @@ object BuildSummary {
             }
             failure.throwable.foreach { stack =>
               lines += s"  ${C.CYAN}Stack trace:${C.RESET}"
-              stack.split("\n").take(20).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
-              val stackLines = stack.split("\n").length
-              if (stackLines > 20)
-                lines += s"  ${C.YELLOW}|${C.RESET} ... and ${stackLines - 20} more lines"
+              StackTraceCycles.collapse(stack).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
             }
             if (failure.output.nonEmpty) {
               lines += s"  ${C.CYAN}Output:${C.RESET}"
-              failure.output.take(30).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
-              if (failure.output.size > 30)
-                lines += s"  ${C.YELLOW}|${C.RESET} ... and ${failure.output.size - 30} more lines"
+              failure.output.foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
             }
             lines += ""
           }
@@ -360,10 +347,7 @@ object BuildSummary {
             }
             failure.throwable.foreach { stack =>
               lines += s"  ${C.CYAN}Stack trace:${C.RESET}"
-              stack.split("\n").take(20).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
-              val stackLines = stack.split("\n").length
-              if (stackLines > 20)
-                lines += s"  ${C.YELLOW}|${C.RESET} ... and ${stackLines - 20} more lines"
+              StackTraceCycles.collapse(stack).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
             }
             lines += ""
           }

--- a/bleep-core/src/scala/bleep/testing/StackTraceCycles.scala
+++ b/bleep-core/src/scala/bleep/testing/StackTraceCycles.scala
@@ -1,0 +1,170 @@
+package bleep.testing
+
+/** Detects and collapses repeating frame cycles in stack traces.
+  *
+  * StackOverflowError produces thousands of identical frame sequences. This utility detects the repeating pattern and collapses it to a single occurrence with
+  * a repetition count.
+  *
+  * Handles:
+  *   - Repeating cycles of "at ..." frames
+  *   - "Caused by:" sections (each processed independently)
+  *   - JVM's own "... N more" lines (preserved as-is)
+  *   - Partial cycles at boundaries
+  */
+object StackTraceCycles {
+
+  /** Collapse repeating cycles in a stack trace string. Returns the collapsed lines. */
+  def collapse(stackTrace: String): List[String] = {
+    val lines = stackTrace.split("\n").toList
+    collapseSegments(lines)
+  }
+
+  /** Split lines into segments separated by "Caused by:" headers, collapse each frame block independently, then reassemble.
+    */
+  private def collapseSegments(lines: List[String]): List[String] = {
+    // Split into segments: each segment starts with a non-frame line (exception header or "Caused by:")
+    // and is followed by frame lines ("at ..." or "... N more")
+    val result = List.newBuilder[String]
+    var currentFrames = List.newBuilder[String]
+    var hasFrames = false
+
+    lines.foreach { line =>
+      val trimmed = line.trim
+      if (isFrameLine(trimmed)) {
+        currentFrames += line
+        hasFrames = true
+      } else {
+        // Non-frame line — flush any accumulated frames first
+        if (hasFrames) {
+          result ++= collapseFrameCycles(currentFrames.result())
+          currentFrames = List.newBuilder[String]
+          hasFrames = false
+        }
+        result += line
+      }
+    }
+
+    // Flush remaining frames
+    if (hasFrames) {
+      result ++= collapseFrameCycles(currentFrames.result())
+    }
+
+    result.result()
+  }
+
+  /** A frame line is "at ...", "\tat ...", or "... N more" */
+  private def isFrameLine(trimmed: String): Boolean =
+    trimmed.startsWith("at ") || trimmed.startsWith("... ")
+
+  /** Given a block of consecutive frame lines, detect and collapse repeating cycles.
+    *
+    * Algorithm: try cycle lengths from 2 up to half the block size. For each candidate length, check if the first N lines repeat consecutively. Take the
+    * shortest cycle that repeats at least 3 times.
+    */
+  private def collapseFrameCycles(frames: List[String]): List[String] = {
+    val n = frames.size
+    if (n < 6) return frames // Need at least 3 repetitions of length 2
+
+    val arr = frames.toArray
+
+    // Try cycle lengths from 1 to n/3 (need at least 3 reps to be worth collapsing)
+    val maxCycleLen = n / 3
+    var bestCycleLen = -1
+    var bestReps = 0
+    var bestOffset = 0
+
+    // Try starting at offset 0 first (most common case for StackOverflowError)
+    var cycleLen = 1
+    while (cycleLen <= maxCycleLen && bestCycleLen == -1) {
+      val reps = countRepetitions(arr, 0, cycleLen)
+      if (reps >= 3) {
+        bestCycleLen = cycleLen
+        bestReps = reps
+        bestOffset = 0
+      }
+      cycleLen += 1
+    }
+
+    // If no cycle found starting at 0, try skipping a few leading frames
+    if (bestCycleLen == -1) {
+      var offset = 1
+      while (offset < math.min(10, n / 3) && bestCycleLen == -1) {
+        val remaining = n - offset
+        val maxCL = remaining / 3
+        cycleLen = 1
+        while (cycleLen <= maxCL && bestCycleLen == -1) {
+          val reps = countRepetitions(arr, offset, cycleLen)
+          if (reps >= 3) {
+            bestCycleLen = cycleLen
+            bestReps = reps
+            bestOffset = offset
+          }
+          cycleLen += 1
+        }
+        offset += 1
+      }
+    }
+
+    if (bestCycleLen == -1) return frames // No cycle found
+
+    // Build result: prefix + one cycle + indicator + suffix
+    val result = List.newBuilder[String]
+
+    // Lines before the cycle
+    var i = 0
+    while (i < bestOffset) {
+      result += arr(i)
+      i += 1
+    }
+
+    // One instance of the cycle
+    i = bestOffset
+    val cycleEnd = bestOffset + bestCycleLen
+    while (i < cycleEnd) {
+      result += arr(i)
+      i += 1
+    }
+
+    // Cycle indicator — use same indentation as the frame lines
+    val indent = detectIndent(arr(bestOffset))
+    result += s"$indent... above $bestCycleLen frames repeated $bestReps times (${bestCycleLen * bestReps} frames total)"
+
+    // Lines after the cycle
+    val afterCycle = bestOffset + bestCycleLen * bestReps
+    i = afterCycle
+    while (i < n) {
+      result += arr(i)
+      i += 1
+    }
+
+    result.result()
+  }
+
+  /** Count how many times the sequence arr[offset..offset+cycleLen) repeats consecutively starting at offset. */
+  private def countRepetitions(arr: Array[String], offset: Int, cycleLen: Int): Int = {
+    val n = arr.length
+    var reps = 1
+    var pos = offset + cycleLen
+    var matching = true
+    while (matching && pos + cycleLen <= n) {
+      var j = 0
+      while (j < cycleLen && matching) {
+        if (arr(offset + j).trim != arr(pos + j).trim) {
+          matching = false
+        }
+        j += 1
+      }
+      if (matching) {
+        reps += 1
+        pos += cycleLen
+      }
+    }
+    reps
+  }
+
+  /** Detect leading whitespace from a frame line. */
+  private def detectIndent(line: String): String = {
+    val idx = line.indexWhere(!_.isWhitespace)
+    if (idx > 0) line.substring(0, idx) else "\t"
+  }
+}

--- a/bleep-tests/src/scala/bleep/testing/StackTraceCyclesTest.scala
+++ b/bleep-tests/src/scala/bleep/testing/StackTraceCyclesTest.scala
@@ -1,0 +1,194 @@
+package bleep.testing
+
+import org.scalactic.TripleEqualsSupport
+import org.scalatest.funsuite.AnyFunSuite
+
+class StackTraceCyclesTest extends AnyFunSuite with TripleEqualsSupport {
+
+  test("no cycle — short stack trace passes through unchanged") {
+    val input =
+      """java.lang.RuntimeException: boom
+        |	at com.foo.A.method(A.scala:10)
+        |	at com.foo.B.method(B.scala:20)
+        |	at com.foo.C.method(C.scala:30)""".stripMargin
+
+    val result = StackTraceCycles.collapse(input)
+    assert(result === input.split("\n").toList)
+  }
+
+  test("simple 2-frame cycle repeated 5 times") {
+    val cycle = List(
+      "\tat com.foo.A.methodA(A.scala:10)",
+      "\tat com.foo.B.methodB(B.scala:20)"
+    )
+    val frames = List.fill(5)(cycle).flatten
+    val input = ("java.lang.StackOverflowError" :: frames).mkString("\n")
+
+    val result = StackTraceCycles.collapse(input)
+    assert(result.head === "java.lang.StackOverflowError")
+    assert(result(1) === "\tat com.foo.A.methodA(A.scala:10)")
+    assert(result(2) === "\tat com.foo.B.methodB(B.scala:20)")
+    assert(result(3).contains("2 frames repeated 5 times"))
+    assert(result(3).contains("10 frames total"))
+    assert(result.size === 4)
+  }
+
+  test("3-frame cycle repeated 4 times") {
+    val cycle = List(
+      "\tat com.foo.A.a(A.scala:1)",
+      "\tat com.foo.B.b(B.scala:2)",
+      "\tat com.foo.C.c(C.scala:3)"
+    )
+    val frames = List.fill(4)(cycle).flatten
+    val input = ("java.lang.StackOverflowError" :: frames).mkString("\n")
+
+    val result = StackTraceCycles.collapse(input)
+    assert(result.head === "java.lang.StackOverflowError")
+    assert(result(1) === "\tat com.foo.A.a(A.scala:1)")
+    assert(result(2) === "\tat com.foo.B.b(B.scala:2)")
+    assert(result(3) === "\tat com.foo.C.c(C.scala:3)")
+    assert(result(4).contains("3 frames repeated 4 times"))
+    assert(result(4).contains("12 frames total"))
+    assert(result.size === 5)
+  }
+
+  test("cycle with trailing non-repeating frames") {
+    val cycle = List(
+      "\tat com.foo.A.a(A.scala:1)",
+      "\tat com.foo.B.b(B.scala:2)"
+    )
+    val tail = List(
+      "\tat com.foo.Main.main(Main.scala:100)",
+      "\tat sun.reflect.NativeMethodAccessorImpl.invoke(Native Method)"
+    )
+    val frames = List.fill(4)(cycle).flatten ++ tail
+    val input = ("java.lang.StackOverflowError" :: frames).mkString("\n")
+
+    val result = StackTraceCycles.collapse(input)
+    assert(result.head === "java.lang.StackOverflowError")
+    assert(result(1) === "\tat com.foo.A.a(A.scala:1)")
+    assert(result(2) === "\tat com.foo.B.b(B.scala:2)")
+    assert(result(3).contains("2 frames repeated 4 times"))
+    // Trailing frames preserved
+    assert(result.contains("\tat com.foo.Main.main(Main.scala:100)"))
+    assert(result.contains("\tat sun.reflect.NativeMethodAccessorImpl.invoke(Native Method)"))
+  }
+
+  test("cycle starting after a few non-repeating frames") {
+    val prefix = List(
+      "\tat com.foo.Entry.start(Entry.scala:5)"
+    )
+    val cycle = List(
+      "\tat com.foo.A.a(A.scala:1)",
+      "\tat com.foo.B.b(B.scala:2)"
+    )
+    val frames = prefix ++ List.fill(5)(cycle).flatten
+    val input = ("java.lang.StackOverflowError" :: frames).mkString("\n")
+
+    val result = StackTraceCycles.collapse(input)
+    assert(result.head === "java.lang.StackOverflowError")
+    // Prefix frame preserved
+    assert(result(1) === "\tat com.foo.Entry.start(Entry.scala:5)")
+    // One cycle instance
+    assert(result(2) === "\tat com.foo.A.a(A.scala:1)")
+    assert(result(3) === "\tat com.foo.B.b(B.scala:2)")
+    assert(result(4).contains("2 frames repeated 5 times"))
+  }
+
+  test("caused-by sections processed independently") {
+    val outerFrames = List(
+      "\tat com.foo.Outer.run(Outer.scala:10)",
+      "\tat com.foo.Outer.main(Outer.scala:5)"
+    )
+    val innerCycle = List(
+      "\tat com.foo.A.a(A.scala:1)",
+      "\tat com.foo.B.b(B.scala:2)"
+    )
+    val innerFrames = List.fill(4)(innerCycle).flatten
+    val lines = List("java.lang.RuntimeException: wrapper") ++
+      outerFrames ++
+      List("Caused by: java.lang.StackOverflowError") ++
+      innerFrames
+
+    val input = lines.mkString("\n")
+    val result = StackTraceCycles.collapse(input)
+
+    // Outer exception and frames unchanged
+    assert(result(0) === "java.lang.RuntimeException: wrapper")
+    assert(result(1) === "\tat com.foo.Outer.run(Outer.scala:10)")
+    assert(result(2) === "\tat com.foo.Outer.main(Outer.scala:5)")
+    // Caused by header
+    assert(result(3) === "Caused by: java.lang.StackOverflowError")
+    // Inner cycle collapsed
+    assert(result(4) === "\tat com.foo.A.a(A.scala:1)")
+    assert(result(5) === "\tat com.foo.B.b(B.scala:2)")
+    assert(result(6).contains("2 frames repeated 4 times"))
+    assert(result.size === 7)
+  }
+
+  test("JVM '... N more' lines are preserved") {
+    val input =
+      """java.lang.RuntimeException: outer
+        |	at com.foo.A.method(A.scala:10)
+        |	at com.foo.B.method(B.scala:20)
+        |Caused by: java.lang.IllegalStateException: inner
+        |	at com.foo.C.method(C.scala:30)
+        |	... 15 more""".stripMargin
+
+    val result = StackTraceCycles.collapse(input)
+    assert(result === input.split("\n").toList)
+  }
+
+  test("fewer than 3 repetitions — no collapsing") {
+    val cycle = List(
+      "\tat com.foo.A.a(A.scala:1)",
+      "\tat com.foo.B.b(B.scala:2)"
+    )
+    // Only 2 repetitions — not enough to collapse
+    val frames = List.fill(2)(cycle).flatten
+    val input = ("java.lang.StackOverflowError" :: frames).mkString("\n")
+
+    val result = StackTraceCycles.collapse(input)
+    assert(result === input.split("\n").toList)
+  }
+
+  test("empty input") {
+    val result = StackTraceCycles.collapse("")
+    assert(result === List(""))
+  }
+
+  test("single-frame cycle repeated many times") {
+    val frames = List.fill(100)("\tat com.foo.A.recurse(A.scala:10)")
+    val input = ("java.lang.StackOverflowError" :: frames).mkString("\n")
+
+    val result = StackTraceCycles.collapse(input)
+    assert(result.head === "java.lang.StackOverflowError")
+    assert(result(1) === "\tat com.foo.A.recurse(A.scala:10)")
+    assert(result(2).contains("1 frames repeated 100 times"))
+    assert(result(2).contains("100 frames total"))
+    assert(result.size === 3)
+  }
+
+  test("large realistic StackOverflowError") {
+    val cycle = List(
+      "\tat com.example.Parser.parseExpr(Parser.scala:42)",
+      "\tat com.example.Parser.parseTerm(Parser.scala:78)",
+      "\tat com.example.Parser.parseFactor(Parser.scala:103)",
+      "\tat com.example.Parser.parseExpr(Parser.scala:55)"
+    )
+    val frames = List.fill(250)(cycle).flatten
+    val tail = List(
+      "\tat com.example.Main.main(Main.scala:10)",
+      "\tat java.base/java.lang.Thread.run(Thread.java:829)"
+    )
+    val input = ("java.lang.StackOverflowError" :: (frames ++ tail)).mkString("\n")
+
+    val result = StackTraceCycles.collapse(input)
+    // Should be: header + 4 cycle frames + indicator + 2 tail frames = 8 lines
+    assert(result.size === 8)
+    assert(result(5).contains("4 frames repeated 250 times"))
+    assert(result(5).contains("1000 frames total"))
+    assert(result(6) === "\tat com.example.Main.main(Main.scala:10)")
+    assert(result(7) === "\tat java.base/java.lang.Thread.run(Thread.java:829)")
+  }
+}


### PR DESCRIPTION
## Summary

- **Remove output truncation** from `BuildDisplay.scala` — stack traces were capped at 20 lines and stdout/stderr at 30 lines, hiding exception causes behind `... and N more lines`
- **Add `StackTraceCycles`** utility that detects repeating frame sequences (StackOverflowError) and collapses them to one cycle + repetition count
- **Apply cycle detection in MCP path** (`BleepMcpServer`, `McpEventFilter`) so stack traces are collapsed there too

## Test plan

- [x] 11 unit tests for cycle detection (no-cycle passthrough, 2/3/single-frame cycles, trailing frames, offset cycles, `Caused by:` sections, JVM `... N more` preservation, large 1000-frame StackOverflowError)
- [ ] Manual test with a failing test that produces a long stack trace — verify full output is shown
- [ ] Manual test with StackOverflowError — verify cycle is collapsed with count


🤖 Generated with [Claude Code](https://claude.com/claude-code)