### PR TITLE
Fail when --only matches no test suites

### DIFF
--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -1747,7 +1747,17 @@ class MultiWorkspaceBspServer(
             (discoverTask, _) =>
               discoverTestSuites(started, discoverTask.project).map { case (result, suites) =>
                 val filtered = filterSuites(suites, testOptions.only, testOptions.exclude)
-                (result, filtered)
+                if (testOptions.only.nonEmpty && filtered.isEmpty) {
+                  val msg = if (suites.nonEmpty) {
+                    val available = suites.map(_._1).mkString(", ")
+                    s"--only ${testOptions.only.mkString(", ")} matched no test suites in ${discoverTask.project.value}. Available suites: $available"
+                  } else {
+                    s"--only ${testOptions.only.mkString(", ")} matched no test suites in ${discoverTask.project.value}. No test suites were discovered"
+                  }
+                  (TaskDag.TaskResult.Failure(msg, Nil), Nil)
+                } else {
+                  (result, filtered)
+                }
               }
 
           val testHandler: (TaskDag.TestSuiteTask, Deferred[IO, Outcome.KillReason]) => IO[TaskDag.TaskResult] = (testTask, taskKillSignal) => {
@@ -2860,8 +2870,13 @@ class MultiWorkspaceBspServer(
               case _: TaskDag.LinkTask =>
                 None // Link tasks are not exposed via test protocol
 
-              case _: TaskDag.DiscoverTask =>
-                None // Discovery finished is handled by SuitesDiscovered event
+              case dt: TaskDag.DiscoverTask =>
+                result match {
+                  case TaskDag.TaskResult.Failure(msg, _) =>
+                    Some(BleepBspProtocol.Event.Error(msg, None, timestamp))
+                  case _ =>
+                    None // Discovery success is handled by SuitesDiscovered event
+                }
 
               case tt: TaskDag.TestSuiteTask =>
                 result match {

--- a/bleep-tests/src/scala/bleep/IntegrationTests.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationTests.scala
@@ -425,6 +425,183 @@ object SourceGen extends BleepCodegenScript("SourceGen") {
     }
   }
 
+  test("test --only with fully qualified class name") {
+    runTest(
+      "test --only with fully qualified class name",
+      // language=yaml
+      """projects:
+        |  mytest:
+        |    dependencies: org.scalatest::scalatest:3.2.15
+        |    isTestProject: true
+        |    platform:
+        |      name: jvm
+        |    scala:
+        |      version: 3.3.3
+        |""".stripMargin,
+      Map(
+        RelPath.of("mytest/src/scala/MyTest.scala") ->
+          // language=scala
+          """package example
+            |
+            |import org.scalatest.funsuite.AnyFunSuite
+            |
+            |class MyTest extends AnyFunSuite {
+            |  test("dummy test") {
+            |    assert(1 + 1 == 2)
+            |  }
+            |}
+            |""".stripMargin
+      )
+    ) { (started, commands, storingLogger) =>
+      commands.test(
+        projects = List(model.CrossProjectName(model.ProjectName("mytest"), None)),
+        watch = false,
+        only = Some(NonEmptyList.of("example.MyTest")),
+        exclude = None
+      )
+      succeed
+    }
+  }
+
+  test("test --only filters to matching suite among multiple") {
+    runTest(
+      "test --only filters to matching suite among multiple",
+      // language=yaml
+      """projects:
+        |  mytest:
+        |    dependencies: org.scalatest::scalatest:3.2.15
+        |    isTestProject: true
+        |    platform:
+        |      name: jvm
+        |    scala:
+        |      version: 3.3.3
+        |""".stripMargin,
+      Map(
+        RelPath.of("mytest/src/scala/PassingTest.scala") ->
+          // language=scala
+          """package example
+            |
+            |import org.scalatest.funsuite.AnyFunSuite
+            |
+            |class PassingTest extends AnyFunSuite {
+            |  test("this passes") {
+            |    assert(true)
+            |  }
+            |}
+            |""".stripMargin,
+        RelPath.of("mytest/src/scala/FailingTest.scala") ->
+          // language=scala
+          """package example
+            |
+            |import org.scalatest.funsuite.AnyFunSuite
+            |
+            |class FailingTest extends AnyFunSuite {
+            |  test("this fails") {
+            |    assert(false)
+            |  }
+            |}
+            |""".stripMargin
+      )
+    ) { (started, commands, storingLogger) =>
+      commands.test(
+        projects = List(model.CrossProjectName(model.ProjectName("mytest"), None)),
+        watch = false,
+        only = Some(NonEmptyList.of("PassingTest")),
+        exclude = None
+      )
+      succeed
+    }
+  }
+
+  test("test --exclude skips matching suite") {
+    runTest(
+      "test --exclude skips matching suite",
+      // language=yaml
+      """projects:
+        |  mytest:
+        |    dependencies: org.scalatest::scalatest:3.2.15
+        |    isTestProject: true
+        |    platform:
+        |      name: jvm
+        |    scala:
+        |      version: 3.3.3
+        |""".stripMargin,
+      Map(
+        RelPath.of("mytest/src/scala/PassingTest.scala") ->
+          // language=scala
+          """package example
+            |
+            |import org.scalatest.funsuite.AnyFunSuite
+            |
+            |class PassingTest extends AnyFunSuite {
+            |  test("this passes") {
+            |    assert(true)
+            |  }
+            |}
+            |""".stripMargin,
+        RelPath.of("mytest/src/scala/FailingTest.scala") ->
+          // language=scala
+          """package example
+            |
+            |import org.scalatest.funsuite.AnyFunSuite
+            |
+            |class FailingTest extends AnyFunSuite {
+            |  test("this fails") {
+            |    assert(false)
+            |  }
+            |}
+            |""".stripMargin
+      )
+    ) { (started, commands, storingLogger) =>
+      commands.test(
+        projects = List(model.CrossProjectName(model.ProjectName("mytest"), None)),
+        watch = false,
+        only = None,
+        exclude = Some(NonEmptyList.of("FailingTest"))
+      )
+      succeed
+    }
+  }
+
+  test("test --only with nonexistent suite fails") {
+    runTest(
+      "test --only with nonexistent suite fails",
+      // language=yaml
+      """projects:
+        |  mytest:
+        |    dependencies: org.scalatest::scalatest:3.2.15
+        |    isTestProject: true
+        |    platform:
+        |      name: jvm
+        |    scala:
+        |      version: 3.3.3
+        |""".stripMargin,
+      Map(
+        RelPath.of("mytest/src/scala/MyTest.scala") ->
+          // language=scala
+          """package example
+            |
+            |import org.scalatest.funsuite.AnyFunSuite
+            |
+            |class MyTest extends AnyFunSuite {
+            |  test("dummy test") {
+            |    assert(1 + 1 == 2)
+            |  }
+            |}
+            |""".stripMargin
+      )
+    ) { (started, commands, storingLogger) =>
+      assertThrows[BleepException] {
+        commands.test(
+          projects = List(model.CrossProjectName(model.ProjectName("mytest"), None)),
+          watch = false,
+          only = Some(NonEmptyList.of("NonExistentTest")),
+          exclude = None
+        )
+      }
+    }
+  }
+
   test("kotlin compilation") {
     runTest(
       "kotlin compilation",


### PR DESCRIPTION
## Summary

- When `--only` is specified and no discovered test suites match, the build now fails with a clear error listing available suites instead of silently passing with zero tests
- Integration tests for `--only` (simple name, fully qualified, multi-suite filtering), `--exclude`, and nonexistent suite detection
- Fixes pre-existing ambiguous `ProjectConfig` import in `BleepBuildConverter`

## Test plan

- [x] `--only` with fully qualified class name
- [x] `--only` filters to one suite among multiple (FailingTest excluded by filter)
- [x] `--exclude` skips matching suite
- [x] `--only` with nonexistent suite throws `BleepException`

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)