### PR TITLE
Fix publish coords: check scala.version, not scala-block presence

### DIFF
--- a/bleep-core/src/scala/bleep/packaging/CoordinatesFor.scala
+++ b/bleep-core/src/scala/bleep/packaging/CoordinatesFor.scala
@@ -22,7 +22,11 @@ object CoordinatesFor {
   private def fromGroupId(groupId: String, version: String, crossName: model.CrossProjectName, explodedProject: model.Project): model.Dep = {
     val name = crossName.name.value.replace('/', '-')
 
-    explodedProject.scala match {
+    // Check for an actual Scala version, not just the presence of a `scala:` block. Projects can
+    // inherit Scala options (encoding, language flags, strict mode) from shared templates without
+    // declaring a Scala version themselves — those projects are Java artifacts and should publish
+    // with a plain `groupId:name:version` coord, not `groupId:name_${binVersion}:version`.
+    explodedProject.scala.flatMap(_.version) match {
       case Some(_) => model.Dep.Scala(org = groupId, name = name, version = version)
       case None    => model.Dep.Java(org = groupId, name = name, version = version)
     }

--- a/bleep-tests/src/scala/bleep/CoordinatesForTest.scala
+++ b/bleep-tests/src/scala/bleep/CoordinatesForTest.scala
@@ -1,0 +1,81 @@
+package bleep
+
+import bleep.packaging.CoordinatesFor
+import org.scalatest.funsuite.AnyFunSuite
+
+class CoordinatesForTest extends AnyFunSuite {
+  private val projectName = model.CrossProjectName(model.ProjectName("myartifact"), None)
+  private val coords = CoordinatesFor.Default(groupId = "com.example", version = "1.0.0")
+
+  test("project with no scala block publishes as Java artifact (single-colon repr)") {
+    val project = model.Project.empty
+    val dep = coords(projectName, project)
+
+    assert(dep.isInstanceOf[model.Dep.JavaDependency])
+    assert(dep.repr == "com.example:myartifact:1.0.0")
+  }
+
+  test("project with scala block AND version publishes as Scala artifact (double-colon repr)") {
+    val scala = model.Scala(
+      version = Some(model.VersionScala.Scala3),
+      options = model.Options.empty,
+      setup = None,
+      compilerPlugins = model.JsonSet.empty,
+      strict = None
+    )
+    val project = model.Project.empty.copy(scala = Some(scala))
+    val dep = coords(projectName, project)
+
+    assert(dep.isInstanceOf[model.Dep.ScalaDependency])
+    assert(dep.repr == "com.example::myartifact:1.0.0")
+  }
+
+  test("project with scala block but NO version publishes as Java artifact") {
+    // The case that broke bleep-plugin-spring-boot: extending template-common pulls in
+    // `scala.options`, `scala.setup`, `scala.strict` without a version. The project is still
+    // a Java artifact and should publish with a single-colon coordinate, not be treated as
+    // Scala-suffixed (which would fail to resolve without a known Scala binVersion).
+    val scala = model.Scala(
+      version = None,
+      options = model.Options(Set(model.Options.Opt.Flag("-feature"))),
+      setup = None,
+      compilerPlugins = model.JsonSet.empty,
+      strict = Some(true)
+    )
+    val project = model.Project.empty.copy(scala = Some(scala))
+    val dep = coords(projectName, project)
+
+    assert(
+      dep.isInstanceOf[model.Dep.JavaDependency],
+      s"expected Dep.JavaDependency, got ${dep.getClass.getSimpleName} with repr=${dep.repr}"
+    )
+    assert(dep.repr == "com.example:myartifact:1.0.0")
+  }
+
+  test("FromModel falls back to provided groupId when project has no publish.groupId") {
+    val coords = CoordinatesFor.FromModel(version = "2.0.0", fallbackGroupId = "fallback.group")
+    val project = model.Project.empty
+    val dep = coords(projectName, project)
+
+    assert(dep.repr == "fallback.group:myartifact:2.0.0")
+  }
+
+  test("FromModel uses publish.groupId when set on the project") {
+    val coords = CoordinatesFor.FromModel(version = "2.0.0", fallbackGroupId = "fallback.group")
+    val publish = model.PublishConfig(
+      enabled = None,
+      groupId = Some("real.group"),
+      description = None,
+      url = None,
+      organization = None,
+      developers = model.JsonSet.empty,
+      licenses = model.JsonSet.empty,
+      sonatypeProfileName = None,
+      sonatypeCredentialHost = None
+    )
+    val project = model.Project.empty.copy(publish = Some(publish))
+    val dep = coords(projectName, project)
+
+    assert(dep.repr == "real.group:myartifact:2.0.0")
+  }
+}


### PR DESCRIPTION
## Summary

- `CoordinatesFor.fromGroupId` decided Java-vs-Scala publish artifact shape by pattern-matching `explodedProject.scala` (presence of the `scala:` block). A Java project inheriting Scala options from a shared template — but no Scala version — was being constructed as `Dep.ScalaDependency`, which then failed downstream with *"You need to configure a scala version to resolve build.bleep::name:version"* (the `::` from `ScalaDependency.repr`).
- Changed the match to `explodedProject.scala.flatMap(_.version)`. Inherited options without a version mean the project is Java; publish as plain `groupId:name:version`.
- Added 5 unit-test cases in `bleep-tests/src/scala/bleep/CoordinatesForTest.scala` covering Java-only, Scala-with-version, the scala-block-without-version regression, and `FromModel`'s fallback-vs-publish-config logic.

## Test plan

- [x] `bleep test bleep-tests --only "bleep.CoordinatesForTest"` → 5/5 pass on this branch
- [x] Reverted the fix locally to confirm the regression test catches the bug: case 3 fails with `ScalaDependency(...) was not instance of bleep.model.Dep.JavaDependency`
- [x] `bleep compile` (full build) succeeds
- [ ] Reviewer: `bleep publish-local --groupId X --version Y bleepscript` still produces `bleepscript-Y.jar` (no `_3` suffix)
- [ ] Reviewer: `bleep publish-local --groupId X --version Y bleep-core` still produces `bleep-core_3-Y.jar` (Scala-suffixed, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)