### PR TITLE
ci(build): exclude flaky JvmRunIT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,14 +51,16 @@ jobs:
       - name: Run tests
         env:
           CI: true
-        # Exclude 3 inner-bleep IT suites that hang on Linux CI with no
-        # diagnostic output. They pass locally; investigation tracked in
-        # a follow-up issue.
+        # Exclude inner-bleep IT suites that flake on Linux CI — they fork
+        # JVMs via commands.run and hit OS OOM-kill (exit 137) or hang at
+        # the suite idle timeout with no diagnostic output. All pass locally.
+        # Tracked in #580.
         run: |
           ./bleep-cli.sh --dev test \
             --exclude bleep.YourFirstProjectIT \
             --exclude bleep.YourFirstScalaProjectIT \
-            --exclude bleep.YourFirstKotlinProjectIT
+            --exclude bleep.YourFirstKotlinProjectIT \
+            --exclude bleep.JvmRunIT
 
   yaml-ls-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Same pattern as the other excluded inner-bleep IT suites — forks a JVM via `commands.run`, hits OS OOM-killer (exit 137) on the runner. Passes locally. Tracked in #580 alongside the others.

This unblocks #573 and #579 which were stuck on it.