### PR TITLE
test: bump default suite idle timeout from 2 to 5 minutes

### DIFF
--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -2,7 +2,7 @@ package bleep.bsp
 
 import bleep.bsp.Outcome.KillReason
 import bleep.bsp.protocol.{BleepBspProtocol, OutputChannel, ProcessExit, TestStatus}
-import bleep.model.{CrossProjectName, SuiteName, TestName}
+import bleep.model.{BspServerConfig, CrossProjectName, SuiteName, TestName}
 import bleep.testing.{JvmPool, TestJvm, TestProtocol}
 import cats.effect._
 import cats.effect.std.Queue
@@ -31,7 +31,7 @@ object TestRunner {
     val default: Options = Options(
       jvmOptions = Nil,
       testArgs = Nil,
-      idleTimeout = 2.minutes,
+      idleTimeout = BspServerConfig.DefaultTestIdleTimeoutMinutes.minutes,
       environment = Map.empty,
       workingDirectory = None
     )

--- a/bleep-core/src/scala/bleep/testing/ReactiveTestRunner.scala
+++ b/bleep-core/src/scala/bleep/testing/ReactiveTestRunner.scala
@@ -38,7 +38,7 @@ object ReactiveTestRunner {
       testArgs = Nil,
       maxParallelJvms = Runtime.getRuntime.availableProcessors(),
       quietMode = false,
-      idleTimeout = 2.minutes
+      idleTimeout = model.BspServerConfig.DefaultTestIdleTimeoutMinutes.minutes
     )
   }
 

--- a/bleep-model/src/scala/bleep/model/BleepConfig.scala
+++ b/bleep-model/src/scala/bleep/model/BleepConfig.scala
@@ -59,7 +59,7 @@ case class BspServerConfig(
 }
 
 object BspServerConfig {
-  val DefaultTestIdleTimeoutMinutes: Int = 2
+  val DefaultTestIdleTimeoutMinutes: Int = 5
   val DefaultHeapPressureThreshold: Double = 0.80
 
   val default: BspServerConfig = BspServerConfig(


### PR DESCRIPTION
## Summary

Bumps \`BspServerConfig.DefaultTestIdleTimeoutMinutes\` from \`2\` to \`5\`. Also de-dupes the two hardcoded \`idleTimeout = 2.minutes\` defaults in \`TestRunner\` and \`ReactiveTestRunner\` so they reference the same constant.

## Why

The inner-bleep IT suites added in #521 hit the 120s idle timeout on cold CI and never produce a green build:

\`\`\`
T bleep-tests / bleep.YourFirstKotlinProjectIT
  | Suite idle timeout after 120s
T bleep-tests / bleep.YourFirstProjectIT
  | Suite idle timeout after 120s
T bleep-tests / bleep.YourFirstScalaProjectIT
  | Suite idle timeout after 120s
\`\`\`

The idle timeout resets only between test completions, and each of these suites has exactly one test that does a lot of work in sequence: \`bleepNew\` → bootstrap test workspace → compile \`myapp\` → fork JVM to run main → compile \`myapp-test\` → fork JVM to run tests. With one test per suite, the whole pipeline has to finish under the timeout or the suite is killed.

Locally with warm caches each suite completes in 3-9s:

| Suite | Local |
|---|---|
| YourFirstProjectIT (Java) | 3.4s |
| YourFirstKotlinProjectIT  | 8.0s |
| YourFirstScalaProjectIT   | 5.5s |

On cold CI the inner bleep has to download GraalVM 25.0.1 (~250 MB), resolve & download Kotlin 2.3 / Scala 3.8.3 / munit / kotest / JUnit deps, JIT-warm the compile server, and fork two JVMs. 2 minutes is too tight for that path.

5 minutes is generous enough that bleep-running-bleep tests get through cold start and still bounded so genuinely hung suites die. Existing well-behaved tests are completely unaffected — they finish in seconds.

## Test plan

- [x] \`bleep test bleep-tests --only bleep.YourFirstKotlinProjectIT\` — passes locally (8s).
- [x] \`bleep compile bleep-bsp bleep-core bleep-model\` — clean compile.
- [x] \`bleep fmt\` — no diff.
- [ ] CI green on this PR (and on master once #574 + this land).