### PR TITLE
Stabilize integration tests (#580)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,16 +51,7 @@ jobs:
       - name: Run tests
         env:
           CI: true
-        # Exclude inner-bleep IT suites that flake on Linux CI — they fork
-        # JVMs via commands.run and hit OS OOM-kill (exit 137) or hang at
-        # the suite idle timeout with no diagnostic output. All pass locally.
-        # Tracked in #580.
-        run: |
-          ./bleep-cli.sh --dev test \
-            --exclude bleep.YourFirstProjectIT \
-            --exclude bleep.YourFirstScalaProjectIT \
-            --exclude bleep.YourFirstKotlinProjectIT \
-            --exclude bleep.JvmRunIT
+        run: ./bleep-cli.sh --dev test
 
   yaml-ls-check:
     runs-on: ubuntu-latest

--- a/bleep-bsp-tests/src/scala/bleep/analysis/JstackThreadDumpTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/JstackThreadDumpTest.scala
@@ -1,0 +1,108 @@
+package bleep.analysis
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.nio.file.{Files, Path}
+import java.util.concurrent.TimeUnit
+
+/** End-to-end test for the thread-dump-on-timeout mechanism that runs at suite-idle in [[bleep.bsp.TestRunner]] / [[bleep.testing.JvmPool]].
+  *
+  * Strategy: spawn a real Java subprocess that hangs in a recognizable named thread, then shell out to `<javaHome>/bin/jstack <pid>` exactly like
+  * `JvmPool.ManagedJvm.dumpThreads` does in production, and assert the captured lines look like a real HotSpot thread dump.
+  *
+  * If this test ever fails it means something broke in the chain: the JDK we run under no longer ships jstack, or jstack changed its output format, or our
+  * drain logic regressed. All three cases are silent in production — the only signal would be "Suite idle timeout after 120s" with no accompanying frames
+  * again, so keep this test alive.
+  *
+  * On Windows we self-skip — the production path there returns Nil if `jstack.exe` is missing, and the test is platform-noisy enough as-is.
+  */
+class JstackThreadDumpTest extends AnyFunSuite with Matchers {
+
+  val isWindows: Boolean = System.getProperty("os.name").toLowerCase.contains("win")
+
+  test("jstack against a hanging JVM produces a thread dump containing our named thread") {
+    assume(!isWindows, "jstack subprocess output capture is verified on POSIX only")
+
+    val javaSrc =
+      """public class Hang {
+        |  public static void main(String[] args) throws Exception {
+        |    Thread.currentThread().setName("hanging-test-thread");
+        |    Thread.sleep(java.util.concurrent.TimeUnit.MINUTES.toMillis(5));
+        |  }
+        |}
+        |""".stripMargin
+
+    val workDir = Files.createTempDirectory("threaddump-test")
+    try {
+      val srcFile = workDir.resolve("Hang.java")
+      Files.writeString(srcFile, javaSrc)
+
+      val javaHome = Path.of(System.getProperty("java.home"))
+      val javac = javaHome.resolve("bin").resolve("javac").toString
+      val java = javaHome.resolve("bin").resolve("java").toString
+      val jstack = javaHome.resolve("bin").resolve("jstack")
+
+      assume(Files.isExecutable(jstack), s"this JDK ($javaHome) doesn't ship jstack — production fallback returns Nil here")
+
+      val compile = new ProcessBuilder(javac, srcFile.toString)
+        .directory(workDir.toFile)
+        .redirectErrorStream(true)
+        .start()
+      compile.waitFor(30, TimeUnit.SECONDS)
+      compile.exitValue() shouldBe 0
+
+      val pb = new ProcessBuilder(java, "-cp", workDir.toString, "Hang")
+      pb.redirectErrorStream(true)
+      val process = pb.start()
+
+      try {
+        // Give the JVM a moment to actually start sleeping.
+        Thread.sleep(1500)
+        process.isAlive shouldBe true
+
+        val jstackProc = new ProcessBuilder(jstack.toString, process.pid().toString)
+          .redirectErrorStream(true)
+          .start()
+        val reader = new BufferedReader(new InputStreamReader(jstackProc.getInputStream))
+        val captured = scala.collection.mutable.ListBuffer.empty[String]
+        val drainer = new Thread(() =>
+          try {
+            var line = reader.readLine()
+            while (line != null) {
+              captured.synchronized(captured += line)
+              line = reader.readLine()
+            }
+          } catch { case _: Throwable => () }
+        )
+        drainer.setDaemon(true)
+        drainer.start()
+        jstackProc.waitFor(10, TimeUnit.SECONDS) shouldBe true
+        jstackProc.exitValue() shouldBe 0
+        drainer.join(1000)
+
+        val capturedSnapshot = captured.synchronized(captured.toList)
+        val joined = capturedSnapshot.mkString("\n")
+        withClue(s"captured ${capturedSnapshot.size} jstack line(s):\n$joined\n") {
+          capturedSnapshot should not be empty
+          joined should include("Full thread dump")
+          joined should include("hanging-test-thread")
+        }
+      } finally
+        try process.destroyForcibly()
+        catch { case _: Throwable => () }
+    } finally
+      try {
+        import scala.jdk.StreamConverters.*
+        Files
+          .walk(workDir)
+          .toScala(List)
+          .reverse
+          .foreach(p =>
+            try Files.delete(p)
+            catch { case _: Throwable => () }
+          )
+      } catch { case _: Throwable => () }
+  }
+}

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -1815,59 +1815,64 @@ class MultiWorkspaceBspServer(
                 }
               }
 
