### PR TITLE
Fix remote cache on Windows; regenerate noop manifest after pull

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,19 +6,4 @@ project.excludePaths = [
   "glob:**/snapshot-tests/**",
   "glob:**/snapshot-tests-in/**",
 ]
-runner.dialect = Scala213Source3
-
-fileOverride {
-  "glob:**/liberated/mdoc/**/scala-3/**" {
-    runner.dialect = scala3
-  }
-  "glob:**/bleep-bsp/**" {
-    runner.dialect = scala3
-  }
-  "glob:**/bleep-bsp-tests/**" {
-    runner.dialect = scala3
-  }
-  "glob:**/bleep-cli/src/scala-3/**" {
-    runner.dialect = scala3
-  }
-}
+runner.dialect = scala3

--- a/bleep-bsp-tests/src/scala/bleep/analysis/IncrementalCompilationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/IncrementalCompilationTest.scala
@@ -182,7 +182,6 @@ class IncrementalTrackingTest extends AnyFunSuite with Matchers {
       val language: ProjectLanguage.ScalaJava = ProjectLanguage.ScalaJava(
         scalaVersion = "3.3.3",
         scalaOptions = Nil,
-        javaRelease = None,
         javaOptions = Nil
       )
 
@@ -240,7 +239,6 @@ class IncrementalTrackingTest extends AnyFunSuite with Matchers {
       val language: ProjectLanguage.ScalaJava = ProjectLanguage.ScalaJava(
         scalaVersion = "3.3.3",
         scalaOptions = Nil,
-        javaRelease = None,
         javaOptions = Nil
       )
 

--- a/bleep-bsp-tests/src/scala/bleep/analysis/PlatformTestHelper.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/PlatformTestHelper.scala
@@ -93,7 +93,7 @@ trait PlatformTestHelper {
     val language: ProjectLanguage.ScalaJava = ProjectLanguage.ScalaJava(
       scalaVersion = scalaVersion,
       scalaOptions = scalaOptions,
-      javaRelease = None
+      javaOptions = Nil
     )
 
     val config = ProjectConfig(
@@ -159,7 +159,7 @@ trait PlatformTestHelper {
     val language: ProjectLanguage.ScalaJava = ProjectLanguage.ScalaJava(
       scalaVersion = scalaVersion,
       scalaOptions = scalaOptions,
-      javaRelease = None
+      javaOptions = Nil
     )
 
     val fullClasspath = (scalaLibJars ++ snLibJars ++ extraDeps).distinct

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ProjectDagTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ProjectDagTest.scala
@@ -11,7 +11,7 @@ class ProjectDagTest extends AnyFunSuite with Matchers {
     sources = Set(Paths.get(s"src/$name")),
     classpath = Seq.empty,
     outputDir = Paths.get(s"target/$name"),
-    language = ProjectLanguage.ScalaJava("3.3.3", Nil, None),
+    language = ProjectLanguage.ScalaJava("3.3.3", Nil, Nil),
     analysisDir = None,
     buildDir = Paths.get(".")
   )

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ZincCacheRoundtripTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ZincCacheRoundtripTest.scala
@@ -41,7 +41,7 @@ class ZincCacheRoundtripTest extends AnyFunSuite with Matchers with TimeLimits {
       Files.write(dir.resolve("a.txt"), "hello".getBytes)
       Files.write(dir.resolve("sub/b.bin"), Array[Byte](0, 1, 2, -1, -128, 127))
 
-      val archive = bleep.TarGz.pack(dir)
+      val archive = bleep.TarGz.pack(dir, _ => true)
       info(s"Archive: ${archive.length} bytes")
 
       val restored = workspace.resolve("restored")
@@ -104,7 +104,7 @@ class ZincCacheRoundtripTest extends AnyFunSuite with Matchers with TimeLimits {
 
           // Step 4: Pack the target dir
           val targetDir = workspace.resolve("target")
-          val archive = bleep.TarGz.pack(targetDir)
+          val archive = bleep.TarGz.pack(targetDir, _ => true)
           info(s"Packed target dir: ${archive.length} bytes")
 
           // Step 5: Delete the target dir (simulate bleep clean)

--- a/bleep-bsp/src/scala/bleep/analysis/Compiler.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/Compiler.scala
@@ -108,36 +108,6 @@ case object CompilationCancelled extends CompilationResult {
   def isSuccess: Boolean = false
 }
 
-/** A compiler error with location information */
-case class CompilerError(
-    path: Option[Path],
-    line: Int,
-    column: Int,
-    message: String,
-    rendered: Option[String],
-    severity: CompilerError.Severity
-) {
-  def formatted: String = {
-    val loc = path match {
-      case Some(p) =>
-        val locPart = (line, column) match {
-          case (0, 0) => ""
-          case (l, 0) => s":$l"
-          case (l, c) => s":$l:$c"
-        }
-        s"${p.getFileName}$locPart"
-      case None => "<unknown>"
-    }
-    s"$loc: $message"
-  }
-}
-
-object CompilerError {
-  enum Severity {
-    case Error, Warning, Info
-  }
-}
-
 /** Why compilation is triggered */
 sealed trait CompilationReason {
 
@@ -348,7 +318,6 @@ object Compiler {
     ProjectLanguage.ScalaJava(
       scalaVersion = c.version,
       scalaOptions = c.options,
-      javaRelease = None,
       javaOptions = Nil
     )
 

--- a/bleep-bsp/src/scala/bleep/analysis/ProjectCompiler.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ProjectCompiler.scala
@@ -11,79 +11,10 @@ import scala.jdk.CollectionConverters.*
   *   - Zinc handles Scala/Java incremental compilation internally
   *   - Kotlin compiler handles Kotlin incremental compilation internally
   *   - Cross-language dependencies happen only at project boundaries (via classpath)
+  *
+  * The data types `ProjectLanguage`, `ProjectConfig`, `ProjectCompileResult`, `ProjectCompileSuccess`, `ProjectCompileFailure`, and `CompilerError` live in
+  * `bleep-core` so they can be used outside the bsp server (e.g. by the remote-cache pull command for noop manifest regeneration).
   */
-
-/** Language mode for a project */
-enum ProjectLanguage {
-
-  /** Scala and Java compiled together by Zinc */
-  case ScalaJava(scalaVersion: String, scalaOptions: List[String], javaRelease: Option[Int], javaOptions: List[String] = Nil)
-
-  /** Kotlin/JVM compiled by K2JVMCompiler */
-  case Kotlin(kotlinVersion: String, jvmTarget: String, kotlinOptions: List[String], javaRelease: Option[Int])
-
-  /** Kotlin/JS compiled by K2JSCompiler
-    *
-    * @param kotlinVersion
-    *   Kotlin compiler version
-    * @param kotlinOptions
-    *   additional compiler options
-    * @param isTest
-    *   whether this is a test project (affects library resolution)
-    */
-  case KotlinJs(kotlinVersion: String, kotlinOptions: List[String], isTest: Boolean)
-
-  /** Kotlin/Native compiled by K2Native
-    *
-    * @param kotlinVersion
-    *   Kotlin compiler version
-    * @param kotlinOptions
-    *   additional compiler options
-    * @param isTest
-    *   whether this is a test project (affects library resolution)
-    */
-  case KotlinNative(kotlinVersion: String, kotlinOptions: List[String], isTest: Boolean)
-
-  /** Java-only compiled by javac or ECJ.
-    * @param release
-    *   Java release version (--release flag)
-    * @param javaOptions
-    *   additional javac options
-    * @param ecjVersion
-    *   if set, use ECJ (Eclipse Compiler for Java) instead of javac
-    */
-  case JavaOnly(release: Option[Int], javaOptions: List[String], ecjVersion: Option[String])
-}
-
-/** Configuration for compiling a project */
-case class ProjectConfig(
-    name: String,
-    sources: Set[Path],
-    classpath: Seq[Path],
-    outputDir: Path,
-    language: ProjectLanguage,
-    analysisDir: Option[Path],
-    buildDir: Path
-)
-
-/** Result of compiling a project */
-sealed trait ProjectCompileResult {
-  def isSuccess: Boolean
-}
-
-case class ProjectCompileSuccess(
-    outputDir: Path,
-    classFiles: Set[Path],
-    analysisFile: Option[Path]
-) extends ProjectCompileResult {
-  def isSuccess: Boolean = true
-}
-
-case class ProjectCompileFailure(
-    errors: List[CompilerError]
-) extends ProjectCompileResult {
-  def isSuccess: Boolean = false
-}
 
 /** Trait for compiling a single project.
   *
@@ -454,11 +385,12 @@ object JavacProjectCompiler extends ProjectCompiler {
   ): IO[ProjectCompileResult] =
     config.language match {
       case javaLang: ProjectLanguage.JavaOnly =>
-        // Convert to ScalaJava with empty Scala options - Zinc will only compile .java files
+        // Convert to ScalaJava with empty Scala options - Zinc will only compile .java files.
+        // `--release` from JavaOnly.javaOptions carries through; the typed JavaOnly.release is
+        // unrelated (it's used by the Kotlin/javac path elsewhere).
         val scalaJavaLang: ProjectLanguage.ScalaJava = ProjectLanguage.ScalaJava(
           scalaVersion = zincScalaVersion,
           scalaOptions = List.empty,
-          javaRelease = javaLang.release,
           javaOptions = javaLang.javaOptions
         )
         val javaConfig = config.copy(language = scalaJavaLang)

--- a/bleep-bsp/src/scala/bleep/analysis/ZincBridge.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ZincBridge.scala
@@ -1,10 +1,9 @@
 package bleep.analysis
 
 import cats.effect.IO
-import java.io.{DataInputStream, DataOutputStream, File, IOException}
+import java.io.{File, IOException}
 import java.lang.ref.SoftReference
 import java.nio.file.{Files, Path, StandardCopyOption, StandardOpenOption}
-import java.nio.file.attribute.BasicFileAttributes
 import java.util.Optional
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
@@ -48,12 +47,9 @@ object ProgressListener {
   */
 object ZincBridge {
 
-  /** Drop source directories that are nested under another source directory. E.g. given {src, src/java}, drop src/java since walking src already covers it.
-    */
-  private[analysis] def removeNestedDirs(dirs: Set[Path]): Set[Path] = {
-    val abs = dirs.map(_.toAbsolutePath.normalize())
-    abs.filter(d => !abs.exists(other => other != d && d.startsWith(other)))
-  }
+  /** Re-exported from NoopManifestStore for callers in this module that already imported it from here. */
+  private[analysis] def removeNestedDirs(dirs: Set[Path]): Set[Path] =
+    NoopManifestStore.removeNestedDirs(dirs)
 
   // ─── Cached compiler infrastructure ───────────────────────────────────────
   // Safe to share: immutable values and stateless objects.
@@ -121,24 +117,14 @@ object ZincBridge {
   // by ALL file operations (cp, mv, rsync -a, tar x, touch -t, echo >, git ops).
   // Non-root users cannot fake it. This gives a reliable "was this file touched?"
   // signal without reading file contents (~3-5μs/call vs ~3ms/file for FarmHash).
+  //
+  // Manifest data types + serialization live in bleep-core's NoopManifestStore so
+  // RemoteCache.Pull can regenerate them locally after extraction.
 
-  private case class FileStatEntry(ctimeMillis: Long, mtimeMillis: Long, size: Long)
-
-  private case class NoopManifest(
-      sourceStats: Map[Path, FileStatEntry],
-      sourceDirStats: Map[Path, FileStatEntry], // source dir → stat (detects file add/delete)
-      outputDirStats: Map[Path, FileStatEntry], // output dir + subdirs → stat (detects class file add/delete)
-      depAnalysisStats: Map[Path, Long], // outputDir → dep analysis mtime millis
-      optionsHash: Long,
-      cachedResult: ProjectCompileSuccess
-  )
+  import NoopManifestStore.{FileStatEntry, NoopManifest}
 
   private val noopManifestCache = new java.util.concurrent.ConcurrentHashMap[Path, NoopManifest]()
-  private val ctimeAvailable: Boolean =
-    !System.getProperty("os.name", "").toLowerCase.contains("win")
-
-  private val NoopManifestMagic: Int = 0x4e4f4f50
-  private val NoopManifestVersion: Byte = 3
+  private def ctimeAvailable: Boolean = NoopManifestStore.ctimeAvailable
 
   private val debugLogFile = Path.of(System.getProperty("user.home"), ".bleep", "zinc-debug.log")
   private val debugEnabled = System.getProperty("bleep.zinc.debug", "false").toBoolean
@@ -242,7 +228,7 @@ object ZincBridge {
       val mem = noopManifestCache.get(analysisFile)
       if (mem != null) mem
       else {
-        loadNoopManifest(analysisFile) match {
+        NoopManifestStore.load(analysisFile) match {
           case Some(disk) =>
             noopManifestCache.put(analysisFile, disk)
             disk
@@ -400,44 +386,14 @@ object ZincBridge {
     Some(manifest.cachedResult)
   }
 
-  /** Stat a file: read ctime, mtime, size. */
-  private def statFile(path: Path): FileStatEntry = {
-    val attrs = Files.readAttributes(path, classOf[BasicFileAttributes])
-    val ctimeAttr = Files.getAttribute(path, "unix:ctime").asInstanceOf[java.nio.file.attribute.FileTime]
-    FileStatEntry(
-      ctimeMillis = ctimeAttr.toMillis,
-      mtimeMillis = attrs.lastModifiedTime().toMillis,
-      size = attrs.size()
-    )
-  }
+  private def statFile(path: Path): FileStatEntry = NoopManifestStore.statFile(path)
 
-  /** FNV-1a hash of compiler options for cheap equality check. */
-  private def computeOptionsHash(language: ProjectLanguage.ScalaJava, ecjVersion: Option[String]): Long = {
-    var hash = 0xcbf29ce484222325L
-    val prime = 0x100000001b3L
-
-    def mix(s: String): Unit = {
-      var i = 0
-      while (i < s.length) {
-        hash ^= s.charAt(i).toLong
-        hash *= prime
-        i += 1
-      }
-      hash ^= 0L // separator
-      hash *= prime
-    }
-
-    mix(language.scalaVersion)
-    language.scalaOptions.foreach(mix)
-    language.javaRelease.foreach(r => mix(r.toString))
-    language.javaOptions.foreach(mix)
-    ecjVersion.foreach(mix)
-    hash
-  }
+  private def computeOptionsHash(language: ProjectLanguage.ScalaJava, ecjVersion: Option[String]): Long =
+    NoopManifestStore.computeOptionsHash(language, ecjVersion)
 
   // ─── Noop manifest: save ────────────────────────────────────────────────
 
-  /** Save a noop manifest after successful compilation. */
+  /** Save a noop manifest after successful compilation. Walks the source VirtualFiles to extract paths, then delegates to NoopManifestStore. */
   private def saveNoopManifest(
       analysisFile: Path,
       sourceDirs: Set[Path],
@@ -447,219 +403,23 @@ object ZincBridge {
       ecjVersion: Option[String],
       result: ProjectCompileSuccess
   ): Unit = {
-    if (!ctimeAvailable) return
-
-    val sourceStats = new java.util.HashMap[Path, FileStatEntry](sources.length * 2)
+    val sourcePaths = new Array[Path](sources.length)
     var i = 0
     while (i < sources.length) {
-      val vf = sources(i)
-      val path = vf match {
+      sourcePaths(i) = sources(i) match {
         case pvf: PlainVirtualFile => pvf.path
         case other                 => Path.of(other.id())
       }
-      val stat = statFile(path)
-      sourceStats.put(path, stat)
       i += 1
     }
 
-    // Stat source directories — mtime changes on file add/delete/rename (POSIX)
-    val normalizedDirs = removeNestedDirs(sourceDirs)
-    val sourceDirStatsMap = normalizedDirs.flatMap { dir =>
-      if (Files.isDirectory(dir)) Some(dir -> statFile(dir))
-      else None
-    }.toMap
-
-    val depStats = dependencyAnalyses.map { case (outputDir, depAnalysisFile) =>
-      val mtime = if (Files.exists(depAnalysisFile)) Files.getLastModifiedTime(depAnalysisFile).toMillis else 0L
-      outputDir -> mtime
+    NoopManifestStore.regenerateFromLocal(analysisFile, sourceDirs, sourcePaths, dependencyAnalyses, language, ecjVersion, result) match {
+      case Some(manifest) => noopManifestCache.put(analysisFile, manifest)
+      case None           => () // ctime unavailable (Windows) — manifest disabled
     }
-
-    // Stat output directories (outputDir + all subdirs).
-    // Directory mtime changes on file add/delete — catches class file deletion cheaply.
-    val outputDirStatsMap: Map[Path, FileStatEntry] =
-      if (Files.isDirectory(result.outputDir)) {
-        import scala.jdk.CollectionConverters.*
-        val dirs = scala.util
-          .Using(Files.walk(result.outputDir)) { stream =>
-            stream.iterator().asScala.filter(Files.isDirectory(_)).toArray
-          }
-          .getOrElse(Array.empty[Path])
-        dirs.map(d => d -> statFile(d)).toMap
-      } else Map.empty
-
-    val manifest = NoopManifest(
-      sourceStats = {
-        import scala.jdk.CollectionConverters.*
-        sourceStats.asScala.toMap
-      },
-      sourceDirStats = sourceDirStatsMap,
-      outputDirStats = outputDirStatsMap,
-      depAnalysisStats = depStats,
-      optionsHash = computeOptionsHash(language, ecjVersion),
-      cachedResult = result
-    )
-
-    noopManifestCache.put(analysisFile, manifest)
-    writeNoopManifest(analysisFile, manifest)
   }
 
-  // ─── Noop manifest: disk I/O ───────────────────────────────────────────
-
-  private def manifestPath(analysisFile: Path): Path =
-    analysisFile.resolveSibling("noop-manifest.bin")
-
-  private def writeNoopManifest(analysisFile: Path, manifest: NoopManifest): Unit = {
-    val target = manifestPath(analysisFile)
-    val tmpFile = target.resolveSibling(target.getFileName.toString + ".tmp")
-    val out = new DataOutputStream(new java.io.BufferedOutputStream(Files.newOutputStream(tmpFile)))
-    try {
-      out.writeInt(NoopManifestMagic)
-      out.writeByte(NoopManifestVersion)
-      out.writeLong(manifest.optionsHash)
-
-      // Sources
-      out.writeInt(manifest.sourceStats.size)
-      manifest.sourceStats.foreach { case (path, stat) =>
-        out.writeUTF(path.toString)
-        out.writeLong(stat.ctimeMillis)
-        out.writeLong(stat.mtimeMillis)
-        out.writeLong(stat.size)
-      }
-
-      // Source directories
-      out.writeInt(manifest.sourceDirStats.size)
-      manifest.sourceDirStats.foreach { case (dir, stat) =>
-        out.writeUTF(dir.toString)
-        out.writeLong(stat.ctimeMillis)
-        out.writeLong(stat.mtimeMillis)
-        out.writeLong(stat.size)
-      }
-
-      // Output directories
-      out.writeInt(manifest.outputDirStats.size)
-      manifest.outputDirStats.foreach { case (dir, stat) =>
-        out.writeUTF(dir.toString)
-        out.writeLong(stat.ctimeMillis)
-        out.writeLong(stat.mtimeMillis)
-        out.writeLong(stat.size)
-      }
-
-      // Dependency analyses
-      out.writeInt(manifest.depAnalysisStats.size)
-      manifest.depAnalysisStats.foreach { case (outputDir, mtime) =>
-        out.writeUTF(outputDir.toString)
-        out.writeLong(mtime)
-      }
-
-      // Cached result
-      out.writeUTF(manifest.cachedResult.outputDir.toString)
-      val analysisPath = manifest.cachedResult.analysisFile match {
-        case Some(p) => p.toString
-        case None    => ""
-      }
-      out.writeUTF(analysisPath)
-      out.writeInt(manifest.cachedResult.classFiles.size)
-      manifest.cachedResult.classFiles.foreach(cf => out.writeUTF(cf.toString))
-
-      out.flush()
-    } finally out.close()
-
-    val _ = Files.move(tmpFile, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-  }
-
-  /** Load noop manifest from disk. Returns None if file doesn't exist or has a stale format version. */
-  private def loadNoopManifest(analysisFile: Path): Option[NoopManifest] = {
-    val target = manifestPath(analysisFile)
-    if (!Files.exists(target)) return None
-
-    val in = new DataInputStream(new java.io.BufferedInputStream(Files.newInputStream(target)))
-    try {
-      val magic = in.readInt()
-      if (magic != NoopManifestMagic)
-        throw new IllegalStateException(s"Bad noop-manifest magic: 0x${magic.toHexString}, expected 0x${NoopManifestMagic.toHexString}")
-      val version = in.readByte()
-      if (version != NoopManifestVersion) return None // stale format — treat as cache miss
-      val optionsHash = in.readLong()
-
-      // Sources
-      val sourceCount = in.readInt()
-      val sourceStatsBuilder = Map.newBuilder[Path, FileStatEntry]
-      sourceStatsBuilder.sizeHint(sourceCount)
-      var i = 0
-      while (i < sourceCount) {
-        val path = Path.of(in.readUTF())
-        val ctime = in.readLong()
-        val mtime = in.readLong()
-        val size = in.readLong()
-        sourceStatsBuilder += path -> FileStatEntry(ctime, mtime, size)
-        i += 1
-      }
-
-      // Source directories
-      val dirCount = in.readInt()
-      val sourceDirStatsBuilder = Map.newBuilder[Path, FileStatEntry]
-      sourceDirStatsBuilder.sizeHint(dirCount)
-      i = 0
-      while (i < dirCount) {
-        val dir = Path.of(in.readUTF())
-        val dirCtime = in.readLong()
-        val dirMtime = in.readLong()
-        val dirSize = in.readLong()
-        sourceDirStatsBuilder += dir -> FileStatEntry(dirCtime, dirMtime, dirSize)
-        i += 1
-      }
-
-      // Output directories
-      val outDirCount = in.readInt()
-      val outputDirStatsBuilder = Map.newBuilder[Path, FileStatEntry]
-      outputDirStatsBuilder.sizeHint(outDirCount)
-      i = 0
-      while (i < outDirCount) {
-        val dir = Path.of(in.readUTF())
-        val outCtime = in.readLong()
-        val outMtime = in.readLong()
-        val outSize = in.readLong()
-        outputDirStatsBuilder += dir -> FileStatEntry(outCtime, outMtime, outSize)
-        i += 1
-      }
-
-      // Dependency analyses
-      val depCount = in.readInt()
-      val depStatsBuilder = Map.newBuilder[Path, Long]
-      depStatsBuilder.sizeHint(depCount)
-      i = 0
-      while (i < depCount) {
-        val outputDir = Path.of(in.readUTF())
-        val mtime = in.readLong()
-        depStatsBuilder += outputDir -> mtime
-        i += 1
-      }
-
-      // Cached result
-      val outputDir = Path.of(in.readUTF())
-      val analysisPathStr = in.readUTF()
-      val cachedAnalysisFile = if (analysisPathStr.isEmpty) None else Some(Path.of(analysisPathStr))
-      val classFileCount = in.readInt()
-      val classFilesBuilder = Set.newBuilder[Path]
-      classFilesBuilder.sizeHint(classFileCount)
-      i = 0
-      while (i < classFileCount) {
-        classFilesBuilder += Path.of(in.readUTF())
-        i += 1
-      }
-
-      Some(
-        NoopManifest(
-          sourceStats = sourceStatsBuilder.result(),
-          sourceDirStats = sourceDirStatsBuilder.result(),
-          outputDirStats = outputDirStatsBuilder.result(),
-          depAnalysisStats = depStatsBuilder.result(),
-          optionsHash = optionsHash,
-          cachedResult = ProjectCompileSuccess(outputDir, classFilesBuilder.result(), cachedAnalysisFile)
-        )
-      )
-    } finally in.close()
-  }
+  // Noop manifest disk I/O lives in NoopManifestStore (bleep-core).
 
   /** Run a single compilation attempt. Unexpected Zinc exceptions propagate. On cancellation, the analysis file is preserved so the next compile can be
     * incremental. Corrupt analysis is detected and cleaned automatically.
@@ -1125,8 +885,7 @@ object ZincBridge {
     val classpathVf = (outputDir +: config.classpath).map(p => PlainVirtualFile(p, config.buildDir): VirtualFile).toArray
 
     val scalacOptions = language.scalaOptions.toArray
-    val releaseOptions = language.javaRelease.map(r => Array(s"--release", r.toString)).getOrElse(Array.empty[String])
-    val javacOptions = releaseOptions ++ language.javaOptions.toArray
+    val javacOptions = language.javaOptions.toArray
 
     // Load analyses from dependency projects for proper incremental compilation.
     // Uses a global SoftReference cache to avoid re-reading from disk when the same

--- a/bleep-bsp/src/scala/bleep/bsp/BleepBuildConverter.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BleepBuildConverter.scala
@@ -148,16 +148,9 @@ object BleepBuildConverter {
         // Scala/Java project - check resolved config using the Language ADT
         resolved.language match {
           case scalaLang: ResolvedProject.Language.Scala =>
-            val javaRelease = scalaLang.javaOptions.collectFirst {
-              case opt if opt.startsWith("--release") =>
-                opt.stripPrefix("--release").trim.toIntOption
-              case opt if opt == "-release" =>
-                None
-            }.flatten
             ProjectLanguage.ScalaJava(
               scalaVersion = scalaLang.version,
               scalaOptions = scalaLang.options,
-              javaRelease = javaRelease,
               javaOptions = scalaLang.javaOptions ++ additionalJavaOptions
             )
 

--- a/bleep-bsp/src/scala/bleep/bsp/BspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServer.scala
@@ -932,7 +932,7 @@ class BspServer(
   /** Convert old LanguageConfig to new ProjectLanguage */
   private def convertToProjectLanguage(config: LanguageConfig): ProjectLanguage = config match {
     case sc: ScalaConfig =>
-      ProjectLanguage.ScalaJava(sc.version, sc.options, None) // ScalaConfig doesn't have Java release
+      ProjectLanguage.ScalaJava(sc.version, sc.options, Nil)
     case kc: KotlinConfig =>
       ProjectLanguage.Kotlin(kc.version, kc.jvmTarget, kc.options, None)
     case jc: JavaConfig =>

--- a/bleep-cli/src/scala/bleep/commands/BuildCreateNew.scala
+++ b/bleep-cli/src/scala/bleep/commands/BuildCreateNew.scala
@@ -332,7 +332,8 @@ object BuildCreateNew {
       ),
       resolvers = model.JsonList.empty,
       jvm = Some(model.Jvm.graalvm),
-      scripts = Map.empty
+      scripts = Map.empty,
+      remoteCache = None
     )
 
     templatesInfer(new BleepTemplateLogger(logger), explodedBuild, ignoreWhenInferringTemplates = _ => false)

--- a/bleep-cli/src/scala/bleep/mavenimport/buildFromMavenPom.scala
+++ b/bleep-cli/src/scala/bleep/mavenimport/buildFromMavenPom.scala
@@ -88,7 +88,8 @@ object buildFromMavenPom {
       explodedProjects = allProjects.toMap,
       resolvers = buildResolvers,
       jvm = jvm,
-      scripts = Map.empty
+      scripts = Map.empty,
+      remoteCache = None
     )
   }
 

--- a/bleep-cli/src/scala/bleep/sbtimport/buildFromBloopFiles.scala
+++ b/bleep-cli/src/scala/bleep/sbtimport/buildFromBloopFiles.scala
@@ -212,7 +212,7 @@ object buildFromBloopFiles {
           .toList
       )
 
-    model.Build.Exploded(bleepVersion.latestRelease, projects, buildResolvers, jvm = None, scripts = Map.empty)
+    model.Build.Exploded(bleepVersion.latestRelease, projects, buildResolvers, jvm = None, scripts = Map.empty, remoteCache = None)
   }
 
   object Configs {

--- a/bleep-core/src/scala/bleep/ProjectDigest.scala
+++ b/bleep-core/src/scala/bleep/ProjectDigest.scala
@@ -100,8 +100,9 @@ object ProjectDigest {
           // Clean directory — use git blob hashes (fast, no file I/O)
           val gitHashes = gitLsTree(buildDir, dir)
           if (gitHashes.nonEmpty) {
-            // git ls-tree returns paths relative to repo root. Make them relative to dir.
-            val dirRelToRepo = buildDir.relativize(dir).toString
+            // git ls-tree returns paths relative to repo root with '/' separators on every OS.
+            // Normalize the dir prefix so the strip works on Windows.
+            val dirRelToRepo = buildDir.relativize(dir).toString.replace('\\', '/')
             val dirPrefix = if (dirRelToRepo.isEmpty) "" else dirRelToRepo + "/"
             gitHashes.foreach { case (repoRelPath, hash) =>
               val relPath = if (repoRelPath.startsWith(dirPrefix)) repoRelPath.substring(dirPrefix.length) else repoRelPath
@@ -185,7 +186,8 @@ object ProjectDigest {
       .getOrElse(Nil)
 
     files.foreach { file =>
-      val relPath = dir.relativize(file).toString
+      // Normalize to '/' so the digest matches git ls-tree's representation across OSes.
+      val relPath = dir.relativize(file).toString.replace('\\', '/')
       val content = Files.readAllBytes(file)
       val blobHash = gitBlobHash(content)
       md.update(relPath.getBytes("UTF-8"))

--- a/bleep-core/src/scala/bleep/TarGz.scala
+++ b/bleep-core/src/scala/bleep/TarGz.scala
@@ -15,13 +15,15 @@ object TarGz {
     *
     * @param root
     *   the directory to archive
+    * @param include
+    *   predicate over each regular file's absolute path; only paths returning true are packed
     * @return
     *   gzipped tar bytes
     */
-  def pack(root: Path): Array[Byte] = {
+  def pack(root: Path, include: Path => Boolean): Array[Byte] = {
     val files = scala.util
       .Using(Files.walk(root)) { stream =>
-        stream.toScala(List).filter(Files.isRegularFile(_)).sorted
+        stream.toScala(List).filter(p => Files.isRegularFile(p) && include(p)).sorted
       }
       .getOrElse(Nil)
 

--- a/bleep-core/src/scala/bleep/analysis/NoopManifestStore.scala
+++ b/bleep-core/src/scala/bleep/analysis/NoopManifestStore.scala
@@ -1,0 +1,292 @@
+package bleep.analysis
+
+import java.io.{DataInputStream, DataOutputStream}
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{Files, Path, StandardCopyOption}
+
+/** Persistent fast-path cache that lets bleep skip Zinc entirely when nothing about a project has changed since its last successful compile.
+  *
+  * The manifest captures per-source/per-dir/per-output-dir `(ctime, mtime, size)` tuples plus a hash of compiler options and the recorded result. On the next
+  * compile attempt, [[ZincBridge.isNoop]] short-circuits when every recorded stat still matches.
+  *
+  * The format is binary; see `NoopManifestVersion` for evolution. Old versions are treated as cache misses (forces a Zinc round-trip which then writes a fresh
+  * manifest).
+  *
+  * Lives in `bleep-core` (not `bleep-bsp`) so the remote-cache pull command can regenerate manifests against the local filesystem after extracting an archive
+  * from S3 — turning the first post-pull compile into a true noop hit instead of a Zinc no-op compile.
+  */
+object NoopManifestStore {
+
+  /** Per-file (or per-directory) stat tuple captured at compile time. */
+  case class FileStatEntry(ctimeMillis: Long, mtimeMillis: Long, size: Long)
+
+  case class NoopManifest(
+      sourceStats: Map[Path, FileStatEntry],
+      sourceDirStats: Map[Path, FileStatEntry], // source dir → stat (detects file add/delete)
+      outputDirStats: Map[Path, FileStatEntry], // output dir + subdirs → stat (detects class file add/delete)
+      depAnalysisStats: Map[Path, Long], // outputDir → dep analysis mtime millis
+      optionsHash: Long,
+      cachedResult: ProjectCompileSuccess
+  )
+
+  /** True on macOS/Linux. False on Windows where Java's `unix:ctime` attribute is unsupported. When false, [[isNoop]] short-circuits to None and the manifest
+    * mechanism is fully disabled.
+    */
+  val ctimeAvailable: Boolean =
+    !System.getProperty("os.name", "").toLowerCase.contains("win")
+
+  private val NoopManifestMagic: Int = 0x4e4f4f50
+  private val NoopManifestVersion: Byte = 3
+
+  /** Path of the manifest file, sibling to the analysis file. */
+  def manifestPath(analysisFile: Path): Path =
+    analysisFile.resolveSibling("noop-manifest.bin")
+
+  /** Stat a file: read ctime, mtime, size. */
+  def statFile(path: Path): FileStatEntry = {
+    val attrs = Files.readAttributes(path, classOf[BasicFileAttributes])
+    val ctimeAttr = Files.getAttribute(path, "unix:ctime").asInstanceOf[java.nio.file.attribute.FileTime]
+    FileStatEntry(
+      ctimeMillis = ctimeAttr.toMillis,
+      mtimeMillis = attrs.lastModifiedTime().toMillis,
+      size = attrs.size()
+    )
+  }
+
+  /** Drop source directories that are nested under another source directory. E.g. given {src, src/java}, drop src/java since walking src already covers it. */
+  def removeNestedDirs(dirs: Set[Path]): Set[Path] = {
+    val abs = dirs.map(_.toAbsolutePath.normalize())
+    abs.filter(d => !abs.exists(other => other != d && d.startsWith(other)))
+  }
+
+  /** FNV-1a hash of compiler options for cheap equality check. */
+  def computeOptionsHash(language: ProjectLanguage.ScalaJava, ecjVersion: Option[String]): Long = {
+    var hash = 0xcbf29ce484222325L
+    val prime = 0x100000001b3L
+
+    def mix(s: String): Unit = {
+      var i = 0
+      while (i < s.length) {
+        hash ^= s.charAt(i).toLong
+        hash *= prime
+        i += 1
+      }
+      hash ^= 0L // separator
+      hash *= prime
+    }
+
+    mix(language.scalaVersion)
+    language.scalaOptions.foreach(mix)
+    language.javaOptions.foreach(mix)
+    ecjVersion.foreach(mix)
+    hash
+  }
+
+  /** Build + write a manifest by stat'ing the local filesystem. Used by both ZincBridge (post-compile) and RemoteCache.Pull (post-extraction).
+    *
+    * Returns the constructed manifest so the caller can populate any in-memory cache. No-op on Windows.
+    */
+  def regenerateFromLocal(
+      analysisFile: Path,
+      sourceDirs: Set[Path],
+      sourceFiles: Array[Path],
+      dependencyAnalyses: Map[Path, Path],
+      language: ProjectLanguage.ScalaJava,
+      ecjVersion: Option[String],
+      result: ProjectCompileSuccess
+  ): Option[NoopManifest] = {
+    if (!ctimeAvailable) return None
+
+    val sourceStats = new java.util.HashMap[Path, FileStatEntry](sourceFiles.length * 2)
+    var i = 0
+    while (i < sourceFiles.length) {
+      val path = sourceFiles(i)
+      sourceStats.put(path, statFile(path))
+      i += 1
+    }
+
+    // Stat source directories — mtime changes on file add/delete/rename (POSIX)
+    val normalizedDirs = removeNestedDirs(sourceDirs)
+    val sourceDirStatsMap = normalizedDirs.flatMap { dir =>
+      if (Files.isDirectory(dir)) Some(dir -> statFile(dir))
+      else None
+    }.toMap
+
+    val depStats = dependencyAnalyses.map { case (outputDir, depAnalysisFile) =>
+      val mtime = if (Files.exists(depAnalysisFile)) Files.getLastModifiedTime(depAnalysisFile).toMillis else 0L
+      outputDir -> mtime
+    }
+
+    // Stat output directories (outputDir + all subdirs).
+    // Directory mtime changes on file add/delete — catches class file deletion cheaply.
+    val outputDirStatsMap: Map[Path, FileStatEntry] =
+      if (Files.isDirectory(result.outputDir)) {
+        import scala.jdk.CollectionConverters.*
+        val dirs = scala.util
+          .Using(Files.walk(result.outputDir)) { stream =>
+            stream.iterator().asScala.filter(Files.isDirectory(_)).toArray
+          }
+          .getOrElse(Array.empty[Path])
+        dirs.map(d => d -> statFile(d)).toMap
+      } else Map.empty
+
+    val manifest = NoopManifest(
+      sourceStats = {
+        import scala.jdk.CollectionConverters.*
+        sourceStats.asScala.toMap
+      },
+      sourceDirStats = sourceDirStatsMap,
+      outputDirStats = outputDirStatsMap,
+      depAnalysisStats = depStats,
+      optionsHash = computeOptionsHash(language, ecjVersion),
+      cachedResult = result
+    )
+
+    write(analysisFile, manifest)
+    Some(manifest)
+  }
+
+  /** Serialize a manifest to disk via tmp + atomic rename. */
+  def write(analysisFile: Path, manifest: NoopManifest): Unit = {
+    val target = manifestPath(analysisFile)
+    val tmpFile = target.resolveSibling(target.getFileName.toString + ".tmp")
+    val out = new DataOutputStream(new java.io.BufferedOutputStream(Files.newOutputStream(tmpFile)))
+    try {
+      out.writeInt(NoopManifestMagic)
+      out.writeByte(NoopManifestVersion)
+      out.writeLong(manifest.optionsHash)
+
+      out.writeInt(manifest.sourceStats.size)
+      manifest.sourceStats.foreach { case (path, stat) =>
+        out.writeUTF(path.toString)
+        out.writeLong(stat.ctimeMillis)
+        out.writeLong(stat.mtimeMillis)
+        out.writeLong(stat.size)
+      }
+
+      out.writeInt(manifest.sourceDirStats.size)
+      manifest.sourceDirStats.foreach { case (dir, stat) =>
+        out.writeUTF(dir.toString)
+        out.writeLong(stat.ctimeMillis)
+        out.writeLong(stat.mtimeMillis)
+        out.writeLong(stat.size)
+      }
+
+      out.writeInt(manifest.outputDirStats.size)
+      manifest.outputDirStats.foreach { case (dir, stat) =>
+        out.writeUTF(dir.toString)
+        out.writeLong(stat.ctimeMillis)
+        out.writeLong(stat.mtimeMillis)
+        out.writeLong(stat.size)
+      }
+
+      out.writeInt(manifest.depAnalysisStats.size)
+      manifest.depAnalysisStats.foreach { case (outputDir, mtime) =>
+        out.writeUTF(outputDir.toString)
+        out.writeLong(mtime)
+      }
+
+      out.writeUTF(manifest.cachedResult.outputDir.toString)
+      val analysisPath = manifest.cachedResult.analysisFile match {
+        case Some(p) => p.toString
+        case None    => ""
+      }
+      out.writeUTF(analysisPath)
+      out.writeInt(manifest.cachedResult.classFiles.size)
+      manifest.cachedResult.classFiles.foreach(cf => out.writeUTF(cf.toString))
+
+      out.flush()
+    } finally out.close()
+
+    val _ = Files.move(tmpFile, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+  }
+
+  /** Load a manifest from disk. Returns None if the file doesn't exist or has a stale format version. */
+  def load(analysisFile: Path): Option[NoopManifest] = {
+    val target = manifestPath(analysisFile)
+    if (!Files.exists(target)) return None
+
+    val in = new DataInputStream(new java.io.BufferedInputStream(Files.newInputStream(target)))
+    try {
+      val magic = in.readInt()
+      if (magic != NoopManifestMagic)
+        throw new IllegalStateException(s"Bad noop-manifest magic: 0x${magic.toHexString}, expected 0x${NoopManifestMagic.toHexString}")
+      val version = in.readByte()
+      if (version != NoopManifestVersion) return None
+      val optionsHash = in.readLong()
+
+      val sourceCount = in.readInt()
+      val sourceStatsBuilder = Map.newBuilder[Path, FileStatEntry]
+      sourceStatsBuilder.sizeHint(sourceCount)
+      var i = 0
+      while (i < sourceCount) {
+        val path = Path.of(in.readUTF())
+        val ctime = in.readLong()
+        val mtime = in.readLong()
+        val size = in.readLong()
+        sourceStatsBuilder += path -> FileStatEntry(ctime, mtime, size)
+        i += 1
+      }
+
+      val dirCount = in.readInt()
+      val sourceDirStatsBuilder = Map.newBuilder[Path, FileStatEntry]
+      sourceDirStatsBuilder.sizeHint(dirCount)
+      i = 0
+      while (i < dirCount) {
+        val dir = Path.of(in.readUTF())
+        val dirCtime = in.readLong()
+        val dirMtime = in.readLong()
+        val dirSize = in.readLong()
+        sourceDirStatsBuilder += dir -> FileStatEntry(dirCtime, dirMtime, dirSize)
+        i += 1
+      }
+
+      val outDirCount = in.readInt()
+      val outputDirStatsBuilder = Map.newBuilder[Path, FileStatEntry]
+      outputDirStatsBuilder.sizeHint(outDirCount)
+      i = 0
+      while (i < outDirCount) {
+        val dir = Path.of(in.readUTF())
+        val outCtime = in.readLong()
+        val outMtime = in.readLong()
+        val outSize = in.readLong()
+        outputDirStatsBuilder += dir -> FileStatEntry(outCtime, outMtime, outSize)
+        i += 1
+      }
+
+      val depCount = in.readInt()
+      val depStatsBuilder = Map.newBuilder[Path, Long]
+      depStatsBuilder.sizeHint(depCount)
+      i = 0
+      while (i < depCount) {
+        val outputDir = Path.of(in.readUTF())
+        val mtime = in.readLong()
+        depStatsBuilder += outputDir -> mtime
+        i += 1
+      }
+
+      val outputDir = Path.of(in.readUTF())
+      val analysisPathStr = in.readUTF()
+      val cachedAnalysisFile = if (analysisPathStr.isEmpty) None else Some(Path.of(analysisPathStr))
+      val classFileCount = in.readInt()
+      val classFilesBuilder = Set.newBuilder[Path]
+      classFilesBuilder.sizeHint(classFileCount)
+      i = 0
+      while (i < classFileCount) {
+        classFilesBuilder += Path.of(in.readUTF())
+        i += 1
+      }
+
+      Some(
+        NoopManifest(
+          sourceStats = sourceStatsBuilder.result(),
+          sourceDirStats = sourceDirStatsBuilder.result(),
+          outputDirStats = outputDirStatsBuilder.result(),
+          depAnalysisStats = depStatsBuilder.result(),
+          optionsHash = optionsHash,
+          cachedResult = ProjectCompileSuccess(outputDir, classFilesBuilder.result(), cachedAnalysisFile)
+        )
+      )
+    } finally in.close()
+  }
+}

--- a/bleep-core/src/scala/bleep/analysis/ProjectTypes.scala
+++ b/bleep-core/src/scala/bleep/analysis/ProjectTypes.scala
@@ -1,0 +1,101 @@
+package bleep.analysis
+
+import bleep.ResolvedProject
+
+import java.nio.file.Path
+
+/** Language mode for a project */
+enum ProjectLanguage {
+
+  /** Scala and Java compiled together by Zinc. `--release` lives in `javaOptions` like any other javac flag — javac honors it from there. */
+  case ScalaJava(scalaVersion: String, scalaOptions: List[String], javaOptions: List[String])
+
+  /** Kotlin/JVM compiled by K2JVMCompiler */
+  case Kotlin(kotlinVersion: String, jvmTarget: String, kotlinOptions: List[String], javaRelease: Option[Int])
+
+  /** Kotlin/JS compiled by K2JSCompiler */
+  case KotlinJs(kotlinVersion: String, kotlinOptions: List[String], isTest: Boolean)
+
+  /** Kotlin/Native compiled by K2Native */
+  case KotlinNative(kotlinVersion: String, kotlinOptions: List[String], isTest: Boolean)
+
+  /** Java-only compiled by javac or ECJ */
+  case JavaOnly(release: Option[Int], javaOptions: List[String], ecjVersion: Option[String])
+}
+
+object ProjectLanguage {
+
+  /** Derive a `ScalaJava` from a resolved project. Returns None for non-Scala languages — Kotlin variants etc. don't use the Zinc-backed noop manifest path. */
+  def fromResolvedScalaJava(resolved: ResolvedProject): Option[ProjectLanguage.ScalaJava] =
+    resolved.language match {
+      case scalaLang: ResolvedProject.Language.Scala =>
+        Some(
+          ProjectLanguage.ScalaJava(
+            scalaVersion = scalaLang.version,
+            scalaOptions = scalaLang.options,
+            javaOptions = scalaLang.javaOptions
+          )
+        )
+      case _ => None
+    }
+}
+
+/** Configuration for compiling a project */
+case class ProjectConfig(
+    name: String,
+    sources: Set[Path],
+    classpath: Seq[Path],
+    outputDir: Path,
+    language: ProjectLanguage,
+    analysisDir: Option[Path],
+    buildDir: Path
+)
+
+/** Result of compiling a project */
+sealed trait ProjectCompileResult {
+  def isSuccess: Boolean
+}
+
+case class ProjectCompileSuccess(
+    outputDir: Path,
+    classFiles: Set[Path],
+    analysisFile: Option[Path]
+) extends ProjectCompileResult {
+  def isSuccess: Boolean = true
+}
+
+case class ProjectCompileFailure(
+    errors: List[CompilerError]
+) extends ProjectCompileResult {
+  def isSuccess: Boolean = false
+}
+
+/** A compiler error with location information */
+case class CompilerError(
+    path: Option[Path],
+    line: Int,
+    column: Int,
+    message: String,
+    rendered: Option[String],
+    severity: CompilerError.Severity
+) {
+  def formatted: String = {
+    val loc = path match {
+      case Some(p) =>
+        val locPart = (line, column) match {
+          case (0, 0) => ""
+          case (l, 0) => s":$l"
+          case (l, c) => s":$l:$c"
+        }
+        s"${p.getFileName}$locPart"
+      case None => "<unknown>"
+    }
+    s"$loc: $message"
+  }
+}
+
+object CompilerError {
+  enum Severity {
+    case Error, Warning, Info
+  }
+}

--- a/bleep-core/src/scala/bleep/commands/RemoteCache.scala
+++ b/bleep-core/src/scala/bleep/commands/RemoteCache.scala
@@ -1,10 +1,13 @@
 package bleep
 package commands
 
+import bleep.analysis.{NoopManifestStore, ProjectCompileSuccess, ProjectLanguage}
+
 import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, Future as JFuture}
 import scala.collection.immutable.SortedMap
+import scala.jdk.StreamConverters.*
 
 /** Remote build cache: pull pre-compiled classes from S3, push after building.
   *
@@ -13,18 +16,23 @@ import scala.collection.immutable.SortedMap
   *
   * Resources affect the digest but are NOT included in the archive (they're already on disk and don't need compilation).
   *
-  * Zinc analysis IS included so incremental compilation works correctly after pulling.
+  * Zinc analysis IS included so incremental compilation works correctly after pulling. The noop manifest is per-machine state and is excluded from the archive
+  * — Pull regenerates it locally so the next compile is a true noop hit.
   */
 object RemoteCache {
 
   private val Parallelism = 16
 
+  /** Per-machine noop manifest is regenerated locally after pull, never shipped. */
+  private val NoopManifestFileName = "noop-manifest.bin"
+
+  /** Predicate used to filter files when packing an archive for upload. Exposed so tests can verify the same exclusion behavior as production. */
+  private[bleep] def packFilter(p: Path): Boolean =
+    p.getFileName.toString != NoopManifestFileName
+
   case class Pull(projects: Array[model.CrossProjectName]) extends BleepBuildCommand {
     override def run(started: Started): Either[BleepException, Unit] = {
-      val cacheConfig = started.build match {
-        case fb: model.Build.FileBacked => fb.file.`remote-cache`
-        case _                          => None
-      }
+      val cacheConfig = started.build.remoteCache
       cacheConfig match {
         case None =>
           Left(new BleepException.Text("No remote-cache configured in bleep.yaml. Add:\n  remote-cache:\n    uri: s3://bucket/prefix\n    region: us-east-1"))
@@ -58,6 +66,7 @@ object RemoteCache {
                   } else if (client.headObject(key)) {
                     val archive = client.getObject(key)
                     TarGz.unpack(archive, projectPaths.targetDir)
+                    regenerateManifest(started, crossName, projectPaths)
                     pulled.incrementAndGet()
                     started.logger.info(s"${crossName.value}: pulled from cache (${archive.length / 1024}KB)")
                   } else {
@@ -89,10 +98,7 @@ object RemoteCache {
     }
 
     override def run(started: Started): Either[BleepException, Unit] = {
-      val cacheConfig = started.build match {
-        case fb: model.Build.FileBacked => fb.file.`remote-cache`
-        case _                          => None
-      }
+      val cacheConfig = started.build.remoteCache
       cacheConfig match {
         case None =>
           Left(new BleepException.Text("No remote-cache configured in bleep.yaml"))
@@ -136,7 +142,7 @@ object RemoteCache {
                           s"${crossName.value}: analysis contains ${absolutePaths.size} absolute path(s), e.g. '$head'. Kill BSP servers and recompile."
                         )
                       case Nil =>
-                        val archive = TarGz.pack(projectPaths.targetDir)
+                        val archive = TarGz.pack(projectPaths.targetDir, packFilter)
                         semaphore.acquire()
                         try {
                           client.putObject(key, archive)
@@ -186,4 +192,62 @@ object RemoteCache {
           "No remote cache credentials found. Set remoteCacheCredentials in ~/.config/bleep/config.yaml or BLEEP_REMOTE_CACHE_S3_ACCESS_KEY_ID/BLEEP_REMOTE_CACHE_S3_SECRET_ACCESS_KEY env vars."
         )
       )
+
+  /** After unpacking a project archive, write a fresh noop manifest stat'd against the local filesystem. The next compile then short-circuits via the pre-Zinc
+    * fast-path instead of going through a Zinc no-op compile. No-op on Windows (ctime unavailable) and on non-Scala projects.
+    */
+  private def regenerateManifest(
+      started: Started,
+      crossName: model.CrossProjectName,
+      projectPaths: ProjectPaths
+  ): Unit = {
+    if (!NoopManifestStore.ctimeAvailable) return
+
+    val resolved = started.resolvedProject(crossName)
+    val maybeLanguage = ProjectLanguage.fromResolvedScalaJava(resolved)
+    if (maybeLanguage.isEmpty) return
+
+    val analysisFile = projectPaths.targetDir.resolve(".zinc").resolve("analysis.zip")
+    if (!Files.exists(analysisFile)) return
+
+    val sourceDirs = projectPaths.sourcesDirs.all.toSet
+    val sourceFiles = sourceDirs.toList.sorted.flatMap { dir =>
+      if (Files.isDirectory(dir))
+        scala.util
+          .Using(Files.walk(dir)) { stream =>
+            stream.toScala(List).filter(p => Files.isRegularFile(p) && (p.toString.endsWith(".scala") || p.toString.endsWith(".java")))
+          }
+          .getOrElse(Nil)
+      else Nil
+    }.toArray
+
+    val classFiles =
+      if (Files.isDirectory(projectPaths.classes))
+        scala.util
+          .Using(Files.walk(projectPaths.classes)) { stream =>
+            stream.toScala(List).filter(p => Files.isRegularFile(p) && p.toString.endsWith(".class")).toSet
+          }
+          .getOrElse(Set.empty[Path])
+      else Set.empty[Path]
+
+    val deps = started.build.resolvedDependsOn.getOrElse(crossName, Set.empty)
+    val dependencyAnalyses = deps.iterator.flatMap { dep =>
+      val depPaths = started.projectPaths(dep)
+      val depAnalysis = depPaths.targetDir.resolve(".zinc").resolve("analysis.zip")
+      Some(depPaths.classes -> depAnalysis)
+    }.toMap
+
+    val result = ProjectCompileSuccess(projectPaths.classes, classFiles, Some(analysisFile))
+
+    NoopManifestStore.regenerateFromLocal(
+      analysisFile = analysisFile,
+      sourceDirs = sourceDirs,
+      sourceFiles = sourceFiles,
+      dependencyAnalyses = dependencyAnalyses,
+      language = maybeLanguage.get,
+      ecjVersion = None,
+      result = result
+    )
+    started.logger.debug(s"${crossName.value}: regenerated noop manifest")
+  }
 }

--- a/bleep-model/src/scala/bleep/model/Build.scala
+++ b/bleep-model/src/scala/bleep/model/Build.scala
@@ -16,9 +16,15 @@ sealed trait Build {
   def scripts: Map[ScriptName, JsonList[ScriptDef]]
   def jvm: Option[Jvm]
 
+  /** Remote-cache config from `bleep.yaml`. Survives the FileBacked → Exploded transformation that some `ResolveProjects` implementations perform — without
+    * this, anything that pattern-matches on `Build.FileBacked` (and only `FileBacked`) would silently lose the field after a rewrite.
+    */
+  def remoteCache: Option[RemoteCacheConfig]
+
   def dropBuildFile: Build.Exploded = this match {
     case build: Build.Exploded   => build
-    case build: Build.FileBacked => Build.Exploded(build.file.$version, explodedProjects, build.resolvers, build.file.jvm, build.scripts)
+    case build: Build.FileBacked =>
+      Build.Exploded(build.file.$version, explodedProjects, build.resolvers, build.file.jvm, build.scripts, build.file.`remote-cache`)
   }
 
   def requireFileBacked(ctx: String): Build.FileBacked =
@@ -122,7 +128,8 @@ object Build {
       explodedProjects: Map[CrossProjectName, Project],
       resolvers: JsonList[Repository],
       jvm: Option[Jvm],
-      scripts: Map[ScriptName, JsonList[ScriptDef]]
+      scripts: Map[ScriptName, JsonList[ScriptDef]],
+      remoteCache: Option[RemoteCacheConfig]
   ) extends Build {
     def dropTemplates: Exploded = {
       def stripExtends(p: Project): Project =
@@ -163,6 +170,7 @@ object Build {
     def resolvers: JsonList[Repository] = file.resolvers
     def scripts: Map[ScriptName, JsonList[ScriptDef]] = file.scripts.value
     def jvm: Option[Jvm] = file.jvm
+    def remoteCache: Option[RemoteCacheConfig] = file.`remote-cache`
 
     def mapBuildFile(f: BuildFile => BuildFile): Build.FileBacked =
       Build.FileBacked(f(file))

--- a/bleep-model/src/scala/bleep/templates/templatesInfer.scala
+++ b/bleep-model/src/scala/bleep/templates/templatesInfer.scala
@@ -43,7 +43,7 @@ object templatesInfer {
         resolvers = build.resolvers,
         projects = model.JsonMap(finishedProjects),
         jvm = build.jvm,
-        `remote-cache` = None
+        `remote-cache` = build.remoteCache
       )
 
     val build2 = inlineTrivialTemplates(build1)

--- a/bleep-nosbt/src/scala/bleep/nosbt/io/Hash.scala
+++ b/bleep-nosbt/src/scala/bleep/nosbt/io/Hash.scala
@@ -70,8 +70,7 @@ object Hash {
       while (dis.read(buffer) >= 0) {}
       dis.close()
       digest.digest
-    } finally
-      stream.close()
+    } finally stream.close()
   }
 
   private def toHex(b: Byte): Char = {

--- a/bleep-tests/src/scala/bleep/BuildInvalidatedTest.scala
+++ b/bleep-tests/src/scala/bleep/BuildInvalidatedTest.scala
@@ -22,7 +22,8 @@ class BuildInvalidatedTest extends AnyFunSuite with Matchers {
       explodedProjects = projects.map { case (name, p) => cpn(name) -> p }.toMap,
       resolvers = model.JsonList.empty,
       jvm = None,
-      scripts = Map.empty
+      scripts = Map.empty,
+      remoteCache = None
     )
 
   // ============================================================================

--- a/bleep-tests/src/scala/bleep/ProjectDigestTest.scala
+++ b/bleep-tests/src/scala/bleep/ProjectDigestTest.scala
@@ -23,7 +23,8 @@ class ProjectDigestTest extends AnyFunSuite with Matchers {
       explodedProjects = projects.map { case (name, p) => cpn(name) -> p }.toMap,
       resolvers = model.JsonList.empty,
       jvm = None,
-      scripts = Map.empty
+      scripts = Map.empty,
+      remoteCache = None
     )
 
   private def createTempWorkspace(): Path = {
@@ -188,9 +189,13 @@ class ProjectDigestTest extends AnyFunSuite with Matchers {
       scala.sys.process.Process(List("git", "config", "user.name", "test"), workspace.toFile).!!
 
       val srcDir = workspace.resolve("a/src/scala")
-      Files.createDirectories(srcDir)
+      val nestedDir = srcDir.resolve("com/example")
+      Files.createDirectories(nestedDir)
       Files.writeString(srcDir.resolve("Foo.scala"), "object Foo { val x = 42 }")
       Files.writeString(srcDir.resolve("Bar.scala"), "object Bar")
+      // Nested file ensures both code paths produce relPath strings containing a separator,
+      // which would expose any OS-native ('\') vs git ('/') mismatch on Windows.
+      Files.writeString(nestedDir.resolve("Baz.scala"), "package com.example; object Baz")
 
       val p = model.Project.empty.copy(
         sources = model.JsonSet(SortedSet(RelPath.force("src/scala")))
@@ -211,6 +216,33 @@ class ProjectDigestTest extends AnyFunSuite with Matchers {
       info(s"before commit (filesystem): $digestBefore")
       info(s"after commit (git ls-tree): $digestAfter")
       digestBefore shouldBe digestAfter
+    } finally deleteRecursively(workspace)
+  }
+
+  test("golden: nested source paths produce stable cross-OS digest") {
+    // Regression for the Windows path-separator bug: ProjectDigest used to feed OS-native
+    // separators into the SHA-256 (`\` on Windows, `/` elsewhere). With nested source
+    // files the buggy version produced different digests across OSes; the fixed version
+    // produces the value asserted below regardless of platform.
+    //
+    // If this golden value changes, every existing remote-cache entry becomes invalid.
+    val workspace = Files.createTempDirectory("bleep-digest-nested-")
+    try {
+      val srcDir = workspace.resolve("a/src/scala")
+      val nestedDir = srcDir.resolve("com/example")
+      Files.createDirectories(nestedDir)
+      Files.writeString(srcDir.resolve("Foo.scala"), "object Foo { val x = 42 }")
+      Files.writeString(nestedDir.resolve("Baz.scala"), "package com.example\nobject Baz")
+
+      val p = model.Project.empty.copy(
+        sources = model.JsonSet(SortedSet(RelPath.force("src/scala")))
+      )
+      val build = makeBuild("a" -> p)
+      val buildPaths = BuildPaths(workspace, BuildLoader.inDirectory(workspace), model.BuildVariant.Normal)
+
+      val digest = ProjectDigest.computeAll(build, buildPaths)(cpn("a"))
+      info(s"nested-paths digest: $digest")
+      digest shouldBe "07b5f8295cb4dee3988c29c46e674d380fd70c29c71e23949c49941a424357ae"
     } finally deleteRecursively(workspace)
   }
 

--- a/bleep-tests/src/scala/bleep/RemoteCacheIT.scala
+++ b/bleep-tests/src/scala/bleep/RemoteCacheIT.scala
@@ -1,0 +1,185 @@
+package bleep
+
+import bleep.analysis.NoopManifestStore
+import bleep.commands.RemoteCache
+import bleep.internal.FileUtils
+
+import java.nio.file.{Files, Path}
+import scala.jdk.StreamConverters.*
+
+class RemoteCacheIT extends IntegrationTestHarness {
+
+  /** S3 client picks credentials up from `Started.config.remoteCacheCredentials` (or env vars). The local `S3LikeServer` ignores AWS SigV4 entirely, so any
+    * non-empty pair works; the value is exercised through the real codepath that builds the Authorization header so cred-plumbing regressions still surface.
+    *
+    * Reconstructed in full because the harness exposes `testConfig` as a `val` — `super.testConfig` is not a legal Scala expression.
+    */
+  override val testConfig: model.BleepConfig = model.BleepConfig(
+    compileServerMode = Some(model.CompileServerMode.NewEachInvocation),
+    authentications = None,
+    logTiming = None,
+    bspServerConfig = Some(model.BspServerConfig.default.copy(testRunnerMaxMemory = Some("512m"))),
+    remoteCacheCredentials = Some(model.RemoteCacheCredentials(accessKeyId = "test-access-key", secretAccessKey = "test-secret-key"))
+  )
+
+  /** Read every file under `dir`, returning relative paths sorted. Mirrors HttpMavenRepoServer.storedFiles for archive contents. */
+  private def listRelativeFiles(dir: Path): List[String] =
+    if (!Files.isDirectory(dir)) Nil
+    else
+      scala.util
+        .Using(Files.walk(dir)) { stream =>
+          stream
+            .toScala(List)
+            .filter(Files.isRegularFile(_))
+            .map(p => dir.relativize(p).toString.replace('\\', '/'))
+            .sorted
+        }
+        .getOrElse(Nil)
+
+  integrationTest("remote cache: push uploads archive without noop-manifest, pull restores classes + regenerates manifest") { ws =>
+    S3LikeServer.withServer("test-bucket") { server =>
+      ws.yaml(
+        s"""remote-cache:
+           |  uri: ${server.baseUri}/cache-prefix
+           |  region: us-east-1
+           |
+           |projects:
+           |  greeter:
+           |    platform:
+           |      name: jvm
+           |    scala:
+           |      version: 3.3.3
+           |""".stripMargin
+      )
+      ws.file(
+        "greeter/src/scala/com/test/Greeter.scala",
+        """package com.test
+          |object Greeter { def hello: String = "hi" }
+          |""".stripMargin
+      )
+
+      val (started, _, _) = ws.start()
+      val greeter = model.CrossProjectName(model.ProjectName("greeter"), None)
+      ws.compileAll()
+
+      val projectPaths = started.projectPaths(greeter)
+      val analysisFile = projectPaths.targetDir.resolve(".zinc/analysis.zip")
+      val classFile = projectPaths.classes.resolve("com/test/Greeter.class")
+      val noopManifest = NoopManifestStore.manifestPath(analysisFile)
+
+      // Sanity: compile produced what we expect to ship + a per-machine manifest we expect to NOT ship.
+      assert(Files.exists(classFile), s"compile should have produced $classFile")
+      assert(Files.exists(analysisFile), s"compile should have produced $analysisFile")
+      if (NoopManifestStore.ctimeAvailable)
+        assert(Files.exists(noopManifest), s"compile should have produced $noopManifest on macOS/Linux")
+
+      // === PUSH ===
+      RemoteCache.Push(projects = Array.empty, force = false).run(started).fold(e => fail(s"push failed: ${e.getMessage}"), identity)
+
+      // Server should have exactly one object: <prefix>/<project>/<digest>.tar.gz.
+      assert(server.size == 1, s"expected 1 cached object, got ${server.keys}")
+      val cacheKey = server.keys.head
+      assert(cacheKey.startsWith("cache-prefix/greeter/"), s"unexpected cache key: $cacheKey")
+      assert(cacheKey.endsWith(".tar.gz"), s"unexpected cache key extension: $cacheKey")
+
+      // Inspect archive contents: classes + analysis must be present, noop-manifest.bin must NOT be.
+      val uploaded = server.get(cacheKey).getOrElse(fail(s"object missing for $cacheKey"))
+      val unpackDir = Files.createTempDirectory("bleep-cache-inspect-")
+      try {
+        TarGz.unpack(uploaded, unpackDir)
+        val archived = listRelativeFiles(unpackDir)
+        assert(archived.exists(_.endsWith("Greeter.class")), s"archive missing classes: $archived")
+        assert(archived.exists(_ == ".zinc/analysis.zip"), s"archive missing analysis: $archived")
+        assert(!archived.exists(_.endsWith("noop-manifest.bin")), s"noop-manifest.bin must not be shipped, got $archived")
+      } finally FileUtils.deleteDirectory(unpackDir)
+
+      // === WIPE LOCAL ===
+      FileUtils.deleteDirectory(projectPaths.targetDir)
+      assert(!Files.exists(classFile), "wipe should have removed local classes")
+      assert(!Files.exists(analysisFile), "wipe should have removed local analysis")
+
+      // === PULL ===
+      RemoteCache.Pull(projects = Array.empty).run(started).fold(e => fail(s"pull failed: ${e.getMessage}"), identity)
+
+      // Classes + analysis restored, noop manifest regenerated locally.
+      assert(Files.exists(classFile), s"pull should have restored $classFile")
+      assert(Files.exists(analysisFile), s"pull should have restored $analysisFile")
+      if (NoopManifestStore.ctimeAvailable) {
+        assert(Files.exists(noopManifest), s"pull should have regenerated $noopManifest")
+
+        // The regenerated manifest must be loadable and reference local paths (not the source machine's).
+        val loaded = NoopManifestStore.load(analysisFile).getOrElse(fail("regenerated manifest must load"))
+        assert(loaded.cachedResult.outputDir == projectPaths.classes, s"manifest outputDir wrong: ${loaded.cachedResult.outputDir}")
+        assert(loaded.cachedResult.classFiles.exists(_.endsWith("Greeter.class")), s"manifest classFiles missing Greeter: ${loaded.cachedResult.classFiles}")
+        assert(
+          loaded.sourceStats.keySet.exists(_.toString.endsWith("Greeter.scala")),
+          s"manifest sourceStats missing Greeter.scala: ${loaded.sourceStats.keys}"
+        )
+      }
+      succeed
+    }
+  }
+
+  integrationTest("remote cache: pull skips when classes already present locally") { ws =>
+    S3LikeServer.withServer("test-bucket") { server =>
+      ws.yaml(
+        s"""remote-cache:
+             |  uri: ${server.baseUri}/cache-prefix
+             |  region: us-east-1
+             |
+             |projects:
+             |  hello:
+             |    platform:
+             |      name: jvm
+             |    scala:
+             |      version: 3.3.3
+             |""".stripMargin
+      )
+      ws.file(
+        "hello/src/scala/Hello.scala",
+        """object Hello { def main(args: Array[String]): Unit = println("hi") }
+            |""".stripMargin
+      )
+
+      val (started, _, _) = ws.start()
+      ws.compileAll()
+
+      // Nothing has been pushed; pull should be a no-op (classes already exist locally).
+      RemoteCache.Pull(projects = Array.empty).run(started).fold(e => fail(s"pull failed: ${e.getMessage}"), identity)
+      assert(server.size == 0, "no pull traffic should have hit the server when classes are present")
+      succeed
+    }
+  }
+
+  integrationTest("remote cache: push of an already-cached digest is skipped (without --force)") { ws =>
+    S3LikeServer.withServer("test-bucket") { server =>
+      ws.yaml(
+        s"""remote-cache:
+             |  uri: ${server.baseUri}/cache-prefix
+             |  region: us-east-1
+             |
+             |projects:
+             |  echo:
+             |    platform:
+             |      name: jvm
+             |    scala:
+             |      version: 3.3.3
+             |""".stripMargin
+      )
+      ws.file("echo/src/scala/Echo.scala", "object Echo")
+
+      val (started, _, _) = ws.start()
+      ws.compileAll()
+
+      // First push uploads.
+      RemoteCache.Push(projects = Array.empty, force = false).run(started).fold(e => fail(s"first push failed: ${e.getMessage}"), identity)
+      assert(server.size == 1, s"expected 1 object after first push, got ${server.keys}")
+      val firstKeys = server.keys
+
+      // Second push without --force: head returns 200, push skips.
+      RemoteCache.Push(projects = Array.empty, force = false).run(started).fold(e => fail(s"second push failed: ${e.getMessage}"), identity)
+      assert(server.keys == firstKeys, "second push should not have written a new key")
+      succeed
+    }
+  }
+}

--- a/bleep-tests/src/scala/bleep/S3LikeServer.scala
+++ b/bleep-tests/src/scala/bleep/S3LikeServer.scala
@@ -1,0 +1,86 @@
+package bleep
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+
+import java.net.{InetSocketAddress, URI}
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters.*
+
+/** A throwaway in-process S3-compatible HTTP server — receives PUT uploads, serves GET/HEAD requests, stores everything in memory.
+  *
+  * Faithful enough to exercise the full remote-cache stack (URI parsing, key layout, AWS SigV4 header serialization, archive round-trip). Does NOT verify the
+  * AWS signature on incoming requests — we're testing bleep's cache code, not the SigV4 implementation. The S3Client always emits a syntactically-valid
+  * `Authorization` header; the server just ignores it.
+  *
+  * URI shape: `http://127.0.0.1:<port>/<bucket>/<key>` — same layout `S3Client.fromConfig` builds when the configured URI is a non-`s3:` scheme.
+  */
+final class S3LikeServer(bucket: String) {
+
+  private val store = new ConcurrentHashMap[String, Array[Byte]]()
+
+  private val server: HttpServer = {
+    val s = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    s.createContext("/", new BucketHandler)
+    s.setExecutor(null)
+    s.start()
+    s
+  }
+
+  /** Base URI to put in `remote-cache.uri` of a workspace bleep.yaml. The bucket is part of the path; whatever you append becomes the key prefix. */
+  val baseUri: URI = URI.create(s"http://127.0.0.1:${server.getAddress.getPort}/$bucket")
+
+  def stop(): Unit = server.stop(0)
+
+  /** Snapshot of every key currently stored, sorted. Used by tests to assert what was uploaded. */
+  def keys: List[String] = store.keys().asScala.toList.sorted
+
+  /** Raw bytes stored at a key, or None. Use to inspect the archive a Push uploaded. */
+  def get(key: String): Option[Array[Byte]] = Option(store.get(key))
+
+  /** Object count — sanity assertion that Push wrote something. */
+  def size: Int = store.size
+
+  private final class BucketHandler extends HttpHandler {
+    override def handle(exchange: HttpExchange): Unit =
+      try {
+        val rawPath = exchange.getRequestURI.getRawPath.stripPrefix("/")
+        val key = rawPath.stripPrefix(s"$bucket/")
+        if (rawPath == key) {
+          // Path didn't begin with our bucket — refuse so misconfigurations surface immediately.
+          exchange.sendResponseHeaders(404, -1)
+          return
+        }
+        exchange.getRequestMethod match {
+          case "PUT" =>
+            val body = exchange.getRequestBody.readAllBytes()
+            store.put(key, body)
+            exchange.sendResponseHeaders(200, -1)
+          case "HEAD" =>
+            if (store.containsKey(key)) exchange.sendResponseHeaders(200, -1)
+            else exchange.sendResponseHeaders(404, -1)
+          case "GET" =>
+            Option(store.get(key)) match {
+              case Some(bytes) =>
+                exchange.sendResponseHeaders(200, bytes.length.toLong)
+                val os = exchange.getResponseBody
+                try os.write(bytes)
+                finally os.close()
+              case None =>
+                exchange.sendResponseHeaders(404, -1)
+            }
+          case _ =>
+            exchange.sendResponseHeaders(405, -1)
+        }
+      } finally exchange.close()
+  }
+}
+
+object S3LikeServer {
+
+  /** Run `body` against a freshly-started server. Always stops it, even on exception. */
+  def withServer[T](bucket: String)(body: S3LikeServer => T): T = {
+    val srv = new S3LikeServer(bucket)
+    try body(srv)
+    finally srv.stop()
+  }
+}

--- a/bleep-tests/src/scala/bleep/Sip51Tests.scala
+++ b/bleep-tests/src/scala/bleep/Sip51Tests.scala
@@ -79,8 +79,7 @@ class Sip51Tests extends AnyFunSuite with TripleEqualsSupport {
       val ret = f(started)
       FileUtils.deleteDirectory(testTempFolder)
       ret
-    } finally
-      stdLogger.info(s"Ran in $testTempFolder")
+    } finally stdLogger.info(s"Ran in $testTempFolder")
   }
 
   /** Helper to get resolved version of a module from resolution */

--- a/bleep-tests/src/scala/bleep/TemplateTest.scala
+++ b/bleep-tests/src/scala/bleep/TemplateTest.scala
@@ -79,7 +79,7 @@ class TemplateTest extends SnapshotTest {
       testName: String,
       ignoreWhenInferringTemplates: Set[model.ProjectName] = Set.empty
   ): model.BuildFile = {
-    val pre = model.Build.Exploded(model.BleepVersion.dev, projects, model.JsonList.empty, None, Map.empty)
+    val pre = model.Build.Exploded(model.BleepVersion.dev, projects, model.JsonList.empty, None, Map.empty, None)
     val logger = logger0.withContext("testName", testName)
     val buildFile = templatesInfer(new BleepTemplateLogger(logger), pre, ignoreWhenInferringTemplates)
     writeAndCompare(

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -50,7 +50,9 @@ projects:
     - bleep-bsp-protocol
     - bleep-test-runner
     - bleepscript
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     sources: ../liberated/sbt-tpolecat/plugin/src/main/scala
   bleepscript:
     dependencies:
@@ -137,7 +139,9 @@ projects:
     - for3Use213: true
       module: io.get-coursier::coursier:2.1.24
     - org.snakeyaml:snakeyaml-engine:2.9
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     sourcegen:
       main: bleep.scripts.GenerateResources
       project: scripts-init
@@ -146,7 +150,9 @@ projects:
     - for3Use213: true
       module: com.eed3si9n::sjson-new-scalajson:0.13.1
     - org.scala-lang.modules::scala-xml:2.4.0
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     scala:
       strict: false
     sources:
@@ -159,24 +165,31 @@ projects:
     - bleep-plugin-pgp
     - bleep-plugin-sonatype
     extends:
-    - template-cross-all
+    - template-common
+    - template-scala-3
     - template-parcollection-ok
     sources: ../liberated/sbt-ci-release/plugin/src/main/scala
   bleep-plugin-dynver:
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     sources:
     - ../liberated/sbt-dynver/dynver/src/main/scala
     - ../liberated/sbt-dynver/sbtdynver/src/main/scala
   bleep-plugin-git-versioning:
     dependencies: se.sawano.java:alphanumeric-comparator:2.0.0
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     sources: ../liberated/sbt-git-versioning/src/main/scala
   bleep-plugin-jni:
     dependencies: org.ow2.asm:asm:9.9
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     sources:
     - ../liberated/sbt-jni/core/src/main/scala
     - ../liberated/sbt-jni/plugin/src/main/java
@@ -184,14 +197,18 @@ projects:
   bleep-plugin-mdoc:
     dependencies: org.jsoup:jsoup:1.21.2
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     sources: ../liberated/mdoc/mdoc-sbt/src/main/scala
   bleep-plugin-native-image:
     dependencies:
     - com.lihaoyi::os-lib:0.11.6
     - org.ow2.asm:asm:9.9
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     resources: ../liberated/sbt-native-image/plugin/src/main/resources
     sources: ../liberated/sbt-native-image/plugin/src/main/scala
   bleep-plugin-pgp:
@@ -200,14 +217,18 @@ projects:
     - org.bouncycastle:bcpg-jdk15on:1.70
     - org.scala-lang.modules::scala-parser-combinators:2.4.0
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     sources:
     - ../liberated/sbt-pgp/gpg-library/src/main/scala
     - ../liberated/sbt-pgp/sbt-pgp/src/main/scala
   bleep-plugin-scalafix:
     dependencies: ch.epfl.scala:scalafix-interfaces:0.14.4
     dependsOn: bleep-core
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
     sources: ../liberated/mill-scalafix/mill-scalafix/src
   bleep-plugin-sonatype:
     dependencies:
@@ -219,7 +240,8 @@ projects:
     - org.wvlet.airframe::airframe-http:24.12.2
     dependsOn: bleep-core
     extends:
-    - template-cross-all
+    - template-common
+    - template-scala-3
     - template-parcollection-ok
     sources: ../liberated/sbt-sonatype/src/main/scala
   bleep-test-runner:
@@ -273,7 +295,9 @@ projects:
     - io.circe::circe-generic:0.14.15
     - io.circe::circe-parser:0.14.15
     dependsOn: bleep-model
-    extends: template-cross-all
+    extends:
+    - template-common
+    - template-scala-3
   bleep-bsp-tests:
     dependencies:
     - org.scalatest::scalatest:3.2.19
@@ -387,10 +411,6 @@ templates:
       options: -encoding utf8 -feature -language:experimental.macros -language:higherKinds
         -language:implicitConversions -unchecked
       strict: true
-  template-cross-all:
-    extends:
-      - template-common
-      - template-scala-3
   template-parcollection-ok:
     libraryVersionSchemes: org.scala-lang.modules::scala-parallel-collections:always
   template-scala-3:


### PR DESCRIPTION
## Summary

- **Windows fix:** `ProjectDigest` was feeding OS-native path separators into the SHA-256, so cache keys computed on Windows never matched ones from Linux/macOS — every cache pull missed. Normalize relPath strings to `/` in both the git-ls-tree and filesystem-walk paths.
- **Post-pull noop:** extract the noop-manifest serializer from `ZincBridge` into a new `bleep-core` `NoopManifestStore`; `RemoteCache.Pull` regenerates a fresh manifest against the local filesystem after each unpack so the next compile short-circuits via the pre-Zinc fast path. Also exclude `noop-manifest.bin` from the tar archive — per-machine state never needed to ship through S3.
- **Refactor falling out of the above:** move shared analysis types (`ProjectLanguage`, `ProjectConfig`, `ProjectCompileResult`/`Success`/`Failure`, `CompilerError`) from `bleep-bsp/analysis` to `bleep-core/analysis`; drop the redundant `javaRelease` field from `ProjectLanguage.ScalaJava` (duplicated `--release` already in `javaOptions`); move `remoteCache` onto the `Build` trait so it survives `Build.FileBacked` → `Build.Exploded` rewrites (latent bug the new test would have hit).
- **Cleanup:** remove `template-cross-all` from `bleep.yaml` (nothing in the repo is cross-compiled — inline as `[template-common, template-scala-3]`); switch scalafmt default dialect from `Scala213Source3` to `scala3` and drop the per-bleep-module fileOverrides.
- **New tests:**
  - `ProjectDigestTest` now exercises a project with a nested source path under both filesystem hashing and git ls-tree hashing, asserting the same exact hex digest. On Windows-CI this fails loudly without the fix.
  - `RemoteCacheIT` (with `S3LikeServer`, an in-process HTTP server that stores objects in a `ConcurrentHashMap` and ignores AWS SigV4) covers the full push → pull → noop-manifest-regen flow without hitting the network: archive content is inspected to confirm `noop-manifest.bin` is excluded, the regenerated manifest is loaded back and verified, and pull is asserted to be a no-op when classes already exist locally.

## Test plan

- [x] `bleep test bleep-tests` — all unit + integration suites green locally
- [x] `bleep test bleep-bsp-tests` — all 29 suites green locally
- [x] `RemoteCacheIT` passes (3 cases; full push/pull/regen flow against in-process S3-like server)
- [x] `ProjectDigestTest.golden: nested source paths` passes locally with the asserted hex digest
- [ ] Confirm `ProjectDigestTest.golden: nested source paths` produces the same hex digest on Windows-CI
- [ ] Confirm `RemoteCacheIT` passes on Windows-CI

## Local-tree caveat

After pulling this branch, an incremental Zinc compile may not pick up the binary change to `Build.Exploded`'s constructor signature (synthesized `.copy()` arity went 5 → 6). If you hit a `NoSuchMethodError` for `Build$Exploded.copy(...)` at test time, blow away `.bleep/builds/*/.bloop/bleep-cli/{classes,.zinc}` and re-`bleep compile`. CI runners always do a clean compile so this only bites local trees that were already built against the old signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)