### PR TITLE
ci(build): write a per-CI bleep config with 5-min test idle timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Scalafmt Check
         run: ./bleep-cli.sh --dev fmt --check
 
+      # Inner-bleep IT suites (YourFirstProjectIT etc.) do bleepNew + full
+      # bootstrap + compile + fork JVM as a single test, which can exceed the
+      # 2-min default idle timeout on cold runners.
+      - name: Bleep config — longer test idle timeout
+        run: |
+          mkdir -p "$HOME/.config/bleep"
+          printf 'bspServerConfig:\n  testIdleTimeoutMinutes: 5\n' > "$HOME/.config/bleep/config.yaml"
+
       - name: Run tests
         env:
           CI: true


### PR DESCRIPTION
## Summary

Writes \`~/.config/bleep/config.yaml\` with \`testIdleTimeoutMinutes: 5\` before \`Run tests\` in our build workflow. Solves the CI-only problem without changing the bleep tool's default.

\`\`\`yaml
bspServerConfig:
  testIdleTimeoutMinutes: 5
\`\`\`

## Why

The inner-bleep IT suites added in #521 — \`YourFirstProjectIT\`, \`YourFirstKotlinProjectIT\`, \`YourFirstScalaProjectIT\` — each have a single test that does the full \`bleepNew\` + bootstrap + compile + fork-JVM-run + compile-test + fork-JVM-test pipeline. With one test per suite the whole thing has to finish before the idle timeout, since the timer only resets between test completions.

Local timings (warm caches):

| Suite | Time |
|---|---|
| YourFirstProjectIT (Java) | 3.4s |
| YourFirstKotlinProjectIT  | 8.0s |
| YourFirstScalaProjectIT   | 5.5s |

Cold CI is much slower — the inner bleep has to download GraalVM 25.0.1 (~250 MB) plus Kotlin/Scala/munit/kotest/JUnit deps, JIT-warm the compile server, and fork two JVMs. That genuinely exceeds 2 min sometimes (it timed out on the master CI run after the #521 merge).

## Why config.yaml instead of changing the default

The 2-min default is a sensible signal for hung tests in regular bleep workflows. This is just our build-itself doing bleep-running-bleep, which is unusually heavy on cold CI. Best to leave the tool's default alone and bump it only where it's actually needed.

## Test plan

- [x] yaml decodes with the bleep config schema (\`bspServerConfig:\` is the actual key, not \`bspServer:\` — confirmed against \`~/Library/Application Support/build.bleep/config.yaml\`).
- [ ] CI green on this PR (once #574 mdoc fix lands too — these are blocking each other).