-          val testHandler: (TaskDag.TestSuiteTask, Deferred[IO, Outcome.KillReason]) => IO[TaskDag.TaskResult] = (testTask, taskKillSignal) => {
-            val classpath = getTestClasspath(started, testTask.project)
-            val project = started.build.explodedProjects(testTask.project)
-            val projectPlatform = project.platform.flatMap(_.name)
-            val isKotlin = project.kotlin.flatMap(_.version).isDefined
+          val testHandler: (TaskDag.TestSuiteTask, Deferred[IO, Outcome.KillReason]) => IO[TaskDag.TaskResult] = (testTask, taskKillSignal) =>
+            // getTestClasspath ends up in CoursierResolver.Direct.go which calls Fetch.eitherResult → Await.result(future, Duration.Inf).
+            // Without IO.blocking that runs synchronously on the IOFiber's compute thread, holding it for the entire resolve while
+            // every other fiber on the runtime — including the BSP pipe reader on the other end of an in-process server — has to
+            // queue behind it. Routing it through the blocker pool lets cats-effect grow a helper thread instead of starving compute.
+            IO.blocking(getTestClasspath(started, testTask.project)).flatMap { classpath =>
+              val project = started.build.explodedProjects(testTask.project)
+              val projectPlatform = project.platform.flatMap(_.name)
+              val isKotlin = project.kotlin.flatMap(_.version).isDefined
 
-            (projectPlatform, isKotlin) match {
-              case (Some(model.PlatformId.Js), true) =>
-                runKotlinJsTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
-              case (Some(model.PlatformId.Js), false) =>
-                runScalaJsTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
-              case (Some(model.PlatformId.Native), true) =>
-                runKotlinNativeTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
-              case (Some(model.PlatformId.Native), false) =>
-                runScalaNativeTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
-              case _ =>
-                // JVM (default) - use JvmPool
-                val testEnv = computeTestEnvironment(started, testTask.project)
-                val projectDir =
-                  started.build.explodedProjects.get(testTask.project).flatMap(_.folder).map(rp => started.buildPaths.buildDir.resolve(rp.toString))
-                // Project-level JVM options from platform config (e.g. -Djava.util.logging.manager for Quarkus)
-                val projectJvmOptions = started.resolvedProject(testTask.project).platform match {
-                  case Some(p: ResolvedProject.Platform.Jvm) => p.options
-                  case _                                     => Nil
-                }
-                TestRunner.runSuite(
-                  project = testTask.project,
-                  suiteName = testTask.suiteName.value,
-                  framework = testTask.framework,
-                  classpath = classpath,
-                  pool = jvmPool,
-                  eventQueue = eventQueue,
-                  options = TestRunner.Options(
-                    jvmOptions = serverConfig.testRunnerMaxMemory.map(m => s"-Xmx$m").toList ++ projectJvmOptions ++ testOptions.jvmOptions,
-                    testArgs = testOptions.testArgs,
-                    idleTimeout = idleTimeout,
-                    environment = testEnv,
-                    workingDirectory = projectDir
-                  ),
-                  killSignal = taskKillSignal
-                )
+              (projectPlatform, isKotlin) match {
+                case (Some(model.PlatformId.Js), true) =>
+                  runKotlinJsTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
+                case (Some(model.PlatformId.Js), false) =>
+                  runScalaJsTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
+                case (Some(model.PlatformId.Native), true) =>
+                  runKotlinNativeTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
+                case (Some(model.PlatformId.Native), false) =>
+                  runScalaNativeTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
+                case _ =>
+                  // JVM (default) - use JvmPool
+                  val testEnv = computeTestEnvironment(started, testTask.project)
+                  val projectDir =
+                    started.build.explodedProjects.get(testTask.project).flatMap(_.folder).map(rp => started.buildPaths.buildDir.resolve(rp.toString))
+                  // Project-level JVM options from platform config (e.g. -Djava.util.logging.manager for Quarkus)
+                  val projectJvmOptions = started.resolvedProject(testTask.project).platform match {
+                    case Some(p: ResolvedProject.Platform.Jvm) => p.options
+                    case _                                     => Nil
+                  }
+                  TestRunner.runSuite(
+                    project = testTask.project,
+                    suiteName = testTask.suiteName.value,
+                    framework = testTask.framework,
+                    classpath = classpath,
+                    pool = jvmPool,
+                    eventQueue = eventQueue,
+                    options = TestRunner.Options(
+                      jvmOptions = serverConfig.testRunnerMaxMemory.map(m => s"-Xmx$m").toList ++ projectJvmOptions ++ testOptions.jvmOptions,
+                      testArgs = testOptions.testArgs,
+                      idleTimeout = idleTimeout,
+                      environment = testEnv,
+                      workingDirectory = projectDir
+                    ),
+                    killSignal = taskKillSignal
+                  )
+              }
             }
-          }
 
           // Link handler for non-JVM platforms (Scala.js, Scala Native, Kotlin/JS, Kotlin/Native)
           val linkHandler: (TaskDag.LinkTask, Deferred[IO, Outcome.KillReason]) => IO[(TaskDag.TaskResult, TaskDag.LinkResult)] =
-            (linkTask, killSignal) => {
-              val projectPaths = started.projectPaths(linkTask.project)
-              val classpath = getTestClasspath(started, linkTask.project)
-              val logger = createLinkLogger()
-              val outputDir = projectPaths.targetDir
-              LinkExecutor.execute(linkTask, classpath.map(_.toAbsolutePath), None, outputDir, logger, killSignal)
-            }
+            (linkTask, killSignal) =>
+              // Same reasoning as testHandler — getTestClasspath synchronously Awaits a coursier resolve.
+              IO.blocking(getTestClasspath(started, linkTask.project)).flatMap { classpath =>
+                val projectPaths = started.projectPaths(linkTask.project)
+                val logger = createLinkLogger()
+                val outputDir = projectPaths.targetDir
+                LinkExecutor.execute(linkTask, classpath.map(_.toAbsolutePath), None, outputDir, logger, killSignal)
+              }
 
           val apHandler = makeAnnotationProcessorHandler(started, params.originId, apResults)
 
@@ -2450,40 +2455,32 @@ class MultiWorkspaceBspServer(
 
   /** Fetch bleep-test-runner and its dependencies.
     *
-    * Uses `${BLEEP_VERSION}` so the TemplatedVersions resolver handles version rewriting: for dev builds this resolves the test-runner class dir from
-    * BleepDevDeps, for release builds it resolves the published JAR from Coursier.
+    * Two parts:
     *
-    * For dev builds, BleepDevDeps only returns class dirs (no transitive external deps like test-interface). We always resolve the external deps separately so
-    * the forked test JVM has everything it needs.
+    *   1. `bleep-test-runner` itself, versioned `${BLEEP_VERSION}`. Goes through `TemplatedVersions` so dev builds short-circuit to BleepDevDeps class dirs.
+    *      Workspace-specific (the buildDir is in the version), so always resolved fresh — but the BleepDevDeps path is in-process and fast.
+    *   2. Four hardcoded external test-framework deps (test-interface, jupiter-interface, junit-platform-launcher, junit-vintage-engine). These are stable
+    *      across every workspace and every bleep version, so we cache them in a process-wide atomic — see
+    *      `MultiWorkspaceBspServer.cachedExternalTestRunnerJars`. Without this, every inner-bleep `commands.test` re-runs Coursier for the same four deps;
+    *      under CI's contention that's enough to trip the suite-idle timeout in #580.
     */
-  @volatile private var cachedTestRunnerJars: List[Path] = _
-
   private def fetchTestRunnerViaCoursier(started: Started): List[Path] = {
-    val cached = cachedTestRunnerJars
-    if (cached != null) return cached
+    val externalJars = MultiWorkspaceBspServer.fetchExternalTestRunnerDeps(started)
+    val testRunnerJars = fetchBleepTestRunnerOnly(started)
+    if (testRunnerJars.isEmpty)
+      throw new RuntimeException("bleep-test-runner resolution returned no jars")
+    testRunnerJars ++ externalJars
+  }
 
+  private def fetchBleepTestRunnerOnly(started: Started): List[Path] = {
     val testRunnerDep = model.Dep.Java("build.bleep", "bleep-test-runner", model.Replacements.known.BleepVersion)
-    val externalDeps = Set[model.Dep](
-      model.Dep.Java("org.scala-sbt", "test-interface", "1.0"),
-      model.Dep.Java("net.aichler", "jupiter-interface", "0.11.1"),
-      model.Dep.Java("org.junit.platform", "junit-platform-launcher", "1.9.1"),
-      model.Dep.Java("org.junit.vintage", "junit-vintage-engine", "5.9.1")
-    )
-    val allDeps = externalDeps + testRunnerDep
-
     val result = started.resolver.force(
-      allDeps,
+      Set(testRunnerDep),
       model.VersionCombo.Jvm(model.VersionScala.Scala3),
       libraryVersionSchemes = SortedSet.empty[model.LibraryVersionScheme],
       context = "resolving bleep-test-runner",
       model.IgnoreEvictionErrors.No
     )
-
-    if (result.jars.isEmpty) {
-      throw new RuntimeException("bleep-test-runner resolution returned no jars")
-    }
-
-    cachedTestRunnerJars = result.jars
     result.jars
   }
 
@@ -2859,7 +2856,7 @@ class MultiWorkspaceBspServer(
         )
       case TaskDag.TaskResult.Skipped(failedDep) =>
         BleepBspProtocol.Event.CompileFinished(project, CompileStatus.Skipped, durationMs, Nil, skippedBecause = Some(failedDep.project), timestamp)
-      case TaskDag.TaskResult.Killed(_) | TaskDag.TaskResult.Cancelled | TaskDag.TaskResult.TimedOut =>
+      case TaskDag.TaskResult.Killed(_) | TaskDag.TaskResult.Cancelled | _: TaskDag.TaskResult.TimedOut =>
         BleepBspProtocol.Event.CompileFinished(project, CompileStatus.Cancelled, durationMs, Nil, skippedBecause = None, timestamp)
     }
 
@@ -3036,8 +3033,8 @@ class MultiWorkspaceBspServer(
                     Some(BleepBspProtocol.Event.SuiteCancelled(tt.project, tt.suiteName, Some("killed"), timestamp))
                   case TaskDag.TaskResult.Cancelled =>
                     Some(BleepBspProtocol.Event.SuiteCancelled(tt.project, tt.suiteName, Some("cancelled"), timestamp))
-                  case TaskDag.TaskResult.TimedOut =>
-                    Some(BleepBspProtocol.Event.SuiteTimedOut(tt.project, tt.suiteName, durationMs, None, timestamp))
+                  case TaskDag.TaskResult.TimedOut(threadDump) =>
+                    Some(BleepBspProtocol.Event.SuiteTimedOut(tt.project, tt.suiteName, durationMs, threadDump, timestamp))
                 }
 
               case _: TaskDag.SourcegenTask =>
@@ -3644,4 +3641,38 @@ object MultiWorkspaceBspServer {
 
   /** Enable debug logging to stderr (for development only) */
   val DebugLogging: Boolean = sys.env.get("BLEEP_BSP_DEBUG").contains("true")
+
+  /** Hardcoded external test-framework dependencies that bleep-test-runner needs at runtime — same versions for every workspace and every bleep version. */
+  private val externalTestRunnerDeps: SortedSet[model.Dep] = SortedSet[model.Dep](
+    model.Dep.Java("org.scala-sbt", "test-interface", "1.0"),
+    model.Dep.Java("net.aichler", "jupiter-interface", "0.11.1"),
+    model.Dep.Java("org.junit.platform", "junit-platform-launcher", "1.9.1"),
+    model.Dep.Java("org.junit.vintage", "junit-vintage-engine", "5.9.1")
+  )
+
+  /** Process-wide memoization of the [[externalTestRunnerDeps]] resolution.
+    *
+    * The four deps don't change across workspaces or bleep versions, so resolving them once per JVM avoids re-running Coursier on every inner-bleep
+    * `commands.test`. Without this cache, each test workspace's [[InProcessBspServer]] (a fresh [[MultiWorkspaceBspServer]] per `commands.test` call)
+    * re-fetches the same artifacts; under CI's CPU contention with two parallel test JVMs that's enough to trip the 120 s suite-idle timeout in #580.
+    *
+    * `AtomicReference` so we can populate it lock-free on first call and read it without synchronization on every subsequent call. The compute may run twice if
+    * two callers race; harmless — the resolved jars are identical, and Coursier's own disk cache handles concurrent downloads.
+    */
+  private val cachedExternalTestRunnerJars: java.util.concurrent.atomic.AtomicReference[List[Path]] =
+    new java.util.concurrent.atomic.AtomicReference[List[Path]](null)
+
+  private def fetchExternalTestRunnerDeps(started: Started): List[Path] = {
+    val cached = cachedExternalTestRunnerJars.get()
+    if (cached != null) return cached
+    val result = started.resolver.force(
+      externalTestRunnerDeps,
+      model.VersionCombo.Jvm(model.VersionScala.Scala3),
+      libraryVersionSchemes = SortedSet.empty[model.LibraryVersionScheme],
+      context = "resolving bleep-test-runner external deps",
+      model.IgnoreEvictionErrors.No
+    )
+    cachedExternalTestRunnerJars.compareAndSet(null, result.jars)
+    cachedExternalTestRunnerJars.get()
+  }
 }

--- a/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
@@ -221,7 +221,7 @@ object TaskDag {
     case class Error(error: String, processExit: ProcessExit) extends TaskResult
     case class Skipped(failedDependency: Task) extends TaskResult
     case class Killed(reason: KillReason) extends TaskResult
-    case object TimedOut extends TaskResult
+    case class TimedOut(threadDump: Option[String]) extends TaskResult
 
     /** Backward compatibility alias - prefer Killed with explicit reason */
     val Cancelled: TaskResult = Killed(KillReason.UserRequest)
@@ -860,7 +860,7 @@ object TaskDag {
                           case TaskResult.Error(error, _)    => (false, Some(error))
                           case TaskResult.Skipped(failedDep) => (false, Some(s"dependency ${failedDep.id.value} failed"))
                           case TaskResult.Killed(reason)     => (false, Some(s"killed: $reason"))
-                          case TaskResult.TimedOut           => (false, Some("timed out"))
+                          case TaskResult.TimedOut(_)        => (false, Some("timed out"))
                         }
                         _ <- emit(DagEvent.SourcegenFinished(sgt.script.project, sgt.script.main, success, durationMs, errorMsg, sourcegenEndTs))
                       } yield result
@@ -880,7 +880,7 @@ object TaskDag {
                           case TaskResult.Error(error, _)    => (false, Some(error))
                           case TaskResult.Skipped(failedDep) => (false, Some(s"dependency ${failedDep.id.value} failed"))
                           case TaskResult.Killed(reason)     => (false, Some(s"killed: $reason"))
-                          case TaskResult.TimedOut           => (false, Some("timed out"))
+                          case TaskResult.TimedOut(_)        => (false, Some("timed out"))
                         }
                         _ <- emit(
                           DagEvent.ResolveAnnotationProcessorsFinished(apt.project, success, durationMs, errorMsg, discoveredJarCount, apEndTs)
@@ -901,7 +901,7 @@ object TaskDag {
             case TaskResult.Error(_, _)   => dagRef.update(_.error(task.id))
             case TaskResult.Skipped(_)    => dagRef.update(_.skip(task.id))
             case TaskResult.Killed(_)     => dagRef.update(_.kill(task.id))
-            case TaskResult.TimedOut      => dagRef.update(_.timeout(task.id))
+            case TaskResult.TimedOut(_)   => dagRef.update(_.timeout(task.id))
           }
         } yield ()
       }

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -253,6 +253,18 @@ object TestRunner {
             drainStderrToEvents.attempt >> jvm.kill.attempt >> suiteFiber.cancel.attempt.void
           }
 
