### PR TITLE
ci: bump release-job timeout 20m → 40m

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,7 +235,7 @@ jobs:
           retention-days: 1
 
   release:
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on: ubuntu-22.04
     needs: [ build, build-native-image, yaml-ls-check, build-intellij-plugin ]
     if: "startsWith(github.ref, 'refs/tags/v')"


### PR DESCRIPTION
## Summary

The v1.0.0-M10 release job timed out at 20m ([failed run](https://github.com/oyvindberg/bleep/actions/runs/25522591277/job/74912643677)), blocked at the Sonatype Central Portal validation poll. Triage showed the release step itself is unchanged from M9 — same command (`bleep --dev publish sonatype`), same env, same workflow ordering. The failure is Sonatype-side variability, not anything bleep-side.

## Pattern across the last three releases

| | M8 | M9 | M10 |
|---|---|---|---|
| Bundle | 480 files (80 signed) | 384 files (64 signed) | 408 files (68 signed) |
| Sonatype poll wall-time | 6m 58s | 6m 52s | **>15m 17s, killed by 20m job timeout** |
| Total release job | 11m 22s ✅ | 11m 02s ✅ | cancelled at 20m ❌ |

M8 had the **biggest** bundle and the second-fastest poll, so this isn't size-driven — it's pure Central Portal variability. ~7m is the normal poll time; M10 was an outlier.

Bleep-side work (compile + sign + bundle + upload) consumes ~5m of the 20m job budget, leaving only ~13m for the Central Portal poll. Too tight when Sonatype occasionally spikes past that.

## Change

```diff
   release:
-    timeout-minutes: 20
+    timeout-minutes: 40
```

40m gives ~35m of poll headroom — comfortably above the worst observed without masking real regressions in bleep-side work, which is bounded at ~5m and would still surface as an obvious slowdown.

## Test plan

- [ ] Merge to master
- [ ] Next `v1.0.0-M*` tag exercises the new timeout; expect either a clean publish or a *different* failure (which would be a real signal, not a Sonatype-poll false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)