### PR TITLE
Fix BSP cancellation for compile and test requests

### DIFF
--- a/bleep-bsp/src/scala/bleep/analysis/ParallelProjectCompiler.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ParallelProjectCompiler.scala
@@ -137,12 +137,13 @@ object ParallelProjectCompiler {
           if (allDone) {
             IO.unit
           } else if (cancellationToken.isCancelled) {
-            val remaining = dag.projects.keySet -- completedNames -- running
-            remaining.toList.traverse_ { name =>
-              val result = ProjectCompileFailure(List(CompilerError(None, 0, 0, "Compilation cancelled", None, CompilerError.Severity.Error)))
-              completedRef.update(_ + (name -> result)) >>
-                deferreds(name).complete(result).attempt.void
-            }
+            // Non-running projects never had fibers spawned, so nothing is awaiting their deferreds — skip them and
+            // let buildValidDag classify them as notStarted. But wait for already-running fibers to finish before
+            // returning, otherwise Zinc keeps writing class files after the "Cancelled" response has been sent.
+            if (running.nonEmpty)
+              signalRef.get.flatMap(_.get) >>
+                Deferred[IO, Unit].flatMap(s => signalRef.set(s) >> loop(runningRef, signalRef))
+            else IO.unit
           } else {
             val hasFailures = completed.values.exists(!_.isSuccess)
             if (hasFailures && running.isEmpty) {

--- a/bleep-bsp/src/scala/bleep/bsp/BspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServer.scala
@@ -72,8 +72,12 @@ class BspServer(
       catch { case _: IllegalStateException => () } // JVM already shutting down
   }
 
-  /** Methods that run on a CE blocking fiber so the main loop can process cancellation. */
-  private val asyncMethods = Set("buildTarget/run")
+  /** Methods that run on a CE blocking fiber so the main loop can process cancellation.
+    *
+    * These are the long-running operations: compile, test, run. If they blocked the main loop, `$/cancelRequest` notifications would sit in the stdin buffer
+    * unread until the operation finished on its own — making cancellation effectively a no-op.
+    */
+  private val asyncMethods = Set("buildTarget/compile", "buildTarget/test", "buildTarget/run")
 
   /** Handle an incoming JSON-RPC request */
   private def handleRequest(request: JsonRpcRequest): Unit = {


### PR DESCRIPTION
## Summary

Two bugs in BSP cancellation — both needed for cancel to actually do what clients expect.

### Bug 1: cancel messages sat unread while compile/test ran

`buildTarget/compile` and `buildTarget/test` dispatched synchronously on the main server loop, so `\$/cancelRequest` notifications sat in the stdin buffer unread until the operation finished naturally — cancellation was effectively a no-op.

Fix: add both to `asyncMethods` alongside `buildTarget/run` so the main loop stays free to process cancels while compile/test runs on a CE blocking fiber.

### Bug 2: running Zinc fibers leaked past the Cancelled response

`ParallelProjectCompiler.buildProjects` has a signal-based scheduling loop. The cancel branch looked like this:

```scala
} else if (cancellationToken.isCancelled) {
  val remaining = dag.projects.keySet -- completedNames -- running
  remaining.toList.traverse_ { name =>
    // mark as ProjectCompileFailure(\"Compilation cancelled\") and complete the deferred
  }
}
```

Two problems:

1. **Running fibers were abandoned.** The branch marked non-running projects and returned. Already-running fibers (Zinc compiles that had already started via `.start`) kept going — writing class files to `projectN/target/classes/` *after* the outer IO returned `Cancelled` and the BSP response was sent to the client.
2. **Non-running projects were misreported as failures.** Nothing was awaiting their deferreds (no fiber had been spawned yet), so completing them with a synthetic `ProjectCompileFailure` was wasted work that also polluted the `failures` set instead of letting them fall into `notStarted`.

Compare with the adjacent failure branch (line 156-159) which correctly waits for running tasks to drain before exiting — same pattern was needed here.

Fix:

```scala
} else if (cancellationToken.isCancelled) {
  if (running.nonEmpty)
    signalRef.get.flatMap(_.get) >>
      Deferred[IO, Unit].flatMap(s => signalRef.set(s) >> loop(runningRef, signalRef))
  else IO.unit
}
```

- Skip the non-running projects — `buildValidDag` computes `notStarted = dag.projects.keySet -- completed.keySet`, so they land in `notStarted` automatically.
- If anything is still running, block on the next completion signal and re-enter the loop. Each completing fiber removes itself from `runningRef` and fires the signal (see the `.guarantee` block at line ~174). The loop keeps waiting until `running` is empty, then returns.

### Why the test caught it

`BspTestHarness: cancellation returns Cancelled status for multi-project` starts 5 parallel Scala compiles and cancels after 300ms. The assertions passed — statusCode=3 came back — but the test's `finally deleteRecursively(workspace)` raced the leaked fibers and got `DirectoryNotEmptyException` when Zinc wrote a new `.class` file between the dir listing and `Files.delete(dir)`.

With the fix, compile fibers are fully drained before the BSP response is sent, so teardown sees a quiescent filesystem.

## Test plan
- [x] `BspCancellationIntegrationTest` — all 3 pass locally
- [x] `BspHarnessIntegrationTest` — all 9 pass, 4 consecutive runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)