+          // On idle timeout the test runner JVM is alive but stuck. Run jstack against it so
+          // we capture every thread's stack frames, then ship the dump back through the
+          // protocol (TaskResult.TimedOut → SuiteTimedOut.threadDump). Without this the user
+          // just sees "Suite idle timeout after 120s" with no idea what the JVM was doing.
+          // jstack writes to its own stdout, decoupled from the test JVM's stdio, so the
+          // protocol stream doesn't get polluted.
+          def captureThreadDump: IO[Option[String]] =
+            jvm.dumpThreads.attempt.map {
+              case Right(lines) if lines.nonEmpty => Some(lines.mkString("\n"))
+              case _                              => None
+            }
+
           // NOTE: For timeout/kill/error cases, we do NOT emit SuiteFinished here.
           // The executor emits TaskFinished with TimedOut/Killed/Error, which consumeEvents
           // converts to SuiteTimedOut event. Emitting SuiteFinished here would cause
@@ -262,8 +274,8 @@ object TestRunner {
             case Outcome.Succeeded(fa) =>
               fa.flatMap {
                 case Left(_) =>
-                  // Idle timeout - kill JVM and report timed out (does NOT propagate to downstream tasks)
-                  cleanup >> IO.pure(TaskDag.TaskResult.TimedOut)
+                  // Idle timeout - dump threads, kill JVM, ship the dump out via TimedOut
+                  captureThreadDump.flatMap(dump => IO.uncancelable(_ => cleanup) >> IO.pure(TaskDag.TaskResult.TimedOut(dump)))
                 case Right(reason) =>
                   // Kill signal - kill JVM and report killed with reason
                   cleanup >> IO.pure(TaskDag.TaskResult.Killed(reason))

--- a/bleep-cli/src/scala/bleep/commands/BuildUpdateDeps.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildUpdateDeps.scala
@@ -31,7 +31,7 @@ case class BuildUpdateDeps(scalaStewardMode: Boolean, allowPrerelease: Boolean, 
     val credentialProvider = new CredentialProvider(started.logger, started.config.authentications)
     val repos =
       CoursierResolver.coursierRepos(build.resolvers.values, started.config.authentications, credentialProvider, started.logger).filter(_.repr.contains("http"))
-    val fileCache = FileCache[Task]().withLogger(started.pre.cacheLogger)
+    val fileCache = BleepFileCache().withLogger(started.pre.cacheLogger)
 
     val foundByDep: Map[UpgradeDependencies.ContextualDep, (Dependency, Versions)] = {
       implicit val ec: ExecutionContext = started.executionContext

--- a/bleep-core/src/scala/bleep/CoursierResolver.scala
+++ b/bleep-core/src/scala/bleep/CoursierResolver.scala
@@ -210,7 +210,7 @@ object CoursierResolver {
 
   class Direct(logger: Logger, val cacheLogger: BleepCacheLogger, val params: Params, credentialProvider: CredentialProvider) extends CoursierResolver {
 
-    val fileCache = FileCache[Task](params.overrideCacheFolder.getOrElse(CacheDefaults.location)).withLogger(cacheLogger)
+    val fileCache = BleepFileCache.at(params.overrideCacheFolder.getOrElse(CacheDefaults.location)).withLogger(cacheLogger)
     lazy val repos = coursierRepos(params.repos, params.authentications, credentialProvider, logger)
 
     override def withParams(newParams: Params): CoursierResolver =

--- a/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
+++ b/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
@@ -801,6 +801,8 @@ class ReactiveBspClient(
         Some(BuildEvent.SuiteFinished(project, suite, passed, failed, skipped, ignored, durationMs, timestamp))
 
       case PE.SuiteTimedOut(project, suite, timeoutMs, threadDump, timestamp) =>
+        // protocol's `threadDump: Option[String]` carries the full HotSpot dump text from jstack;
+        // park it in singleThreadStack so BuildState can hang it off failure.throwable for the summary's Timeouts section.
         Some(BuildEvent.SuiteTimedOut(project, suite, timeoutMs, threadDump.map(d => bleep.testing.ThreadDumpInfo(0, Some(d), None)), timestamp))
 
       case PE.SuiteError(project, suite, error, processExit, durationMs, timestamp) =>

--- a/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
@@ -301,6 +301,10 @@ object BuildSummary {
               lines += s"  ${C.CYAN}Stack trace:${C.RESET}"
               StackTraceCycles.collapse(stack).foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
             }
+            if (failure.output.nonEmpty) {
+              lines += s"  ${C.CYAN}Output:${C.RESET}"
+              failure.output.foreach(line => lines += s"  ${C.YELLOW}|${C.RESET} $line")
+            }
             lines += ""
           }
         }
@@ -710,19 +714,12 @@ object BuildDisplay {
           renderCompileProgress()
         }
 
-      case BuildEvent.SuiteTimedOut(_, suite, timeoutMs, threadDumpInfo, _) =>
+      case BuildEvent.SuiteTimedOut(_, suite, timeoutMs, _, _) =>
+        // The dump is rendered once at the end under "Timeouts" in the summary (BuildState
+        // hangs the jstack output off failure.throwable). Skip inline here to avoid printing
+        // the same multi-hundred-line dump twice during the run.
         val timeoutSec = timeoutMs / 1000
-        for {
-          _ <- IO.delay(logger.withContext("suite", suite.value).error(s"⏰ timed out after ${timeoutSec}s"))
-          _ <- threadDumpInfo.flatMap(_.singleThreadStack) match {
-            case Some(stack) => log(s"  Stack trace:\n$stack")
-            case None        => IO.unit
-          }
-          _ <- threadDumpInfo.flatMap(_.dumpFile) match {
-            case Some(path) => log(s"  Full thread dump: $path")
-            case None       => IO.unit
-          }
-        } yield ()
+        IO.delay(logger.withContext("suite", suite.value).error(s"⏰ timed out after ${timeoutSec}s"))
 
       case BuildEvent.SuiteError(_, suite, error, processExit, _, _) =>
         val desc = processExit match {

--- a/bleep-core/src/scala/bleep/testing/BuildState.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildState.scala
@@ -301,6 +301,8 @@ object BuildStateReducer {
 
     case BuildEvent.SuiteTimedOut(project, suite, timeoutMs, threadDumpInfo, _) =>
       val key = SuiteKey(project, suite)
+      // jstack dump arrives via `threadDumpInfo.singleThreadStack` (see ReactiveBsp's SuiteTimedOut translation);
+      // expose it as `failure.throwable` so BuildDisplay's summary Timeouts section renders it under "Stack trace:".
       val timeoutFailure = TestFailure(
         project = project,
         suite = suite,
@@ -316,6 +318,7 @@ object BuildStateReducer {
         testsTimedOut = state.testsTimedOut + 1,
         runningSuites = state.runningSuites - key,
         suiteStartTimes = state.suiteStartTimes - key,
+        pendingOutput = state.pendingOutput - key,
         failures = timeoutFailure :: state.failures
       )
 

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -10,6 +10,7 @@ import java.nio.file.Path
 import java.security.MessageDigest
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration._
+import scala.util.Properties
 import scala.util.control.NonFatal
 
 /** A pool of reusable JVM processes for running tests.
@@ -62,6 +63,14 @@ trait TestJvm {
 
   /** Get a thread dump from the JVM */
   def getThreadDump: IO[Option[TestProtocol.TestResponse.ThreadDump]]
+
+  /** Get a thread dump of the child JVM as a list of lines. Spawns `jstack <pid>` from the same JDK as `jvmCommand`; jstack writes its output to its own
+    * stdout, so the dump stream is clean and decoupled from the test JVM's stdio (which is otherwise busy with the JSON-RPC protocol). Returns Nil if jstack
+    * isn't available, the child has already died, or the call times out. Best-effort — never throws.
+    *
+    * Useful right before a forced kill on suite-idle timeout: surfaces *what* the test was stuck on instead of the user just seeing "timed out, no output".
+    */
+  def dumpThreads: IO[List[String]]
 
   /** Read any available stderr lines (non-blocking) */
   def drainStderr: IO[List[String]]
@@ -131,7 +140,8 @@ object JvmPool {
       val stdin: PrintWriter,
       val stdout: BufferedReader,
       val stderr: BufferedReader,
-      val key: JvmKey
+      val key: JvmKey,
+      val jvmCommand: Path
   ) {
     @volatile private var alive = true
     @volatile private var _protocolClean = true
@@ -167,6 +177,44 @@ object JvmPool {
 
     def markDead(): Unit =
       alive = false
+
+    /** Get a thread dump of the child JVM. Spawns `<jvmCommand-dir>/jstack <pid>` and captures its stdout — independent of the child's own stdio, so the dump
+      * doesn't collide with the child's JSON-RPC protocol stream. Returns Nil if jstack isn't on disk, the child has died, or the call times out within 10s.
+      * Best-effort everywhere — never throws.
+      */
+    def dumpThreads(): List[String] = {
+      if (!process.isAlive) return Nil
+      val jstackBin = {
+        val name = if (Properties.isWin) "jstack.exe" else "jstack"
+        jvmCommand.getParent.resolve(name)
+      }
+      if (!java.nio.file.Files.isExecutable(jstackBin)) return Nil
+      try {
+        val pid = process.pid()
+        val pb = new ProcessBuilder(jstackBin.toString, pid.toString)
+        pb.redirectErrorStream(true)
+        val p = pb.start()
+        // jstack prints to stdout; capture it line-by-line.
+        val reader = new BufferedReader(new InputStreamReader(p.getInputStream))
+        val buffer = scala.collection.mutable.ListBuffer.empty[String]
+        val drainer = new Thread(s"jstack-drain-${process.pid}") {
+          override def run(): Unit =
+            try {
+              var line = reader.readLine()
+              while (line != null) {
+                buffer.synchronized(buffer += line)
+                line = reader.readLine()
+              }
+            } catch { case NonFatal(_) => () }
+        }
+        drainer.setDaemon(true)
+        drainer.start()
+        val finished = p.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)
+        if (!finished) p.destroyForcibly()
+        drainer.join(1000)
+        buffer.synchronized(buffer.toList)
+      } catch { case NonFatal(_) => Nil }
+    }
 
     def kill(): Unit = {
       alive = false
@@ -311,7 +359,7 @@ object JvmPool {
           val stdout = new BufferedReader(new InputStreamReader(process.getInputStream))
           val stderr = new BufferedReader(new InputStreamReader(process.getErrorStream))
 
-          new ManagedJvm(process, stdin, stdout, stderr, key)
+          new ManagedJvm(process, stdin, stdout, stderr, key, jvmCommand)
         }
         .flatTap(jvm => allJvms.update(_ + jvm))
         .flatTap(jvm =>
@@ -470,6 +518,9 @@ object JvmPool {
           if (output.isEmpty) Nil
           else output.split('\n').toList
         }
+
+      override def dumpThreads: IO[List[String]] =
+        IO.blocking(jvm.dumpThreads())
 
       override def isAlive: IO[Boolean] =
         IO(jvm.isAlive)

--- a/bleep-model/src/scala/bleep/BleepFileCache.scala
+++ b/bleep-model/src/scala/bleep/BleepFileCache.scala
@@ -1,0 +1,42 @@
+package bleep
+
+import coursier.cache.FileCache
+import coursier.util.Task
+
+/** Bleep-wide [[FileCache]] factory.
+  *
+  * Coursier's [[FileCache]] in this version (`io.get-coursier:coursier-cache_2.13:2.1.24`) exposes no API for read/connect timeouts. The underlying
+  * `HttpURLConnection` therefore uses the JVM defaults, which are **infinite** unless overridden by the `sun.net.client.defaultConnectTimeout` /
+  * `defaultReadTimeout` system properties.
+  *
+  * Without those overrides, a stalled HTTPS read in coursier (e.g. a redirect chase that lands on a slow server) blocks the coursier-pool thread forever, which
+  * in turn blocks the calling code via the `Await.result(..., Inf)` patterns in [[bleep.FetchJvm]] and friends. Surfaced on GHA as the IT-suite hang in #580 —
+  * a coursier-pool thread sat in `sun.security.ssl.SSLSocketImpl.read` for the entire 120 s suite-idle window.
+  *
+  * [[ensureSystemPropertyDefaults]] sets the two `sun.net.client.*` properties if they aren't already configured. We call it from this object's static
+  * initializer so any [[apply]]/[[at]] consumer also gets the timeouts in effect. Anyone else creating their own HttpURLConnection inherits the same defaults
+  * from here on.
+  */
+object BleepFileCache {
+  import scala.concurrent.duration.*
+
+  /** Time to wait while opening a TCP connection. */
+  val connectTimeoutMs: Long = 10.seconds.toMillis
+
+  /** Per-read socket timeout — fires only on stalled connections, not on slow but progressing downloads. */
+  val readTimeoutMs: Long = 30.seconds.toMillis
+
+  ensureSystemPropertyDefaults()
+
+  /** Idempotent. Sets the JVM-wide HTTP/HTTPS connect/read timeouts unless the user already set them. */
+  def ensureSystemPropertyDefaults(): Unit = {
+    if (System.getProperty("sun.net.client.defaultConnectTimeout") == null)
+      System.setProperty("sun.net.client.defaultConnectTimeout", connectTimeoutMs.toString)
+    if (System.getProperty("sun.net.client.defaultReadTimeout") == null)
+      System.setProperty("sun.net.client.defaultReadTimeout", readTimeoutMs.toString)
+  }
+
+  def apply(): FileCache[Task] = FileCache[Task]()
+
+  def at(location: java.io.File): FileCache[Task] = FileCache[Task](location)
+}

--- a/bleep-model/src/scala/bleep/FetchGoogleJavaFormat.scala
+++ b/bleep-model/src/scala/bleep/FetchGoogleJavaFormat.scala
@@ -11,7 +11,7 @@ object FetchGoogleJavaFormat {
   val DefaultVersion = "1.33.0"
 
   def apply(cacheLogger: CacheLogger, ec: ExecutionContext, version: String): Path = {
-    val fileCache = FileCache[Task]().withLogger(cacheLogger)
+    val fileCache = BleepFileCache().withLogger(cacheLogger)
     val artifact = Artifact.apply(
       s"https://github.com/google/google-java-format/releases/download/v$version/google-java-format-$version-all-deps.jar"
     )

--- a/bleep-model/src/scala/bleep/FetchJvm.scala
+++ b/bleep-model/src/scala/bleep/FetchJvm.scala
@@ -51,7 +51,7 @@ case class FetchJvm(maybeCacheDir: Option[Path], cacheLogger: CacheLogger, ec: E
 
 object FetchJvm {
   def doFetch(cacheLogger: CacheLogger, jvm: model.Jvm, ec: ExecutionContext, arch: String): Path = {
-    val fileCache = FileCache[Task]().withLogger(cacheLogger)
+    val fileCache = BleepFileCache().withLogger(cacheLogger)
     val jvmCache = JvmCache()
       .withArchiveCache(ArchiveCache[Task]().withCache(fileCache))
       .withIndex(jvm.index.getOrElse(JvmChannel.gitHubIndexUrl))

--- a/bleep-model/src/scala/bleep/FetchNode.scala
+++ b/bleep-model/src/scala/bleep/FetchNode.scala
@@ -17,7 +17,7 @@ class FetchNode(logger: CacheLogger, ec: ExecutionContext) {
       case OsArch.LinuxArm64    => s"https://nodejs.org/dist/v$nodeVersion/node-v$nodeVersion-linux-arm64.tar.gz"
       case other                => throw new BleepException.Text(s"todo: implement FetchNode for $other")
     }
-    val fileCache = FileCache[Task]().withLogger(logger)
+    val fileCache = BleepFileCache().withLogger(logger)
     val cache = ArchiveCache[Task]().withCache(fileCache)
 
     Await.result(cache.get(Artifact(url)).value(ec), Duration.Inf) match {

--- a/bleep-model/src/scala/bleep/FetchSbt.scala
+++ b/bleep-model/src/scala/bleep/FetchSbt.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{Await, ExecutionContext}
 class FetchSbt(logger: CacheLogger, ec: ExecutionContext) {
   def apply(version: String): Path = {
     val url = s"https://github.com/sbt/sbt/releases/download/v$version/sbt-$version.zip"
-    val fileCache = FileCache[Task]().withLogger(logger)
+    val fileCache = BleepFileCache().withLogger(logger)
     val cache = ArchiveCache[Task]().withCache(fileCache)
     val os = JvmChannel.defaultOs()
 

--- a/bleep-model/src/scala/bleep/FetchScalafmt.scala
+++ b/bleep-model/src/scala/bleep/FetchScalafmt.scala
@@ -20,7 +20,7 @@ object FetchScalafmt {
     }
 
     val url = s"https://github.com/scalameta/scalafmt/releases/download/v$version/${asset.filename}"
-    val fileCache = FileCache[Task]().withLogger(cacheLogger)
+    val fileCache = BleepFileCache().withLogger(cacheLogger)
 
     if (asset.isArchive) fetchArchive(fileCache, ec, url)
     else fetchStandalone(fileCache, ec, url)

--- a/bleep-tests/src/scala/bleep/IntegrationTestHarness.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationTestHarness.scala
@@ -137,7 +137,7 @@ class Workspace(
     startedOpt match {
       case Some(s) => s
       case None    =>
-        val storingLogger = Loggers.storing()
+        val storingLogger = ThreadSafeStoringLogger()
         val stdLogger = parentLogger.withContext("testName", testName)
         val existingBuild = BuildLoader.find(root).existing.orThrow
         val buildPaths = BuildPaths(cwd = root, existingBuild, model.BuildVariant.Normal)
@@ -167,6 +167,11 @@ class Workspace(
 
   /** Run `bleep new` against [[root]] to scaffold a fresh build for the given language. Writes bleep.yaml + Main + MainTest. Idempotent w.r.t. [[start]] — call
     * [[start]] afterwards to bootstrap.
+    *
+    * The scaffolded `bleep.yaml` gets `$version: dev` rather than the running bleep's current version, so the inner workspace's `bleep-test-runner` dep
+    * resolves to `dev:<workspaceDir>` and short-circuits through `BleepDevDeps.resolveFromJvmClasspath` to the same `bleep-test-runner/classes` directory
+    * already on this JVM's classpath. Without this, ITs would try to resolve `bleep-test-runner:1.0.0-MX` from Maven Central — which only works if that exact
+    * release was published, and fails outright on CI runners where the running bleep version may be `0.0.0+...-SNAPSHOT` (no git tags).
     */
   def bleepNew(language: BuildCreateNew.Language, name: String): Unit = {
     val cmd = BuildCreateNew(
@@ -177,7 +182,7 @@ class Workspace(
       platforms = cats.data.NonEmptyList.of(model.PlatformId.Jvm),
       scalas = cats.data.NonEmptyList.of(model.VersionScala.Scala3),
       name = name,
-      bleepVersion = model.BleepVersion.current,
+      bleepVersion = model.BleepVersion.dev,
       coursierResolver = CoursierResolver.Factory.default
     )
     cmd.run().orThrow
@@ -185,11 +190,20 @@ class Workspace(
 
   /** Read a file written by [[bleepNew]] (or any other workspace setup) and tag it as a snippet. The content is mirrored to `<snippetsRoot>/<snippet>` when the
     * test body completes.
+    *
+    * For bleep.yaml content the in-test `$version: dev` is rewritten to the latest release tag so docs are copy-pasteable. Same trick as [[snippetWithPrelude]]
+    * uses for the manually-authored prelude path.
     */
   def attachSnippet(relPath: String, snippet: String): Unit = {
     val source = root.resolve(relPath)
-    val content = Files.readString(source)
+    val raw = Files.readString(source)
+    val content = if (relPath.endsWith("bleep.yaml")) normalizeDevVersionForDocs(raw) else raw
     taggedSnippets.update(snippet, content)
+  }
+
+  private def normalizeDevVersionForDocs(yaml: String): String = {
+    val release = model.BleepVersion.current.value.takeWhile(_ != '+')
+    yaml.replaceFirst("(?m)^\\$version: dev$", s"\\$$version: $release")
   }
 
   /** Mirror `userYaml` (with the published `$schema` / `$version` / `jvm` prelude) to `<snippetsRoot>/<snippet>` without affecting the workspace bleep.yaml.

--- a/bleep-tests/src/scala/bleep/ThreadSafeStoringLogger.scala
+++ b/bleep-tests/src/scala/bleep/ThreadSafeStoringLogger.scala
@@ -1,0 +1,41 @@
+package bleep
+
+import fansi.Str
+import ryddig.{Ctx, Formatter, LogLevel, LoggerFn, Metadata, Stored, TypedLogger}
+
+import java.util.concurrent.ConcurrentLinkedDeque
+import scala.jdk.CollectionConverters.*
+
+/** Thread-safe drop-in replacement for `ryddig.Loggers.storing()`.
+  *
+  * Ryddig 0.0.6's `TypedLogger.Store` uses an unsynchronized `var reversed: List[Stored]` with a `reversed = s :: reversed` write — classic lost-update race
+  * when multiple threads emit log lines concurrently (in-process BSP server fibers, subprocess output drain threads, the test thread itself). Under load, log
+  * entries silently disappear, which is how `YourFirstProjectIT` flaked: the subprocess's "Hello, World!" line was printed to stdout but lost on the way into
+  * the in-memory store, so the assertion failed even though the message had been emitted.
+  *
+  * Same external interface as the ryddig version (`TypedLogger[Array[Stored]]`); only difference is the underlying buffer is a `ConcurrentLinkedDeque`.
+  * Children created via `withContext`/`withPath` share the same buffer, exactly like the ryddig version.
+  */
+object ThreadSafeStoringLogger {
+  def apply(): TypedLogger[Array[Stored]] =
+    new Impl(new ConcurrentLinkedDeque[Stored](), Map.empty[String, Str], Nil)
+
+  private final class Impl(buffer: ConcurrentLinkedDeque[Stored], val context: Ctx, val path: List[String]) extends TypedLogger[Array[Stored]] {
+
+    override def apply[T: Formatter](t: => T, throwable: Option[Throwable], metadata: Metadata): Unit =
+      buffer.add(Stored(Formatter(t), throwable, metadata, context, path))
+
+    override def withContext[T: Formatter](key: String, value: T): TypedLogger[Array[Stored]] =
+      new Impl(buffer, context + (key -> Formatter(value)), path)
+
+    override def withPath(fragment: String): TypedLogger[Array[Stored]] =
+      new Impl(buffer, context, fragment :: path)
+
+    override def underlying: Array[Stored] =
+      buffer.iterator().asScala.toArray
+
+    override def progressMonitor: Option[LoggerFn] = None
+
+    override val minLogLevel: LogLevel = LogLevel.debug
+  }
+}


### PR DESCRIPTION
Fix the chain of independent issues that caused the YourFirst{Project,ScalaProject,KotlinProject}IT and JvmRunIT suites to hang for 120s on GHA runners with zero diagnostic output.

## Root causes (all six)

1. **Unbounded coursier HTTP timeouts** — `coursier-cache:2.1.24` exposes no timeout API; the underlying `HttpURLConnection` inherits JVM defaults (infinite). A stalled HTTPS read sat in `sun.security.ssl.SSLSocketImpl.read` for the full suite-idle window. Fix: new `BleepFileCache` factory sets `sun.net.client.default{Connect,Read}Timeout` (10s/30s) in its static initializer; all `Fetch*` call sites + `BuildUpdateDeps` + `CoursierResolver` use it.

2. **No thread-dump on idle timeout** — when a forked test JVM hung the user just got "Suite idle timeout after 120s". Fix: `JvmPool.dumpThreads` shells out to `<javaHome>/bin/jstack <pid>` and captures its stdout (decoupled from the child's JSON-RPC stdio). The dump rides through `TaskResult.TimedOut(threadDump)` → `BleepBspProtocol.Event.SuiteTimedOut.threadDump` → `TestFailure.throwable` → summary's Timeouts section. New `bleep.analysis.JstackThreadDumpTest` exercises the production path.

3. **Re-resolving the same 4 stable test-framework deps on every `commands.test`** — `test-interface`/`jupiter-interface`/`junit-platform-launcher`/`junit-vintage-engine` were re-fetched per inner-bleep workspace. Fix: process-wide `AtomicReference` cache on `MultiWorkspaceBspServer` companion. Split into `fetchBleepTestRunnerOnly` (per-call, dev-version-aware) and `fetchExternalTestRunnerDeps` (cached).

4. **Synchronous `Await.result` on the IOFiber's compute thread** — `getTestClasspath` ends in `Fetch.eitherResult` → `Await.result(future, Inf)`. In the in-process BSP path used by ITs, that compute thread is shared with the BSP pipe reader; holding it for an entire resolve produced the deadlock pattern in the dumps (`bsp-client-worker` and `io-compute-blocker-7` both parked on `PipedInputStream.read`). Fix: wrap `testHandler` and `linkHandler`'s `getTestClasspath` calls in `IO.blocking`.

5. **ITs scaffolding inner workspaces with a release version** — `BuildCreateNew` baked `latestRelease` into the new workspace's `$version`, so the inner BSP tried to fetch `bleep-test-runner:1.0.0-MX` from Maven Central — works only when that exact release exists, fails outright on CI runners where `dynver` returns `0.0.0+...-SNAPSHOT` (no git tags fetched). Fix: `IntegrationTestHarness.bleepNew` passes `BleepVersion.dev` so `BleepDevDeps.resolveFromJvmClasspath` short-circuits to the parent JVM's `bleep-test-runner/classes`. `attachSnippet` rewrites `$version: dev` → `$version: <latestRelease>` so docs snippets stay copy-pasteable.

6. **Lost-update race in `ryddig.TypedLogger.Store`** — the storing logger's `var reversed: List[Stored]` write isn't synchronized; under parallelism the subprocess's `"Hello, World!"` line was silently dropped from the in-memory store even though it was emitted. Fix: drop-in `ThreadSafeStoringLogger` using `ConcurrentLinkedDeque`, same `TypedLogger[Array[Stored]]` interface.

7. **Drop the IT exclusions in `build.yml`** — with all of the above applied, the four suites pass on CI without timing out.

## Test plan

- [x] `bleep compile` clean
- [x] `bleep fmt` clean
- [x] `bleep test bleep-bsp-tests --only bleep.analysis.JstackThreadDumpTest` passes
- [x] All four previously-hanging IT suites pass locally at parallelism that triggered the flake (`YourFirstProjectIT`, `YourFirstScalaProjectIT`, `YourFirstKotlinProjectIT`, `JvmRunIT`)
- [ ] CI on PR runs all suites without `--exclude`

Closes #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)