### PR TITLE
build: restore bleep-plugin-mdoc as a published artifact

### DIFF
--- a/bleep.yaml
+++ b/bleep.yaml
@@ -181,6 +181,11 @@ projects:
     - ../liberated/sbt-jni/core/src/main/scala
     - ../liberated/sbt-jni/plugin/src/main/java
     - ../liberated/sbt-jni/plugin/src/main/scala
+  bleep-plugin-mdoc:
+    dependencies: org.jsoup:jsoup:1.21.2
+    dependsOn: bleep-core
+    extends: template-cross-all
+    sources: ../liberated/mdoc/mdoc-sbt/src/main/scala
   bleep-plugin-native-image:
     dependencies:
     - com.lihaoyi::os-lib:0.11.6


### PR DESCRIPTION
## Summary

The docs site revamp (#521) dropped the mdoc-based pipeline in favor of compiled \`docs-snippets-*\` projects, but it also accidentally removed \`bleep-plugin-mdoc\` from \`bleep.yaml\`. The plugin is still valuable as a publishable artifact for downstream users; it just isn't a build-time dependency of bleep itself anymore.

This restores the \`bleep-plugin-mdoc\` project (sources from \`liberated/mdoc/mdoc-sbt\`) without adding it back to \`scripts:\`'s dependencies.

## Why this matters

Right now master CI is red on the \`build\` job because \`BleepDevDepsTest\` checks that every artifact mapping in \`BleepDevDeps.scala\` resolves to an actual project in the build:

\`\`\`
- every artifact maps to an existing project *** FAILED ***
  Set(...) did not contain bleep-plugin-mdoc
  artifact 'bleep-plugin-mdoc' maps to bleep-plugin-mdoc which doesn't exist in build
- transitive bleep deps match build model *** FAILED ***
  java.util.NoSuchElementException: key not found: bleep-plugin-mdoc
\`\`\`

\`BleepDevDeps.scala\` correctly still lists mdoc — it's the \`bleep.yaml\` side that drifted. Restoring the project is the right fix; bleep-plugin-mdoc shouldn't disappear from the published artifact set just because we stopped consuming it ourselves.

## Test plan

- [x] \`bleep compile bleep-plugin-mdoc\` — clean compile.
- [x] \`bleep test bleep-tests --only bleep.BleepDevDepsTest\` — 5/5 pass.
- [x] \`bleep fmt\` — no diff.
- [ ] CI green on this PR.