### PR TITLE
Reformat to scalafmt 3.11.1 scala3 dialect and eliminate all 132 warnings

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,8 +1,7 @@
-version=3.10.7
+version=3.11.1
 maxColumn = 160
 rewrite.rules = [SortImports, RedundantBraces, RedundantParens, PreferCurlyFors]
 project.excludePaths = [
-  "glob:**/liberated/**",
   "glob:**/snapshot-tests/**",
   "glob:**/snapshot-tests-in/**",
 ]

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BuildDiffTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BuildDiffTest.scala
@@ -489,27 +489,27 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
   // ==========================================================================
 
   test("formatCompileSummary: all clear, no history") {
-    BuildDiff.formatCompileSummary(10, 0, 0, 0, 0) shouldBe "Build: 10 projects compiled, all clear"
+    BuildDiff.formatCompileSummary(10, 0, 0, 0).shouldBe("Build: 10 projects compiled, all clear")
   }
 
   test("formatCompileSummary: all clear after fixing errors") {
-    BuildDiff.formatCompileSummary(10, 0, 0, 0, 3) shouldBe "Build: 10 projects compiled, all clear (fixed 3 errors)"
+    BuildDiff.formatCompileSummary(10, 0, 0, 3).shouldBe("Build: 10 projects compiled, all clear (fixed 3 errors)")
   }
 
   test("formatCompileSummary: errors with new and fixed and remaining") {
-    BuildDiff.formatCompileSummary(10, 2, 0, 1, 1) shouldBe "Build: 10 projects compiled, 2 errors (1 fixed, 1 new, 1 remaining)"
+    BuildDiff.formatCompileSummary(10, 2, 1, 1).shouldBe("Build: 10 projects compiled, 2 errors (1 fixed, 1 new, 1 remaining)")
   }
 
   test("formatCompileSummary: errors with new and remaining") {
-    BuildDiff.formatCompileSummary(10, 3, 0, 2, 0) shouldBe "Build: 10 projects compiled, 3 errors (2 new, 1 remaining)"
+    BuildDiff.formatCompileSummary(10, 3, 2, 0).shouldBe("Build: 10 projects compiled, 3 errors (2 new, 1 remaining)")
   }
 
   test("formatCompileSummary: singular error") {
-    BuildDiff.formatCompileSummary(5, 1, 0, 1, 0) shouldBe "Build: 5 projects compiled, 1 error (1 new)"
+    BuildDiff.formatCompileSummary(5, 1, 1, 0).shouldBe("Build: 5 projects compiled, 1 error (1 new)")
   }
 
   test("formatCompileSummary: fixed singular error") {
-    BuildDiff.formatCompileSummary(5, 0, 0, 0, 1) shouldBe "Build: 5 projects compiled, all clear (fixed 1 error)"
+    BuildDiff.formatCompileSummary(5, 0, 0, 1).shouldBe("Build: 5 projects compiled, all clear (fixed 1 error)")
   }
 
   // ==========================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaNativeTestIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaNativeTestIntegrationTest.scala
@@ -631,7 +631,6 @@ class ScalaNativeAdvancedTestIntegrationTest extends AnyFunSuite with Matchers w
           ScalaNativeTestRunner.TestFramework.MUnit,
           handler,
           Map.empty,
-          tempDir,
           snVersion,
           killSignal
         )

--- a/bleep-bsp-tests/src/scala/bleep/analysis/TimeoutAndResourceTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/TimeoutAndResourceTest.scala
@@ -195,7 +195,7 @@ class TimeoutAndResourceTest extends AnyFunSuite with Matchers with TimeLimits {
       } yield maybeReason).unsafeRunSync()
 
       // Should have completed on the right (sleep finished) not left (kill signal)
-      result shouldBe a[Right[_, _]]
+      result shouldBe a[Right[?, ?]]
     }
   }
 
@@ -211,7 +211,7 @@ class TimeoutAndResourceTest extends AnyFunSuite with Matchers with TimeLimits {
         reasonAfter <- killSignal.get
       } yield (maybeReasonBefore, reasonAfter)).unsafeRunSync()
 
-      result._1 shouldBe a[Right[_, _]] // Not completed before
+      result._1 shouldBe a[Right[?, ?]] // Not completed before
       result._2 shouldBe KillReason.UserRequest // Completed after
     }
   }

--- a/bleep-bsp/src/scala/bleep/analysis/ClasspathAnalyzer.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ClasspathAnalyzer.scala
@@ -254,9 +254,7 @@ object ClasspathAnalyzer {
   }
 
   /** Hash a type member symbol (type alias, abstract type) */
-  private def hashTypeMemberSymbol(typeMember: tastyquery.Symbols.TypeMemberSymbol)(using
-      tastyquery.Contexts.Context
-  ): String = {
+  private def hashTypeMemberSymbol(typeMember: tastyquery.Symbols.TypeMemberSymbol): String = {
     val sb = new StringBuilder
     sb.append("type:")
     sb.append(typeMember.displayFullName)
@@ -379,7 +377,7 @@ object ClasspathAnalyzer {
           if symbols.nonEmpty && !symbols.contains(sym) then () // skip
           else {
             // Hash with rich Kotlin metadata
-            val hash = hashKotlinClassFile(classBytes, reader)
+            val hash = hashKotlinClassFile(reader)
             hashes(sym) = TypeHash(sym, hash, jarPath)
           }
         } finally is.close()
@@ -389,7 +387,7 @@ object ClasspathAnalyzer {
   }
 
   /** Extract Kotlin metadata from class bytes using ASM */
-  private def extractKotlinMetadata(classBytes: Array[Byte], reader: ClassReader): Option[kotlin.Metadata] = {
+  private def extractKotlinMetadata(reader: ClassReader): Option[kotlin.Metadata] = {
     var kind: Int = 0
     var metadataVersion: Array[Int] = Array.empty
     var data1: Array[String] = Array.empty
@@ -446,13 +444,13 @@ object ClasspathAnalyzer {
   }
 
   /** Hash a Kotlin class file - uses kotlin-metadata-jvm for rich type information */
-  private def hashKotlinClassFile(classBytes: Array[Byte], reader: ClassReader): String = {
+  private def hashKotlinClassFile(reader: ClassReader): String = {
     val sb = new StringBuilder
     sb.append("kotlin-class:")
     sb.append(reader.getClassName)
 
     // Try to extract and parse rich Kotlin metadata
-    extractKotlinMetadata(classBytes, reader) match {
+    extractKotlinMetadata(reader) match {
       case Some(metadata) =>
         try {
           val kcm = KotlinClassMetadata.Companion.readLenient(metadata)

--- a/bleep-bsp/src/scala/bleep/analysis/CompilationCoordinator.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/CompilationCoordinator.scala
@@ -262,7 +262,7 @@ class CompilationCoordinator(
       case Right(deferred) =>
         // We're responsible for compiling
         // Use guaranteeCase to ensure deferred is completed even on error/cancellation
-        doCompile(key, sources, classpath, outputDir, config)
+        doCompile(sources, classpath, outputDir, config)
           .guaranteeCase {
             case cats.effect.Outcome.Succeeded(fa) =>
               fa.flatMap(result => inProcessState.complete(key, result))
@@ -283,7 +283,6 @@ class CompilationCoordinator(
     }
 
   private def doCompile(
-      key: CompileKey,
       sources: Map[Path, String],
       classpath: Seq[Path],
       outputDir: Path,

--- a/bleep-bsp/src/scala/bleep/analysis/Compiler.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/Compiler.scala
@@ -400,9 +400,11 @@ object Compiler {
       if Files.exists(path) then {
         if Files.isDirectory(path) then {
           import scala.jdk.StreamConverters.*
-          scala.util.Using(Files.list(path)) { stream =>
-            stream.toScala(List).foreach(deleteRecursively)
-          }
+          scala.util
+            .Using(Files.list(path)) { stream =>
+              stream.toScala(List).foreach(deleteRecursively)
+            }
+            .get
         }
         Files.delete(path)
       }

--- a/bleep-bsp/src/scala/bleep/analysis/CompilerResolver.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/CompilerResolver.scala
@@ -880,7 +880,7 @@ object CompilerResolver {
           s"https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-native-prebuilt/$kotlinVersion/kotlin-native-prebuilt-$kotlinVersion-$platform.tar.gz"
         val conn = java.net.URI.create(url).toURL.openConnection()
         val in = conn.getInputStream
-        try Files.copy(in, tarGz)
+        try Files.copy(in, tarGz): Unit
         finally in.close()
       }
       // Extract

--- a/bleep-bsp/src/scala/bleep/analysis/KotlinJsCompiler.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/KotlinJsCompiler.scala
@@ -4,8 +4,6 @@ import bleep.model.VersionKotlin
 import cats.effect.IO
 import java.nio.file.{Files, Path}
 import java.lang.reflect.InvocationTargetException
-import scala.jdk.CollectionConverters.*
-import scala.collection.mutable
 
 /** Kotlin/JS compiler.
   *
@@ -287,7 +285,6 @@ object KotlinJsCompiler {
   /** Create Services instance with CompilationCanceledStatus. */
   private def createServicesWithCancellation(loader: ClassLoader, cancellation: CancellationToken): Any =
     try {
-      val servicesClass = loader.loadClass("org.jetbrains.kotlin.config.Services")
       val servicesBuilderClass = loader.loadClass("org.jetbrains.kotlin.config.Services$Builder")
       val canceledStatusClass = loader.loadClass("org.jetbrains.kotlin.progress.CompilationCanceledStatus")
 
@@ -334,7 +331,6 @@ object KotlinJsCompiler {
 
   private def createEmptyServices(loader: ClassLoader): Any = {
     val servicesClass = loader.loadClass("org.jetbrains.kotlin.config.Services")
-    val servicesCompanion = loader.loadClass("org.jetbrains.kotlin.config.Services$Companion")
     val companionField = servicesClass.getField("Companion")
     val companion = companionField.get(null)
     val emptyMethod = companion.getClass.getMethod("getEMPTY")
@@ -359,12 +355,6 @@ object KotlinJsCompiler {
           }
         }
     }
-
-  private def getField[T](obj: Any, fieldName: String): T = {
-    val field = obj.getClass.getDeclaredField(fieldName)
-    field.setAccessible(true)
-    field.get(obj).asInstanceOf[T]
-  }
 
   private def createMessageCollector(
       listener: DiagnosticListener,
@@ -722,7 +712,6 @@ object KotlinJsLinker {
 
   private def createServicesWithCancellation(loader: ClassLoader, cancellation: CancellationToken): Any =
     try {
-      val servicesClass = loader.loadClass("org.jetbrains.kotlin.config.Services")
       val servicesBuilderClass = loader.loadClass("org.jetbrains.kotlin.config.Services$Builder")
       val canceledStatusClass = loader.loadClass("org.jetbrains.kotlin.progress.CompilationCanceledStatus")
 
@@ -730,7 +719,7 @@ object KotlinJsLinker {
         loader,
         Array(canceledStatusClass),
         new java.lang.reflect.InvocationHandler {
-          override def invoke(proxy: Any, method: java.lang.reflect.Method, args: Array[AnyRef]): AnyRef =
+          override def invoke(@annotation.unused proxy: Any, method: java.lang.reflect.Method, @annotation.unused args: Array[AnyRef]): AnyRef =
             method.getName match {
               case "checkCanceled" =>
                 if (Thread.interrupted()) {
@@ -765,7 +754,6 @@ object KotlinJsLinker {
 
   private def createEmptyServices(loader: ClassLoader): Any = {
     val servicesClass = loader.loadClass("org.jetbrains.kotlin.config.Services")
-    val servicesCompanion = loader.loadClass("org.jetbrains.kotlin.config.Services$Companion")
     val companionField = servicesClass.getField("Companion")
     val companion = companionField.get(null)
     val emptyMethod = companion.getClass.getMethod("getEMPTY")

--- a/bleep-bsp/src/scala/bleep/analysis/KotlinNativeCompiler.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/KotlinNativeCompiler.scala
@@ -91,7 +91,7 @@ object KotlinNativeCompiler {
           s"https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-native-prebuilt/$kotlinVersion/kotlin-native-prebuilt-$kotlinVersion-$platform.tar.gz"
         val conn = java.net.URI.create(url).toURL.openConnection()
         val in = conn.getInputStream
-        try Files.copy(in, tarGz)
+        try Files.copy(in, tarGz): Unit
         finally in.close()
       }
       // Extract
@@ -249,8 +249,8 @@ object KotlinNativeCompiler {
         KotlinNativeCompileResult(outputPath, 1)
     } finally
       // Restore previous konan.home
-      if (oldKonanHome != null) System.setProperty("konan.home", oldKonanHome)
-      else System.clearProperty("konan.home")
+      if (oldKonanHome != null) System.setProperty("konan.home", oldKonanHome): Unit
+      else System.clearProperty("konan.home"): Unit
   }
 
   /** Check cancellation and throw if cancelled. Also checks thread interrupt. */
@@ -344,7 +344,7 @@ object KotlinNativeCompiler {
         .inheritIO()
 
       val process = pb.start()
-      cancellation.onCancel(() => process.destroyForcibly())
+      cancellation.onCancel { () => process.destroyForcibly(); () }
 
       val exitCode = process.waitFor()
       if (cancellation.isCancelled) {

--- a/bleep-bsp/src/scala/bleep/analysis/KotlinSourceCompiler.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/KotlinSourceCompiler.scala
@@ -154,9 +154,9 @@ object KotlinSourceCompiler extends Compiler {
           .toScala(LazyList)
           .filter(p => Files.isRegularFile(p) && p != hashFile)
           .foreach { p =>
-            Try(Files.delete(p))
+            Try(Files.delete(p)): Unit
           }
-      }
+      }.get
 
       // Also delete subdirectories (but not the cache dir itself)
       Using(Files.walk(cacheDir)) { stream =>
@@ -164,11 +164,11 @@ object KotlinSourceCompiler extends Compiler {
           .toScala(LazyList)
           .filter(p => Files.isDirectory(p) && p != cacheDir)
           .toList
-          .sortBy(_.toString)(Ordering[String].reverse) // Delete deepest first
+          .sortBy(_.toString)(using Ordering[String].reverse) // Delete deepest first
           .foreach { p =>
-            Try(Files.delete(p))
+            Try(Files.delete(p)): Unit
           }
-      }
+      }.get
 
       debug("Invalidated IC cache due to classpath change")
     }
@@ -263,9 +263,9 @@ object KotlinSourceCompiler extends Compiler {
         Using(Files.walk(dir)) { stream =>
           stream
             .toScala(LazyList)
-            .sorted(Ordering[String].reverse.on[Path](_.toString)) // Delete deepest first
+            .sorted(using Ordering[String].reverse.on[Path](_.toString)) // Delete deepest first
             .foreach(p => Try(Files.delete(p)))
-        }
+        }: Unit
       catch {
         case _: Exception => () // Ignore cleanup errors
       }
@@ -380,7 +380,6 @@ object KotlinSourceCompiler extends Compiler {
       listener: DiagnosticListener,
       cancellation: CancellationToken
   ): CompilationResult = {
-    val loader = setup.loader
     val collectedErrors = mutable.ListBuffer[CompilerError]()
 
     try {
@@ -429,7 +428,7 @@ object KotlinSourceCompiler extends Compiler {
         s"IncrementalJvmCompilerRunner constructors: ${allConstructors.map(c => s"(${c.getParameterCount} params: ${c.getParameterTypes.map(_.getSimpleName).mkString(", ")})").mkString("; ")}"
       )
 
-      val runner = tryConstructRunner(
+      val maybeRunner = tryConstructRunner(
         allConstructors,
         7,
         Array[Object](
@@ -441,25 +440,26 @@ object KotlinSourceCompiler extends Compiler {
           kotlinExtensions,
           icFeatures.asInstanceOf[Object]
         )
-      )
-        .orElse(
-          tryConstructRunner(
-            allConstructors,
-            6,
-            Array[Object](
-              cacheDirFile,
-              setup.buildReporterInstance.asInstanceOf[Object],
-              outputDirs,
-              setup.classpathChangesInstance.asInstanceOf[Object],
-              kotlinExtensions,
-              icFeatures.asInstanceOf[Object]
-            )
+      ).orElse(
+        tryConstructRunner(
+          allConstructors,
+          6,
+          Array[Object](
+            cacheDirFile,
+            setup.buildReporterInstance.asInstanceOf[Object],
+            outputDirs,
+            setup.classpathChangesInstance.asInstanceOf[Object],
+            kotlinExtensions,
+            icFeatures.asInstanceOf[Object]
           )
         )
-        .getOrElse {
-          debug(s"No matching IncrementalJvmCompilerRunner constructor found, falling back to non-incremental compilation")
-          return compileWithReflection(setup, config, sourceFiles, input, listener, cancellation)
-        }
+      )
+
+      if (maybeRunner.isEmpty) {
+        debug(s"No matching IncrementalJvmCompilerRunner constructor found, falling back to non-incremental compilation")
+        return compileWithReflection(setup, config, sourceFiles, input, listener, cancellation)
+      }
+      val runner = maybeRunner.get
 
       // Create K2JVMCompilerArguments
       val arguments = setup.argumentsClass.getDeclaredConstructor().newInstance()
@@ -476,7 +476,7 @@ object KotlinSourceCompiler extends Compiler {
       // Set classpath
       if input.classpath.nonEmpty then {
         val setClasspath = setup.argumentsClass.getMethod("setClasspath", classOf[String])
-        setClasspath.invoke(arguments, input.classpath.map(_.toString).mkString(java.io.File.pathSeparator))
+        setClasspath.invoke(arguments, input.classpath.map(_.toString).mkString(java.io.File.pathSeparator)): Unit
       }
 
       // Set JVM target
@@ -644,7 +644,7 @@ object KotlinSourceCompiler extends Compiler {
       // Set classpath
       if input.classpath.nonEmpty then {
         val setClasspath = setup.argumentsClass.getMethod("setClasspath", classOf[String])
-        setClasspath.invoke(arguments, input.classpath.map(_.toString).mkString(java.io.File.pathSeparator))
+        setClasspath.invoke(arguments, input.classpath.map(_.toString).mkString(java.io.File.pathSeparator)): Unit
       }
 
       // Set JVM target
@@ -728,7 +728,7 @@ object KotlinSourceCompiler extends Compiler {
   /** Try to construct IncrementalJvmCompilerRunner with the given parameter count and args. */
   private def tryConstructRunner(constructors: Array[java.lang.reflect.Constructor[?]], paramCount: Int, args: Array[Object]): Option[Any] =
     constructors.find(_.getParameterCount == paramCount).flatMap { ctor =>
-      try Some(ctor.newInstance(args: _*))
+      try Some(ctor.newInstance(args*))
       catch {
         case e: Exception =>
           debug(s"Constructor with $paramCount params failed: ${e.getClass.getSimpleName}: ${e.getMessage}")
@@ -775,7 +775,7 @@ object KotlinSourceCompiler extends Compiler {
       if (pluginOptions.nonEmpty) {
         try {
           val setPluginOptions = setup.argumentsClass.getMethod("setPluginOptions", classOf[Array[String]])
-          setPluginOptions.invoke(arguments, pluginOptions.toArray.asInstanceOf[AnyRef])
+          setPluginOptions.invoke(arguments, pluginOptions.toArray.asInstanceOf[AnyRef]): Unit
         } catch {
           case _: NoSuchMethodException =>
             debug(s"K2JVMCompilerArguments.setPluginOptions not found, skipping -P options")
@@ -807,7 +807,7 @@ object KotlinSourceCompiler extends Compiler {
           }
           parseMethod match {
             case Some(m) =>
-              m.invoke(null, remainingOpts.asJava, arguments, java.lang.Boolean.FALSE)
+              m.invoke(null, remainingOpts.asJava, arguments, java.lang.Boolean.FALSE): Unit
             case None =>
               debug(s"ParseCommandLineArgumentsKt.parseCommandLineArguments(List, Args, Boolean) not found; could not apply: ${remainingOpts.mkString(", ")}")
           }

--- a/bleep-bsp/src/scala/bleep/analysis/ProjectCompiler.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ProjectCompiler.scala
@@ -333,9 +333,9 @@ object KotlinProjectCompiler extends ProjectCompiler {
         Using(Files.walk(tempDir)) { stream =>
           stream
             .toScala(LazyList)
-            .sorted(Ordering[String].reverse.on[Path](_.toString))
+            .sorted(using Ordering[String].reverse.on[Path](_.toString))
             .foreach(p => scala.util.Try(Files.delete(p)))
-        }
+        }: Unit
       }
     } finally fileManager.close()
   }
@@ -354,7 +354,7 @@ object KotlinProjectCompiler extends ProjectCompiler {
           Files.createDirectories(target.getParent)
           Files.copy(classFile, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
         }
-    }
+    }.get
   }
 }
 

--- a/bleep-bsp/src/scala/bleep/analysis/ProjectDag.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ProjectDag.scala
@@ -108,26 +108,27 @@ case class ProjectDag(
     val visited = mutable.Set[String]()
     val path = mutable.ListBuffer[String]()
 
-    def dfs(node: String): Option[List[String]] = {
-      if (path.contains(node)) {
-        // Found cycle
-        val cycleStart = path.indexOf(node)
-        return Some((path.drop(cycleStart) :+ node).toList)
-      }
-      if (visited.contains(node)) return None
-
-      visited += node
-      path += node
-
-      for (dep <- dependenciesOf(node) if remaining.contains(dep))
-        dfs(dep) match {
-          case Some(cycle) => return Some(cycle)
-          case None        => ()
+    def dfs(node: String): Option[List[String]] =
+      scala.util.boundary {
+        if (path.contains(node)) {
+          // Found cycle
+          val cycleStart = path.indexOf(node)
+          scala.util.boundary.break(Some((path.drop(cycleStart) :+ node).toList))
         }
+        if (visited.contains(node)) scala.util.boundary.break(None)
 
-      path.dropRightInPlace(1)
-      None
-    }
+        visited += node
+        path += node
+
+        for (dep <- dependenciesOf(node) if remaining.contains(dep))
+          dfs(dep) match {
+            case Some(cycle) => scala.util.boundary.break(Some(cycle))
+            case None        => ()
+          }
+
+        path.dropRightInPlace(1)
+        None
+      }
 
     remaining
       .collectFirst {

--- a/bleep-bsp/src/scala/bleep/analysis/ScalaJs1Bridge.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ScalaJs1Bridge.scala
@@ -2,7 +2,7 @@ package bleep.analysis
 
 import cats.effect.IO
 import java.nio.file.{Files, Path}
-import java.lang.reflect.{InvocationTargetException, Method}
+import java.lang.reflect.InvocationTargetException
 import scala.jdk.CollectionConverters.*
 
 /** Scala.js 1.x linker bridge.
@@ -10,7 +10,6 @@ import scala.jdk.CollectionConverters.*
   * Uses reflection to invoke the Scala.js linker APIs, allowing different Scala.js versions to be loaded in isolated classloaders.
   */
 class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends ScalaJsToolchain {
-  import ScalaJs1Bridge.*
 
   override def link(
       config: ScalaJsLinkConfig,
@@ -90,11 +89,9 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
     val standardConfigClass = loader.loadClass("org.scalajs.linker.interface.StandardConfig")
     val standardConfigCompanion = loader.loadClass("org.scalajs.linker.interface.StandardConfig$")
     val linkerClass = loader.loadClass("org.scalajs.linker.StandardImpl$")
-    val moduleInitializerClass = loader.loadClass("org.scalajs.linker.interface.ModuleInitializer")
     val moduleInitializerCompanion = loader.loadClass("org.scalajs.linker.interface.ModuleInitializer$")
     val pathIRContainerClass = loader.loadClass("org.scalajs.linker.PathIRContainer$")
     val pathOutputDirectoryClass = loader.loadClass("org.scalajs.linker.PathOutputDirectory$")
-    val loggerClass = loader.loadClass("org.scalajs.logging.Logger")
     val levelClass = loader.loadClass("org.scalajs.logging.Level")
 
     // Get companion objects
@@ -107,7 +104,6 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
     // Create linker config
     val linkerConfig = createLinkerConfig(
       standardConfigObj,
-      standardConfigClass,
       config,
       loader
     )
@@ -117,7 +113,7 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
     val linker = linkerMethod.invoke(linkerObj, linkerConfig)
 
     // Create logger adapter
-    val scalaJsLogger = createLoggerAdapter(logger, loader, loggerClass, levelClass)
+    val scalaJsLogger = createLoggerAdapter(loader, levelClass)
 
     // Check cancellation
     checkCancellation(cancellation)
@@ -135,7 +131,7 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
     val moduleInitializers = createModuleInitializers(mainClass, moduleInitializerObj, loader, isTest)
 
     // Create output directory handler
-    val outputDirectory = createOutputDirectory(outputDir, pathOutputDirectoryObj, loader)
+    val outputDirectory = createOutputDirectory(outputDir, pathOutputDirectoryObj)
     logger.info(s"[ScalaJs1Bridge] Output directory: $outputDir")
 
     // Check cancellation before linking
@@ -143,7 +139,7 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
 
     // Link
     logger.info(s"[ScalaJs1Bridge] Starting linker...")
-    val linkedFiles = runLinker(linker, irFilesSeq, moduleInitializers, outputDirectory, scalaJsLogger, loader, cancellation)
+    runLinker(linker, irFilesSeq, moduleInitializers, outputDirectory, scalaJsLogger, loader, cancellation)
     logger.info(s"[ScalaJs1Bridge] Linker completed")
 
     // Check cancellation after linking
@@ -183,7 +179,6 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
 
   private def createLinkerConfig(
       standardConfigObj: Any,
-      standardConfigClass: Class[?],
       config: ScalaJsLinkConfig,
       loader: ClassLoader
   ): Any = {
@@ -194,8 +189,6 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
 
     // Apply settings using withXxx methods
     val moduleKindClass = loader.loadClass("org.scalajs.linker.interface.ModuleKind")
-    val moduleKindCompanion = loader.loadClass("org.scalajs.linker.interface.ModuleKind$")
-    val moduleKindObj = moduleKindCompanion.getField("MODULE$").get(null)
 
     val moduleKindName = config.moduleKind match {
       case ScalaJsLinkConfig.ModuleKind.NoModule       => "NoModule$"
@@ -257,9 +250,7 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
   }
 
   private def createLoggerAdapter(
-      logger: ScalaJsToolchain.Logger,
       loader: ClassLoader,
-      loggerClass: Class[?],
       levelClass: Class[?]
   ): Any = {
     // Create ScalaConsoleLogger with Level.Debug (Debug is a nested case object)
@@ -274,9 +265,6 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
       linkerObj: Any,
       loader: ClassLoader
   ): Any = {
-    import scala.concurrent.ExecutionContext.Implicits.global
-    import scala.concurrent.{Await, Future}
-    import scala.concurrent.duration.*
 
     // PathIRContainer.fromClasspath
     val fromClasspathMethod = pathIRContainerObj.getClass.getMethods.find(m => m.getName == "fromClasspath" && m.getParameterCount == 2).get
@@ -297,8 +285,6 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
     }
 
     // Get the IR containers
-    val futureClass = loader.loadClass("scala.concurrent.Future")
-    val ecClass = loader.loadClass("scala.concurrent.ExecutionContext")
     val globalEC = loader.loadClass("scala.concurrent.ExecutionContext$").getField("MODULE$").get(null)
     val ecGlobal = globalEC.getClass.getMethod("global").invoke(globalEC)
 
@@ -388,8 +374,7 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
 
   private def createOutputDirectory(
       outputDir: Path,
-      pathOutputDirectoryObj: Any,
-      loader: ClassLoader
+      pathOutputDirectoryObj: Any
   ): Any = {
     val applyMethod = pathOutputDirectoryObj.getClass.getMethods.find(m => m.getName == "apply" && m.getParameterCount == 1).get
     applyMethod.invoke(pathOutputDirectoryObj, outputDir)
@@ -404,16 +389,6 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
       loader: ClassLoader,
       cancellation: CancellationToken
   ): Any = {
-    import scala.concurrent.ExecutionContext.Implicits.global
-    import scala.concurrent.{Await, Future}
-    import scala.concurrent.duration.*
-
-    // Get the link method
-    val irFileClass = loader.loadClass("org.scalajs.linker.interface.IRFile")
-    val moduleInitializerClass = loader.loadClass("org.scalajs.linker.interface.ModuleInitializer")
-    val outputDirectoryClass = loader.loadClass("org.scalajs.linker.interface.OutputDirectory")
-    val loggerClass = loader.loadClass("org.scalajs.logging.Logger")
-    val ecClass = loader.loadClass("scala.concurrent.ExecutionContext")
 
     val globalEC = loader.loadClass("scala.concurrent.ExecutionContext$").getField("MODULE$").get(null)
     val ecGlobal = globalEC.getClass.getMethod("global").invoke(globalEC)

--- a/bleep-bsp/src/scala/bleep/analysis/ScalaNative04Bridge.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ScalaNative04Bridge.scala
@@ -86,7 +86,6 @@ class ScalaNative04Bridge(scalaNativeVersion: String, scalaVersion: String) exte
 
     try {
       // Load classes
-      val configClass = loader.loadClass("scala.scalanative.build.Config")
       val configCompanion = loader.loadClass("scala.scalanative.build.Config$")
       val nativeConfigClass = loader.loadClass("scala.scalanative.build.NativeConfig")
       val nativeConfigCompanion = loader.loadClass("scala.scalanative.build.NativeConfig$")
@@ -223,11 +222,11 @@ class ScalaNative04Bridge(scalaNativeVersion: String, scalaVersion: String) exte
       }
 
       val rawResult =
-        try buildMethod.invoke(buildObj, args: _*)
+        try buildMethod.invoke(buildObj, args*)
         finally
           // Close the Scope if we created one
           if (scope != null) {
-            try scope.getClass.getMethod("close").invoke(scope)
+            try scope.getClass.getMethod("close").invoke(scope): Unit
             catch { case _: Exception => () }
           }
 
@@ -243,7 +242,7 @@ class ScalaNative04Bridge(scalaNativeVersion: String, scalaVersion: String) exte
 
       // Move result to output path if different
       if (result != outputPath) {
-        Files.copy(result, outputPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        Files.copy(result, outputPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING): Unit
       }
 
       ScalaNativeLinkResult(outputPath, 0)
@@ -359,7 +358,7 @@ class ScalaNative04Bridge(scalaNativeVersion: String, scalaVersion: String) exte
               // Concrete trait methods (timeAsync, time, running) are default methods
               // on the interface — delegate to the actual implementation so they work.
               if (method.isDefault)
-                java.lang.reflect.InvocationHandler.invokeDefault(proxy, method, args: _*)
+                java.lang.reflect.InvocationHandler.invokeDefault(proxy, method, args*)
               else {
                 val rt = method.getReturnType
                 if (rt == java.lang.Boolean.TYPE) Boolean.box(false)

--- a/bleep-bsp/src/scala/bleep/analysis/ScalaNative05Bridge.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ScalaNative05Bridge.scala
@@ -86,7 +86,6 @@ class ScalaNative05Bridge(scalaNativeVersion: String, scalaVersion: String) exte
 
     try {
       // Load classes
-      val configClass = loader.loadClass("scala.scalanative.build.Config")
       val configCompanion = loader.loadClass("scala.scalanative.build.Config$")
       val nativeConfigClass = loader.loadClass("scala.scalanative.build.NativeConfig")
       val nativeConfigCompanion = loader.loadClass("scala.scalanative.build.NativeConfig$")
@@ -288,12 +287,12 @@ class ScalaNative05Bridge(scalaNativeVersion: String, scalaVersion: String) exte
       }
 
       val future =
-        try buildMethod.invoke(buildObj, args: _*)
+        try buildMethod.invoke(buildObj, args*)
         catch {
           case e: Throwable =>
             // Close scope on failure before rethrowing
             if (scope != null) {
-              try scope.getClass.getMethod("close").invoke(scope)
+              try scope.getClass.getMethod("close").invoke(scope): Unit
               catch { case _: Exception => () }
             }
             throw e
@@ -309,7 +308,7 @@ class ScalaNative05Bridge(scalaNativeVersion: String, scalaVersion: String) exte
         try awaitResult(future, loader, cancellation)
         finally
           if (scope != null) {
-            try scope.getClass.getMethod("close").invoke(scope)
+            try scope.getClass.getMethod("close").invoke(scope): Unit
             catch { case _: Exception => () }
           }
 
@@ -319,7 +318,7 @@ class ScalaNative05Bridge(scalaNativeVersion: String, scalaVersion: String) exte
       // Copy result to output path if needed
       val resultPath = result.asInstanceOf[Path]
       if (resultPath != outputPath && Files.exists(resultPath)) {
-        Files.copy(resultPath, outputPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        Files.copy(resultPath, outputPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING): Unit
       }
 
       ScalaNativeLinkResult(outputPath, 0)
@@ -424,7 +423,7 @@ class ScalaNative05Bridge(scalaNativeVersion: String, scalaVersion: String) exte
               // Concrete trait methods (timeAsync, time, running) are default methods
               // on the interface — delegate to the actual implementation so they work.
               if (method.isDefault)
-                java.lang.reflect.InvocationHandler.invokeDefault(proxy, method, args: _*)
+                java.lang.reflect.InvocationHandler.invokeDefault(proxy, method, args*)
               else {
                 val rt = method.getReturnType
                 if (rt == java.lang.Boolean.TYPE) Boolean.box(false)

--- a/bleep-bsp/src/scala/bleep/analysis/ScalaNativeRunner.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ScalaNativeRunner.scala
@@ -99,7 +99,7 @@ object ScalaNativeRunner {
         PosixFilePermission.GROUP_EXECUTE,
         PosixFilePermission.OTHERS_EXECUTE
       )
-      Files.setPosixFilePermissions(binary, newPerms.asJava)
+      Files.setPosixFilePermissions(binary, newPerms.asJava): Unit
     }
   }
 

--- a/bleep-bsp/src/scala/bleep/analysis/ZincBridge.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ZincBridge.scala
@@ -414,7 +414,7 @@ object ZincBridge {
     }
 
     NoopManifestStore.regenerateFromLocal(analysisFile, sourceDirs, sourcePaths, dependencyAnalyses, language, ecjVersion, result) match {
-      case Some(manifest) => noopManifestCache.put(analysisFile, manifest)
+      case Some(manifest) => noopManifestCache.put(analysisFile, manifest): Unit
       case None           => () // ctime unavailable (Windows) — manifest disabled
     }
   }
@@ -468,7 +468,7 @@ object ZincBridge {
     if (!hasPrevAnalysis && Files.exists(config.outputDir)) {
       debug(s"[ZincBridge] No analysis for ${config.name} — clearing stale class files from ${config.outputDir}")
       bleep.internal.FileUtils.deleteDirectory(config.outputDir)
-      Files.createDirectories(config.outputDir)
+      Files.createDirectories(config.outputDir): Unit
     }
 
     // Emit CompilationReason so the client display shows "Compiling: project-name ..."
@@ -557,7 +557,7 @@ object ZincBridge {
         debug(s"[ZincBridge] Saving analysis for ${config.name}")
         saveAnalysis(analysisFile, result.analysis, result.setup)
         checkCaseInsensitiveCollisions(result.analysis, config.name, diagnosticListener)
-        checkAnalysisPortability(result.analysis, config.name, analysisFile)
+        checkAnalysisPortability(result.analysis, analysisFile)
       }
 
       val classFiles = collectClassFiles(config.outputDir)
@@ -575,7 +575,7 @@ object ZincBridge {
         noopManifestCache.remove(analysisFile)
         if (Files.exists(config.outputDir)) {
           bleep.internal.FileUtils.deleteDirectory(config.outputDir)
-          Files.createDirectories(config.outputDir)
+          Files.createDirectories(config.outputDir): Unit
         }
         ProjectCompileFailure(
           List(
@@ -589,7 +589,7 @@ object ZincBridge {
             )
           )
         )
-      case e @ (_: VirtualMachineError | _: ThreadDeath | _: InterruptedException) =>
+      case e @ (_: VirtualMachineError | _: ThreadDeath @scala.annotation.nowarn("msg=ThreadDeath") | _: InterruptedException) =>
         // Don't trap fatal errors or cancellation — let them propagate.
         throw e
       case e: Throwable =>
@@ -693,7 +693,7 @@ object ZincBridge {
   }
 
   /** Check analysis portability and write warnings file next to analysis.zip. Read at push time. */
-  private def checkAnalysisPortability(analysis: CompileAnalysis, projectName: String, analysisFile: Path): Unit = {
+  private def checkAnalysisPortability(analysis: CompileAnalysis, analysisFile: Path): Unit = {
     val stamps = analysis.asInstanceOf[sbt.internal.inc.Analysis].stamps
     val allVfrs = stamps.sources.keySet ++ stamps.products.keySet ++ stamps.libraries.keySet
     val absoluteIds = allVfrs.iterator
@@ -704,9 +704,9 @@ object ZincBridge {
 
     val warningsFile = analysisFile.resolveSibling("portability-warnings")
     if (absoluteIds.nonEmpty) {
-      Files.writeString(warningsFile, absoluteIds.mkString("\n"))
+      Files.writeString(warningsFile, absoluteIds.mkString("\n")): Unit
     } else {
-      Files.deleteIfExists(warningsFile)
+      Files.deleteIfExists(warningsFile): Unit
     }
   }
 
@@ -793,7 +793,7 @@ object ZincBridge {
     )
 
     // Create a forked Java compiler that uses ECJ
-    val ecjCompiler = new EcjCompiler(ecjJars, ecjClassLoader, cancellationToken, progressListener)
+    val ecjCompiler = new EcjCompiler(ecjClassLoader, cancellationToken, progressListener)
 
     // Use standard javadoc (ECJ doesn't include javadoc)
     val standardJavaTools = sbt.internal.inc.javac.JavaTools.directOrFork(
@@ -1159,7 +1159,7 @@ object ZincBridge {
       Files.move(tempFile, analysisFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
       // Update soft reference cache so dependents see the fresh analysis
       val mtime = Files.getLastModifiedTime(analysisFile).toMillis
-      analysisCache.put(analysisFile, new SoftReference((mtime, analysis)))
+      analysisCache.put(analysisFile, new SoftReference((mtime, analysis))): Unit
     } catch {
       case e: Exception =>
         try Files.deleteIfExists(tempFile)
@@ -1225,7 +1225,6 @@ object ZincBridge {
   * Uses ECJ's batch Main with a CompilationProgress bridge (generated via ASM at runtime) to get per-file progress and native cancellation support.
   */
 private class EcjCompiler(
-    ecjJars: Seq[Path],
     ecjClassLoader: ClassLoader,
     cancellationToken: CancellationToken,
     progressListener: ProgressListener
@@ -1317,7 +1316,7 @@ private class EcjCompiler(
           val worked = workedSoFar.get()
           val total = totalWorkUnits.get()
           if (total > 0) {
-            progressListener.onProgress(worked, total, "ecj")
+            progressListener.onProgress(worked, total, "ecj"): Unit
           }
         }
       }
@@ -1573,7 +1572,7 @@ private[analysis] object EcjCompiler {
     *   - worked(int, int) — updates workedSoFar and totalWork
     */
   private[analysis] def generateBridgeClass(): Array[Byte] = {
-    import org.objectweb.asm.{ClassWriter, MethodVisitor, Opcodes}
+    import org.objectweb.asm.{ClassWriter, Opcodes}
 
     val cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS)
     cw.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, BridgeClassName, null, ProgressSuperClass, null)

--- a/bleep-bsp/src/scala/bleep/bsp/BspMetrics.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspMetrics.scala
@@ -14,9 +14,9 @@ import scala.jdk.CollectionConverters._
   */
 object BspMetrics {
 
-  @volatile private var writer: BufferedWriter = _
-  @volatile private var samplerThread: Thread = _
-  @volatile private var metricsPath: Path = _
+  @volatile private var writer: BufferedWriter = scala.compiletime.uninitialized
+  @volatile private var samplerThread: Thread = scala.compiletime.uninitialized
+  @volatile private var metricsPath: Path = scala.compiletime.uninitialized
 
   // High watermarks
   private val maxConcurrentCompiles = AtomicInteger(0)
@@ -187,7 +187,7 @@ object BspMetrics {
     val (cpuProcess, cpuSystem) =
       try {
         val osBean = ManagementFactory.getOperatingSystemMXBean.asInstanceOf[com.sun.management.OperatingSystemMXBean]
-        (osBean.getProcessCpuLoad, osBean.getSystemCpuLoad)
+        (osBean.getProcessCpuLoad, osBean.getCpuLoad)
       } catch {
         case _: ClassCastException => (-1.0, -1.0)
       }
@@ -268,7 +268,7 @@ object BspMetrics {
     try
       if (Files.exists(metricsPath) && Files.size(metricsPath) > MaxMetricsFileBytes) {
         val prev = metricsPath.resolveSibling("metrics.prev.jsonl")
-        Files.move(metricsPath, prev, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        Files.move(metricsPath, prev, java.nio.file.StandardCopyOption.REPLACE_EXISTING): Unit
       }
     catch { case _: Exception => () }
 

--- a/bleep-bsp/src/scala/bleep/bsp/BspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServer.scala
@@ -1,8 +1,7 @@
 package bleep.bsp
 
 import bleep.analysis.*
-import bleep.bsp.Outcome.KillReason
-import cats.effect.{Deferred, IO}
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import ch.epfl.scala.bsp.*
 import com.github.plokhotnyuk.jsoniter_scala.core.*
@@ -68,7 +67,7 @@ class BspServer(
             return
         }
     finally
-      try Runtime.getRuntime.removeShutdownHook(shutdownHook)
+      try Runtime.getRuntime.removeShutdownHook(shutdownHook): Unit
       catch { case _: IllegalStateException => () } // JVM already shutting down
   }
 
@@ -518,7 +517,6 @@ class BspServer(
       releaseMode: Boolean,
       cancellation: CancellationToken
   ): CompileResult = {
-    import cats.effect.unsafe.implicits.global
 
     val taskId = "compile-and-link"
     sendTaskStart(params.originId, taskId, s"Compiling and linking ${params.targets.size} target(s)...")
@@ -553,7 +551,7 @@ class BspServer(
             )
 
             val compiler = Compiler.forConfig(project.languageConfig)
-            val listener = createDiagnosticListener(targetId, params.originId)
+            val listener = createDiagnosticListener(targetId)
             val compileResult = compiler.compile(input, listener, cancellation)
 
             compileResult match {
@@ -853,7 +851,7 @@ class BspServer(
 
       // Create diagnostic listener that streams to BSP
       val targetIdByName = targetProjects.map { case (targetId, project) => project.name -> targetId }
-      val listener = createProjectDiagnosticListener(targetIdByName, params.originId)
+      val listener = createProjectDiagnosticListener(targetIdByName)
 
       // Send task start for overall compilation
       val taskId = "compile-all"
@@ -941,8 +939,7 @@ class BspServer(
 
   /** Create a diagnostic listener for project-level compilation */
   private def createProjectDiagnosticListener(
-      targetIdByName: Map[String, BuildTargetIdentifier],
-      originId: Option[String]
+      targetIdByName: Map[String, BuildTargetIdentifier]
   ): DiagnosticListener =
     new DiagnosticListener {
       override def onDiagnostic(error: CompilerError): Unit = {
@@ -1050,7 +1047,7 @@ class BspServer(
               // Kill the process when cancellation is requested — destroyForcibly
               // closes the streams, so readLine returns null and waitFor returns immediately.
               cancellation.onCancel { () =>
-                process.destroyForcibly()
+                process.destroyForcibly(): Unit
               }
 
               // Stream output to log messages with proper resource cleanup
@@ -1110,7 +1107,7 @@ class BspServer(
 
             val testSucceeded = project.platform match {
               case BuildLoader.Platform.Jvm =>
-                runJvmTests(project, params, cancellation)
+                runJvmTests(project, params)
               case BuildLoader.Platform.ScalaJs(sjsVersion, scalaVersion) =>
                 runScalaJsTests(project, sjsVersion, scalaVersion, cancellation)
               case BuildLoader.Platform.ScalaNative(snVersion, scalaVersion) =>
@@ -1156,8 +1153,7 @@ class BspServer(
   /** Run JVM tests using detected test framework. */
   private def runJvmTests(
       project: buildLoader.ProjectInfo,
-      params: TestParams,
-      cancellation: CancellationToken
+      params: TestParams
   ): Boolean = {
     val classpath = (project.outputDir :: project.classpath).map(_.toString).mkString(java.io.File.pathSeparator)
 
@@ -1359,7 +1355,6 @@ class BspServer(
               framework,
               eventHandler,
               Map.empty,
-              workspaceRoot,
               snVersion,
               killSignal
             )
@@ -1711,8 +1706,7 @@ class BspServer(
 
   /** Create a diagnostic listener that streams to BSP */
   private def createDiagnosticListener(
-      targetId: BuildTargetIdentifier,
-      originId: Option[String]
+      targetId: BuildTargetIdentifier
   ): DiagnosticListener =
     new DiagnosticListener {
       override def onDiagnostic(error: CompilerError): Unit = {

--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -67,13 +67,13 @@ object BspServerDaemon {
     */
   def registerWorkspace(workspaceRoot: Path): Unit = {
     val normalized = workspaceRoot.toAbsolutePath.normalize()
-    workspaces.putIfAbsent(normalized, WorkspaceState(normalized, None))
+    workspaces.putIfAbsent(normalized, WorkspaceState(normalized, None)): Unit
   }
 
   /** Unregister a workspace from the server. */
   def unregisterWorkspace(workspaceRoot: Path): Unit = {
     val normalized = workspaceRoot.toAbsolutePath.normalize()
-    workspaces.remove(normalized)
+    workspaces.remove(normalized): Unit
   }
 
   /** Get all registered workspaces */
@@ -83,7 +83,7 @@ object BspServerDaemon {
   /** Update build state for a workspace */
   def updateBuildState(workspaceRoot: Path, state: BuildState): Unit = {
     val normalized = workspaceRoot.toAbsolutePath.normalize()
-    workspaces.computeIfPresent(normalized, (_, ws) => ws.copy(buildState = Some(state)))
+    workspaces.computeIfPresent(normalized, (_, ws) => ws.copy(buildState = Some(state))): Unit
   }
 
   /** Get workspace state */
@@ -225,7 +225,7 @@ object BspServerDaemon {
         catch { case _: Exception => () }
         try
           ProcessHandle.current().descendants().forEach { ph =>
-            try ph.destroyForcibly()
+            try ph.destroyForcibly(): Unit
             catch { case _: Exception => () }
           }
         catch { case _: Exception => () }
@@ -263,7 +263,6 @@ object BspServerDaemon {
                   clientSocket.getInputStream,
                   clientSocket.getOutputStream,
                   logger.withContext("client", connId),
-                  config.socketDir,
                   compileSemaphore
                 )
               finally BspMetrics.recordConnectionClose(connId)
@@ -279,7 +278,6 @@ object BspServerDaemon {
                       clientSocket.getInputStream,
                       clientSocket.getOutputStream,
                       logger.withContext("client", connId),
-                      config.socketDir,
                       compileSemaphore
                     )
                   finally {
@@ -328,7 +326,6 @@ object BspServerDaemon {
       input: java.io.InputStream,
       output: java.io.OutputStream,
       logger: Logger,
-      socketDir: Path,
       compileSemaphore: java.util.concurrent.Semaphore
   ): Unit =
     try {
@@ -337,7 +334,6 @@ object BspServerDaemon {
         input,
         output,
         logger,
-        socketDir = Some(socketDir),
         compileSemaphore = compileSemaphore,
         heapMonitor = HeapMonitor.system
       )

--- a/bleep-bsp/src/scala/bleep/bsp/ClasspathTestDiscovery.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/ClasspathTestDiscovery.scala
@@ -283,44 +283,42 @@ object ClasspathTestDiscovery {
 
     clazz.flatMap { cls =>
       // Skip abstract classes and interfaces
-      if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface) {
-        return None
-      }
+      if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface) None
+      else
+        fingerprints.find { case (_, fp) =>
+          fp match {
+            case sfp: SubclassFingerprint =>
+              val hasConstructor = !sfp.requireNoArgConstructor || hasNoArgConstructor(cls)
+              hasConstructor && Try {
+                val superclass = classLoader.loadClass(sfp.superclassName())
+                if (sfp.isModule) {
+                  // Check if it's a Scala object
+                  val moduleName = className + "$"
+                  Try(classLoader.loadClass(moduleName))
+                    .map(m => superclass.isAssignableFrom(m))
+                    .getOrElse(false)
+                } else {
+                  superclass.isAssignableFrom(cls)
+                }
+              }.getOrElse(false)
 
-      fingerprints.find { case (_, fp) =>
-        fp match {
-          case sfp: SubclassFingerprint =>
-            val hasConstructor = !sfp.requireNoArgConstructor || hasNoArgConstructor(cls)
-            hasConstructor && Try {
-              val superclass = classLoader.loadClass(sfp.superclassName())
-              if (sfp.isModule) {
-                // Check if it's a Scala object
-                val moduleName = className + "$"
-                Try(classLoader.loadClass(moduleName))
-                  .map(m => superclass.isAssignableFrom(m))
-                  .getOrElse(false)
-              } else {
-                superclass.isAssignableFrom(cls)
+            case afp: AnnotatedFingerprint =>
+              val annotationClass = Try(classLoader.loadClass(afp.annotationName())).toOption
+              annotationClass.exists { annClass =>
+                if (afp.isModule) {
+                  val moduleName = className + "$"
+                  Try(classLoader.loadClass(moduleName))
+                    .map(_.getAnnotations.exists(a => annClass.isAssignableFrom(a.annotationType())))
+                    .getOrElse(false)
+                } else {
+                  cls.getAnnotations.exists(a => annClass.isAssignableFrom(a.annotationType()))
+                }
               }
-            }.getOrElse(false)
 
-          case afp: AnnotatedFingerprint =>
-            val annotationClass = Try(classLoader.loadClass(afp.annotationName())).toOption
-            annotationClass.exists { annClass =>
-              if (afp.isModule) {
-                val moduleName = className + "$"
-                Try(classLoader.loadClass(moduleName))
-                  .map(_.getAnnotations.exists(a => annClass.isAssignableFrom(a.annotationType())))
-                  .getOrElse(false)
-              } else {
-                cls.getAnnotations.exists(a => annClass.isAssignableFrom(a.annotationType()))
-              }
-            }
-
-          case _ =>
-            false
+            case _ =>
+              false
+          }
         }
-      }
     }
   }
 
@@ -390,25 +388,24 @@ object ClasspathTestDiscovery {
   ): Option[String] =
     Try(classLoader.loadClass(className)).toOption.flatMap { cls =>
       // Skip abstract classes and interfaces
-      if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface) {
-        return None
-      }
+      if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface) None
+      else {
+        // Check for class-level @Test annotation (TestNG style)
+        val classLevelAnnotation = findTestAnnotation(cls.getAnnotations, classLoader)
 
-      // Check for class-level @Test annotation (TestNG style)
-      val classLevelAnnotation = findTestAnnotation(cls.getAnnotations, classLoader)
+        // Check for method-level test annotations
+        val methodLevelAnnotation = cls.getDeclaredMethods.flatMap { method =>
+          findTestAnnotation(method.getAnnotations, classLoader)
+        }.headOption
 
-      // Check for method-level test annotations
-      val methodLevelAnnotation = cls.getDeclaredMethods.flatMap { method =>
-        findTestAnnotation(method.getAnnotations, classLoader)
-      }.headOption
-
-      // Determine framework from annotation
-      (classLevelAnnotation orElse methodLevelAnnotation).map {
-        case ann if ann.contains("jupiter") => "JUnit Jupiter"
-        case ann if ann.contains("junit")   => "JUnit"
-        case ann if ann.contains("testng")  => "TestNG"
-        case ann if ann.contains("kotlin")  => "kotlin.test"
-        case _                              => "JUnit" // Default
+        // Determine framework from annotation
+        (classLevelAnnotation orElse methodLevelAnnotation).map {
+          case ann if ann.contains("jupiter") => "JUnit Jupiter"
+          case ann if ann.contains("junit")   => "JUnit"
+          case ann if ann.contains("testng")  => "TestNG"
+          case ann if ann.contains("kotlin")  => "kotlin.test"
+          case _                              => "JUnit" // Default
+        }
       }
     }
 
@@ -475,23 +472,22 @@ object ClasspathTestDiscovery {
   ): Option[String] =
     Try(classLoader.loadClass(className)).toOption.flatMap { cls =>
       // Skip abstract classes and interfaces
-      if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface) {
-        return None
-      }
+      if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface) None
+      else {
+        // Also check module class for Scala objects
+        val classesToCheck = List(
+          Some(cls),
+          Try(classLoader.loadClass(className + "$")).toOption
+        ).flatten
 
-      // Also check module class for Scala objects
-      val classesToCheck = List(
-        Some(cls),
-        Try(classLoader.loadClass(className + "$")).toOption
-      ).flatten
-
-      testBaseClasses.collectFirst {
-        case (framework, baseClasses) if baseClasses.exists { baseName =>
-              Try(classLoader.loadClass(baseName)).toOption.exists { baseClass =>
-                classesToCheck.exists(baseClass.isAssignableFrom)
-              }
-            } =>
-          framework
+        testBaseClasses.collectFirst {
+          case (framework, baseClasses) if baseClasses.exists { baseName =>
+                Try(classLoader.loadClass(baseName)).toOption.exists { baseClass =>
+                  classesToCheck.exists(baseClass.isAssignableFrom)
+                }
+              } =>
+            framework
+        }
       }
     }
 

--- a/bleep-bsp/src/scala/bleep/bsp/InProcessBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/InProcessBspServer.scala
@@ -27,7 +27,7 @@ object InProcessBspServer {
             try {
               val semaphore = new java.util.concurrent.Semaphore(Runtime.getRuntime.availableProcessors())
               val server =
-                new MultiWorkspaceBspServer(serverIn, serverOut, logger, socketDir = None, compileSemaphore = semaphore, heapMonitor = HeapMonitor.system)
+                new MultiWorkspaceBspServer(serverIn, serverOut, logger, compileSemaphore = semaphore, heapMonitor = HeapMonitor.system)
               server.run()
             } catch {
               case e: Exception =>

--- a/bleep-bsp/src/scala/bleep/bsp/JsonRpcTransport.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/JsonRpcTransport.scala
@@ -147,7 +147,7 @@ object JsonRpcCodecs {
           }
           if !in.isCurrentToken('}') then in.objectEndOrCommaError()
         }
-      } else in.readNullOrTokenError(default, '{')
+      } else in.readNullOrTokenError(default, '{'): Unit
       JsonRpcRequest(jsonrpc, id, method, params)
     }
   }
@@ -192,7 +192,7 @@ object JsonRpcCodecs {
           }
           if !in.isCurrentToken('}') then in.objectEndOrCommaError()
         }
-      } else in.readNullOrTokenError(default, '{')
+      } else in.readNullOrTokenError(default, '{'): Unit
       JsonRpcResponse(jsonrpc, id, result, error)
     }
   }
@@ -231,7 +231,7 @@ object JsonRpcCodecs {
           }
           if !in.isCurrentToken('}') then in.objectEndOrCommaError()
         }
-      } else in.readNullOrTokenError(default, '{')
+      } else in.readNullOrTokenError(default, '{'): Unit
       JsonRpcNotification(jsonrpc, method, params)
     }
   }

--- a/bleep-bsp/src/scala/bleep/bsp/KotlinBuildTarget.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/KotlinBuildTarget.scala
@@ -71,7 +71,7 @@ object KotlinBuildTarget {
           }
           if !in.isCurrentToken('}') then in.objectEndOrCommaError()
         }
-      } else in.readNullOrTokenError(default, '{')
+      } else in.readNullOrTokenError(default, '{'): Unit
       KotlinBuildTarget(kotlinVersion, jvmTarget, kotlincOptions, isK2)
     }
   }

--- a/bleep-bsp/src/scala/bleep/bsp/KotlinTestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/KotlinTestRunner.scala
@@ -92,7 +92,7 @@ object KotlinTestRunner {
       */
     def runTests(
         jsOutput: Path,
-        suites: List[TestSuite],
+        @annotation.unused suites: List[TestSuite],
         eventHandler: TestEventHandler,
         env: Map[String, String],
         killSignal: Deferred[IO, KillReason]
@@ -101,7 +101,7 @@ object KotlinTestRunner {
         case Some(reason) => IO.pure(TestResult(0, 0, 0, 0, TerminationReason.Killed(reason)))
         case None         =>
           IO.blocking {
-            val runnerScript = createTestRunnerScript(jsOutput, suites)
+            val runnerScript = createTestRunnerScript(jsOutput)
             val scriptPath = Files.createTempFile("kotlin-js-test-", ".js")
             Files.writeString(scriptPath, runnerScript)
             scriptPath
@@ -225,7 +225,7 @@ object KotlinTestRunner {
          |}
          |""".stripMargin
 
-    private def createTestRunnerScript(jsOutput: Path, suites: List[TestSuite]): String = {
+    private def createTestRunnerScript(jsOutput: Path): String = {
       // Kotlin/JS kotlin.test uses QUnit adapter by default, so we need to provide QUnit stubs
       // that capture and run the registered tests
       s"""

--- a/bleep-bsp/src/scala/bleep/bsp/LinkExecutor.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/LinkExecutor.scala
@@ -256,12 +256,11 @@ object LinkExecutor {
     if (isUpToDate(binaryPath, classpath, logger)) {
       IO.pure((TaskResult.Success, LinkResult.NativeSuccess(binaryPath, wasUpToDate = true)))
     } else {
-      doScalaNativeLink(projectName, platform, classpath, mainClass, binaryPath, outputDir, logger, killSignal)
+      doScalaNativeLink(platform, classpath, mainClass, binaryPath, outputDir, logger, killSignal)
     }
   }
 
   private def doScalaNativeLink(
-      projectName: String,
       platform: LinkPlatform.ScalaNative,
       classpath: Seq[Path],
       mainClass: String,
@@ -322,12 +321,11 @@ object LinkExecutor {
 
     checkJsUpToDate(jsOutputDir, classpath, logger) match {
       case Some(cached) => IO.pure(cached)
-      case None         => doKotlinJsLink(projectName, platform, classpath, jsOutputDir, moduleName, logger, killSignal)
+      case None         => doKotlinJsLink(platform, classpath, jsOutputDir, moduleName, logger, killSignal)
     }
   }
 
   private def doKotlinJsLink(
-      projectName: String,
       platform: LinkPlatform.KotlinJs,
       classpath: Seq[Path],
       jsOutputDir: Path,
@@ -443,7 +441,7 @@ object LinkExecutor {
         // Up-to-date - return cached result
         IO.blocking {
           if (!Files.isExecutable(existingPath)) {
-            existingPath.toFile.setExecutable(true)
+            existingPath.toFile.setExecutable(true): Unit
           }
           (TaskResult.Success, LinkResult.NativeSuccess(existingPath, wasUpToDate = true))
         }
@@ -573,7 +571,7 @@ object LinkExecutor {
               .map { result =>
                 if (result.isSuccess) {
                   if (!Files.isExecutable(binaryPath)) {
-                    binaryPath.toFile.setExecutable(true)
+                    binaryPath.toFile.setExecutable(true): Unit
                   }
                   (TaskResult.Success, LinkResult.NativeSuccess(binaryPath, wasUpToDate = false))
                 } else {

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -7,19 +7,16 @@ import bleep.analysis.{
   CompilePhase,
   CompilerError,
   DiagnosticListener,
-  ParallelProjectCompiler,
   ProgressListener,
   ProjectCompileFailure,
   ProjectCompileSuccess,
   ProjectCompiler,
   ProjectLanguage,
   ScalaJsLinkConfig,
-  ScalaNativeLinkConfig,
-  ScalaNativeToolchain,
   ZincBridge
 }
 import bleep.bsp.Outcome.KillReason
-import bleep.bsp.protocol.{BleepBspProtocol, CompileReason, CompileStatus, LinkPlatformName, OutputChannel, ProcessExit}
+import bleep.bsp.protocol.{BleepBspProtocol, CompileStatus, LinkPlatformName, OutputChannel, ProcessExit}
 import bleep.bsp.TraceCategory
 import bleep.model.{CrossProjectName, SuiteName, TestName}
 import bleep.testing.JvmPool
@@ -50,7 +47,6 @@ class MultiWorkspaceBspServer(
     in: InputStream,
     out: OutputStream,
     logger: Logger,
-    socketDir: Option[Path],
     compileSemaphore: java.util.concurrent.Semaphore,
     heapMonitor: HeapMonitor
 ) {
@@ -63,8 +59,11 @@ class MultiWorkspaceBspServer(
   /** Track active compile count so heap pressure back-pressure can skip stalling when we're the only compile. */
   private val activeCompileCount = new java.util.concurrent.atomic.AtomicInteger(0)
 
-  /** Pre-allocated emergency memory that gets released during OOM to allow sending error response. */
-  @volatile private var emergencyMemory: Array[Byte] = new Array[Byte](1024 * 1024) // 1MB reserve
+  /** Pre-allocated emergency memory that gets released during OOM to allow sending error response. Not "read" in code — just held until handleOutOfMemory nulls
+    * it to let the GC reclaim 1MB.
+    */
+  @scala.annotation.nowarn("msg=mutated but not read")
+  @volatile private var emergencyMemory: Array[Byte] = new Array[Byte](1024 * 1024)
   private val clientCapabilities = AtomicReference[Option[BuildClientCapabilities]](None)
 
   /** The active workspace for this connection (set during initialize) */
@@ -236,7 +235,7 @@ class MultiWorkspaceBspServer(
         Thread.currentThread().interrupt()
         request.id.foreach(id => activeRequests.remove(id.key))
       case oom: OutOfMemoryError =>
-        handleOutOfMemory(request, oom)
+        handleOutOfMemory(request)
       case e: BspException =>
         request.id.foreach { id =>
           activeRequests.remove(id.key)
@@ -275,7 +274,7 @@ class MultiWorkspaceBspServer(
     *
     * Releases emergency memory to ensure we have enough heap to send the error response, then waits briefly before requesting shutdown.
     */
-  private def handleOutOfMemory(request: JsonRpcRequest, oom: OutOfMemoryError): Unit = {
+  private def handleOutOfMemory(request: JsonRpcRequest): Unit = {
     // Release emergency memory to allow sending error response
     emergencyMemory = null
     System.gc() // Hint to GC to reclaim the emergency memory
@@ -674,13 +673,13 @@ class MultiWorkspaceBspServer(
     val kill: Runnable = () => cancelAllActiveRequests()
     val work = SharedWorkspaceState.ActiveWork(operationId, operation, projects, cancellation, System.currentTimeMillis(), kill)
     SharedWorkspaceState.register(workspace, work)
-    myOperationIds.add(operationId)
+    myOperationIds.add(operationId): Unit
   }
 
   /** Unregister an operation after it completes. */
   private def unregisterOperation(workspace: Path, operationId: String): Unit = {
     SharedWorkspaceState.unregister(workspace, operationId)
-    myOperationIds.remove(operationId)
+    myOperationIds.remove(operationId): Unit
   }
 
   /** Cancel all in-flight requests and kill child processes. */
@@ -702,7 +701,7 @@ class MultiWorkspaceBspServer(
       ProcessHandle.current().children().forEach { child =>
         try {
           debugLog(s"Killing child process: ${child.pid()}")
-          child.destroyForcibly()
+          child.destroyForcibly(): Unit
         } catch { case _: Exception => }
       }
     catch { case _: Exception => }
@@ -1211,8 +1210,7 @@ class MultiWorkspaceBspServer(
     * A failed sourcegen returns `TaskResult.Failure` → the DAG skips downstream `CompileTask`s.
     */
   private def makeSourcegenHandler(
-      started: Started,
-      originId: Option[String]
+      started: Started
   ): (TaskDag.SourcegenTask, Deferred[IO, Outcome.KillReason]) => IO[TaskDag.TaskResult] = {
     val listener = new SourceGenRunner.SourceGenListener {
       def onScriptStarted(scriptMain: String, forProjects: List[String]): Unit =
@@ -1431,19 +1429,18 @@ class MultiWorkspaceBspServer(
       val apResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, AnnotationProcessorResult]()
 
       val compileHandler = makeCompileHandler(started, workspace, params.originId, serverConfig.effectiveHeapPressureThreshold, apResults)
-      val sourcegenHandler = makeSourcegenHandler(started, params.originId)
+      val sourcegenHandler = makeSourcegenHandler(started)
 
       // Create link handler
-      val linkHandler: (TaskDag.LinkTask, Deferred[IO, KillReason]) => IO[(TaskDag.TaskResult, TaskDag.LinkResult)] =
-        (linkTask, taskKillSignal) => {
-          val projectPaths = started.projectPaths(linkTask.project)
-          val project = started.build.explodedProjects(linkTask.project)
-          val resolved = started.resolvedProject(linkTask.project)
-          val classpath = projectPaths.classes :: resolved.classpath.map(p => Path.of(p.toString)).toList
-          val linkLogger = createLinkLogger()
-          val outputDir = projectPaths.targetDir.resolve("link-output")
-          LinkExecutor.execute(linkTask, classpath.map(_.toAbsolutePath), project.platform.flatMap(_.mainClass), outputDir, linkLogger, taskKillSignal)
-        }
+      val linkHandler: (TaskDag.LinkTask, Deferred[IO, KillReason]) => IO[(TaskDag.TaskResult, TaskDag.LinkResult)] = { (linkTask, taskKillSignal) =>
+        val projectPaths = started.projectPaths(linkTask.project)
+        val project = started.build.explodedProjects(linkTask.project)
+        val resolved = started.resolvedProject(linkTask.project)
+        val classpath = projectPaths.classes :: resolved.classpath.map(p => Path.of(p.toString)).toList
+        val linkLogger = createLinkLogger()
+        val outputDir = projectPaths.targetDir.resolve("link-output")
+        LinkExecutor.execute(linkTask, classpath.map(_.toAbsolutePath), project.platform.flatMap(_.mainClass), outputDir, linkLogger, taskKillSignal)
+      }
 
       // No-op handlers for task types absent from compile/link DAGs (no DiscoverTasks, TestSuiteTasks here).
       val discoverHandler: (TaskDag.DiscoverTask, Deferred[IO, KillReason]) => IO[(TaskDag.TaskResult, List[(String, String)])] =
@@ -1797,7 +1794,7 @@ class MultiWorkspaceBspServer(
           val apResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, AnnotationProcessorResult]()
 
           val compileHandler = makeCompileHandler(started, workspace, params.originId, serverConfig.effectiveHeapPressureThreshold, apResults)
-          val sourcegenHandler = makeSourcegenHandler(started, params.originId)
+          val sourcegenHandler = makeSourcegenHandler(started)
 
           val discoverHandler: (TaskDag.DiscoverTask, Deferred[IO, Outcome.KillReason]) => IO[(TaskDag.TaskResult, List[(String, String)])] =
             (discoverTask, _) =>
@@ -1828,11 +1825,11 @@ class MultiWorkspaceBspServer(
 
               (projectPlatform, isKotlin) match {
                 case (Some(model.PlatformId.Js), true) =>
-                  runKotlinJsTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
+                  runKotlinJsTestSuite(started, testTask, eventQueue, taskKillSignal)
                 case (Some(model.PlatformId.Js), false) =>
                   runScalaJsTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
                 case (Some(model.PlatformId.Native), true) =>
-                  runKotlinNativeTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
+                  runKotlinNativeTestSuite(started, testTask, eventQueue, taskKillSignal)
                 case (Some(model.PlatformId.Native), false) =>
                   runScalaNativeTestSuite(started, testTask, classpath, eventQueue, taskKillSignal)
                 case _ =>
@@ -2113,58 +2110,57 @@ class MultiWorkspaceBspServer(
       originId: Option[String],
       heapPressureThreshold: Double,
       apResults: java.util.concurrent.ConcurrentHashMap[CrossProjectName, AnnotationProcessorResult]
-  ): (TaskDag.CompileTask, Deferred[IO, Outcome.KillReason]) => IO[TaskDag.TaskResult] =
-    (compileTask, taskKillSignal) => {
-      val projectName = compileTask.project.value
-      val wsStr = workspace.toString
-      val token = CancellationToken.create()
-      taskKillSignal.tryGet.flatMap {
-        case Some(_) => IO.pure(TaskDag.TaskResult.Killed(Outcome.KillReason.UserRequest))
-        case None    =>
-          // Fast path: check noop manifest BEFORE acquiring semaphore / heap gate.
-          // Noop projects skip all waiting and don't consume concurrency slots.
-          val apFlags: List[String] = Option(apResults.get(compileTask.project)).fold(List.empty[String])(_.javacFlags)
-          val config = BleepBuildConverter.toProjectConfig(compileTask.project, started.resolvedProject(compileTask.project), started, apFlags)
-          val depAnalyses = computeDependencyAnalyses(started, compileTask.projectDependencies)
-          val noopResult = config.language match {
-            case sl: ProjectLanguage.ScalaJava => ZincBridge.isNoop(config, sl, depAnalyses, None)
-            case _                             => None
-          }
-          if (noopResult.isDefined) {
-            IO.pure(TaskDag.TaskResult.Success)
-          } else {
-            // Cooperative cancellation: set CancellationToken so advance() returns false
-            val cooperativeCancelIO = taskKillSignal.get.flatMap(_ => IO(token.cancel())).start
+  ): (TaskDag.CompileTask, Deferred[IO, Outcome.KillReason]) => IO[TaskDag.TaskResult] = { (compileTask, taskKillSignal) =>
+    val projectName = compileTask.project.value
+    val wsStr = workspace.toString
+    val token = CancellationToken.create()
+    taskKillSignal.tryGet.flatMap {
+      case Some(_) => IO.pure(TaskDag.TaskResult.Killed(Outcome.KillReason.UserRequest))
+      case None    =>
+        // Fast path: check noop manifest BEFORE acquiring semaphore / heap gate.
+        // Noop projects skip all waiting and don't consume concurrency slots.
+        val apFlags: List[String] = Option(apResults.get(compileTask.project)).fold(List.empty[String])(_.javacFlags)
+        val config = BleepBuildConverter.toProjectConfig(compileTask.project, started.resolvedProject(compileTask.project), started, apFlags)
+        val depAnalyses = computeDependencyAnalyses(started, compileTask.projectDependencies)
+        val noopResult = config.language match {
+          case sl: ProjectLanguage.ScalaJava => ZincBridge.isNoop(config, sl, depAnalyses, None)
+          case _                             => None
+        }
+        if (noopResult.isDefined) {
+          IO.pure(TaskDag.TaskResult.Success)
+        } else {
+          // Cooperative cancellation: set CancellationToken so advance() returns false
+          val cooperativeCancelIO = taskKillSignal.get.flatMap(_ => IO(token.cancel())).start
 
-            // Gate on server-wide semaphore to limit total concurrent compiles across all connections
-            val gatedCompile = IO
-              .interruptible(compileSemaphore.acquire())
-              .bracket { _ =>
-                IO(activeCompileCount.incrementAndGet()) >>
-                  waitForHeapPressure(projectName, originId, heapPressureThreshold) >> {
-                    val compileStartTime = System.currentTimeMillis()
-                    IO(BspMetrics.recordCompileStart(projectName, wsStr)) >>
-                      compileProject(started, compileTask.project, originId, token, depAnalyses, apFlags)
-                        .guaranteeCase {
-                          case cats.effect.Outcome.Succeeded(resultIO) =>
-                            resultIO.flatMap { result =>
-                              val dur = System.currentTimeMillis() - compileStartTime
-                              val ok = result == TaskDag.TaskResult.Success
-                              IO(BspMetrics.recordCompileEnd(projectName, wsStr, dur, ok))
-                            }
-                          case _ =>
-                            IO(BspMetrics.recordCompileEnd(projectName, wsStr, System.currentTimeMillis() - compileStartTime, false))
-                        }
-                  }
-              }(_ => IO(activeCompileCount.decrementAndGet()) >> IO(compileSemaphore.release()))
-            val waitForKill = taskKillSignal.get.map(reason => TaskDag.TaskResult.Killed(reason))
+          // Gate on server-wide semaphore to limit total concurrent compiles across all connections
+          val gatedCompile = IO
+            .interruptible(compileSemaphore.acquire())
+            .bracket { _ =>
+              IO(activeCompileCount.incrementAndGet()) >>
+                waitForHeapPressure(projectName, originId, heapPressureThreshold) >> {
+                  val compileStartTime = System.currentTimeMillis()
+                  IO(BspMetrics.recordCompileStart(projectName, wsStr)) >>
+                    compileProject(started, compileTask.project, originId, token, depAnalyses, apFlags)
+                      .guaranteeCase {
+                        case cats.effect.Outcome.Succeeded(resultIO) =>
+                          resultIO.flatMap { result =>
+                            val dur = System.currentTimeMillis() - compileStartTime
+                            val ok = result == TaskDag.TaskResult.Success
+                            IO(BspMetrics.recordCompileEnd(projectName, wsStr, dur, ok))
+                          }
+                        case _ =>
+                          IO(BspMetrics.recordCompileEnd(projectName, wsStr, System.currentTimeMillis() - compileStartTime, false))
+                      }
+                }
+            }(_ => IO(activeCompileCount.decrementAndGet()) >> IO(compileSemaphore.release()))
+          val waitForKill = taskKillSignal.get.map(reason => TaskDag.TaskResult.Killed(reason))
 
-            cooperativeCancelIO.flatMap { cancelFiber =>
-              IO.race(gatedCompile, waitForKill).map(_.merge).guarantee(cancelFiber.cancel)
-            }
+          cooperativeCancelIO.flatMap { cancelFiber =>
+            IO.race(gatedCompile, waitForKill).map(_.merge).guarantee(cancelFiber.cancel)
           }
-      }
+        }
     }
+  }
 
   /** Compile a single project (dependencies handled by TaskDag ordering).
     *
@@ -2639,7 +2635,7 @@ class MultiWorkspaceBspServer(
             val eventHandler = makeTestEventHandler(dispatcher, eventQueue, testTask.project)
             val suites = List(TestRunnerTypes.TestSuite(testTask.suiteName.value, testTask.suiteName.value))
             ScalaNativeTestRunner
-              .runTestsViaAdapter(binary, suites, framework, eventHandler, Map.empty, started.buildPaths.cwd, snVersion.scalaNativeVersion, killSignal)
+              .runTestsViaAdapter(binary, suites, framework, eventHandler, Map.empty, snVersion.scalaNativeVersion, killSignal)
               .flatMap { result =>
                 val endTs = System.currentTimeMillis()
                 val durationMs = endTs - startTs
@@ -2705,7 +2701,6 @@ class MultiWorkspaceBspServer(
   private def runKotlinJsTestSuite(
       started: Started,
       testTask: TaskDag.TestSuiteTask,
-      classpath: List[Path],
       eventQueue: Queue[IO, Option[TaskDag.DagEvent]],
       killSignal: Deferred[IO, Outcome.KillReason]
   ): IO[TaskDag.TaskResult] = {
@@ -2716,7 +2711,6 @@ class MultiWorkspaceBspServer(
     // Test mode always uses dce=false → linkDirSuffix = "debug"
     val linkSuffix = bleep.bsp.protocol.BleepBspProtocol.linkDirSuffix(isRelease = false, hasDebugInfo = false, hasLto = false)
     val jsOutput = projectPaths.targetDir.resolve(linkSuffix).resolve("js").resolve(s"$moduleName.js")
-    val logger = createLinkLogger()
 
     for {
       startTs <- IO.realTime.map(_.toMillis)
@@ -2761,7 +2755,6 @@ class MultiWorkspaceBspServer(
   private def runKotlinNativeTestSuite(
       started: Started,
       testTask: TaskDag.TestSuiteTask,
-      classpath: List[Path],
       eventQueue: Queue[IO, Option[TaskDag.DagEvent]],
       killSignal: Deferred[IO, Outcome.KillReason]
   ): IO[TaskDag.TaskResult] = {
@@ -2779,7 +2772,6 @@ class MultiWorkspaceBspServer(
       projectPaths.targetDir.resolve(projectName + ".kexe")
     )
     val binary = possiblePaths.find(Files.exists(_)).getOrElse(linkDir.resolve(projectName))
-    val logger = createLinkLogger()
 
     for {
       startTs <- IO.realTime.map(_.toMillis)
@@ -3277,24 +3269,6 @@ class MultiWorkspaceBspServer(
       )
       sendNotification("build/publishDiagnostics", publishParams)
     }
-
-  /** Create a project-scoped logger that sends BSP log messages */
-  private def projectLogger(project: CrossProjectName): BspProjectLogger = new BspProjectLogger {
-    def info(message: String): Unit = sendProjectLogMessage(project, message, MessageType.Info)
-    def warn(message: String): Unit = sendProjectLogMessage(project, message, MessageType.Warning)
-    def error(message: String): Unit = sendProjectLogMessage(project, message, MessageType.Error)
-  }
-
-  /** Send a project-scoped log message notification to the client */
-  private def sendProjectLogMessage(project: CrossProjectName, message: String, messageType: MessageType): Unit = {
-    val params = LogMessageParams(
-      `type` = messageType,
-      task = Some(TaskId(s"project:${project.value}", None)),
-      originId = None,
-      message = message
-    )
-    sendNotification("build/logMessage", params)
-  }
 
   /** Send a log message without project scope (for rare error cases only) */
   private def createLinkLogger(): LinkExecutor.LinkLogger = new LinkExecutor.LinkLogger {

--- a/bleep-bsp/src/scala/bleep/bsp/Outcome.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/Outcome.scala
@@ -180,8 +180,7 @@ object Outcome {
         cancellation.onCancel { () =>
           // Complete the kill signal from the cancellation callback thread.
           // unsafeRunSync is safe here — Deferred.complete is non-blocking.
-          deferred.complete(KillReason.UserRequest).attempt.unsafeRunSync()(cats.effect.unsafe.IORuntime.global)
-          ()
+          deferred.complete(KillReason.UserRequest).attempt.unsafeRunSync()(using cats.effect.unsafe.IORuntime.global): Unit
         }
       }
     }
@@ -215,7 +214,7 @@ object Outcome {
           callbacks.synchronized {
             if (cancelled.get()) callback()
             else callbacks += callback
-          }
+          }: Unit
       }
     }.flatTap { token =>
       killSignal.get.flatMap(_ => IO.delay(token.cancel())).start.void

--- a/bleep-bsp/src/scala/bleep/bsp/ScalaJsTestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/ScalaJsTestRunner.scala
@@ -2,7 +2,7 @@ package bleep.bsp
 
 import bleep.analysis.ScalaJsLinkConfig
 import bleep.bsp.Outcome.KillReason
-import bleep.bsp.TestRunnerTypes.{RunnerEvent, StderrBuffer, TerminationReason, TestEventHandler, TestResult, TestSuite}
+import bleep.bsp.TestRunnerTypes.{StderrBuffer, TerminationReason, TestEventHandler, TestResult, TestSuite}
 import bleep.bsp.protocol.{OutputChannel, TestStatus}
 import cats.effect.{Deferred, IO, Ref}
 import cats.syntax.all._
@@ -84,7 +84,7 @@ object ScalaJsTestRunner {
       moduleKind: ScalaJsLinkConfig.ModuleKind,
       suites: List[TestSuite],
       eventHandler: TestEventHandler,
-      nodeEnv: NodeEnvironment,
+      @annotation.unused nodeEnv: NodeEnvironment,
       env: Map[String, String],
       killSignal: Deferred[IO, KillReason]
   ): IO[TestResult] =
@@ -345,7 +345,7 @@ object ScalaJsTestRunner {
 
   private def createTestRunnerScript(
       linkedJs: Path,
-      moduleKind: ScalaJsLinkConfig.ModuleKind,
+      @annotation.unused moduleKind: ScalaJsLinkConfig.ModuleKind,
       suites: List[TestSuite]
   ): String = {
     val suiteNames = suites.map(s => s"'${s.fullyQualifiedName}'").mkString(", ")

--- a/bleep-bsp/src/scala/bleep/bsp/ScalaNativeTestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/ScalaNativeTestRunner.scala
@@ -7,7 +7,6 @@ import bleep.bsp.TestRunnerTypes.{RunnerEvent, TerminationReason, TestEventHandl
 import bleep.bsp.protocol.{OutputChannel, TestStatus}
 import cats.effect.{Deferred, IO}
 import cats.effect.std.Semaphore
-import cats.syntax.all._
 import java.nio.file.{Files, Path}
 import scala.jdk.CollectionConverters._
 
@@ -75,7 +74,7 @@ object ScalaNativeTestRunner {
   /** Discover test suites from a linked native binary. */
   def discoverSuites(
       binary: Path,
-      classpath: Seq[Path],
+      @annotation.unused classpath: Seq[Path],
       killSignal: Deferred[IO, KillReason]
   ): IO[ProcessRunner.DiscoveryResult[List[TestSuite]]] =
     killSignal.tryGet.flatMap {
@@ -112,38 +111,6 @@ object ScalaNativeTestRunner {
           case Right(reason) => ProcessRunner.DiscoveryResult.Killed(reason)
         }
     }
-
-  private def discoverFromClasspath(classpath: Seq[Path]): List[TestSuite] =
-    classpath.flatMap { path =>
-      if (Files.isDirectory(path)) {
-        findTestClasses(path)
-      } else {
-        List.empty
-      }
-    }.toList
-
-  private def findTestClasses(dir: Path): List[TestSuite] = {
-    import scala.jdk.StreamConverters._
-    import scala.util.Using
-    Using(Files.walk(dir)) { stream =>
-      stream
-        .toScala(List)
-        .filter(p => p.toString.endsWith(".class") || p.toString.endsWith(".nir"))
-        .filter { p =>
-          val name = p.getFileName.toString
-          name.contains("Test") || name.contains("Suite") || name.contains("Spec")
-        }
-        .map { p =>
-          val relative = dir.relativize(p).toString
-          val fqn = relative
-            .replace("/", ".")
-            .replace("\\", ".")
-            .replaceAll("\\.(class|nir)$", "")
-          val simpleName = fqn.split('.').lastOption.getOrElse(fqn)
-          TestSuite(simpleName, fqn)
-        }
-    }.get // Fail loudly if directory walk fails (permission error, etc.)
-  }
 
   /** Run tests in a Scala Native binary. */
   def runTests(
@@ -226,7 +193,7 @@ object ScalaNativeTestRunner {
     * All frameworks use the same TestMain entry point from the scala-native test interface. The framework is detected at runtime by TestMain via the
     * sbt.testing.Framework SPI.
     */
-  def getTestMainClass(framework: TestFramework): String = TestMainClass
+  def getTestMainClass(@annotation.unused framework: TestFramework): String = TestMainClass
 
   /** Framework class names for sbt.testing.Framework SPI discovery. */
   private val frameworkClassNames: Map[TestFramework, List[String]] = Map(
@@ -266,7 +233,6 @@ object ScalaNativeTestRunner {
       framework: TestFramework,
       eventHandler: TestEventHandler,
       env: Map[String, String],
-      workingDir: Path,
       scalaNativeVersion: String,
       killSignal: Deferred[IO, KillReason]
   ): IO[TestResult] =
@@ -274,7 +240,7 @@ object ScalaNativeTestRunner {
       case Some(reason) => IO.pure(TestResult(0, 0, 0, 0, TerminationReason.Killed(reason)))
       case None         =>
         val work = IO.interruptible {
-          runTestsViaAdapterBlocking(binary, suites, framework, eventHandler, env, workingDir, scalaNativeVersion)
+          runTestsViaAdapterBlocking(binary, suites, framework, eventHandler, env, scalaNativeVersion)
         }
 
         Outcome
@@ -295,7 +261,6 @@ object ScalaNativeTestRunner {
       framework: TestFramework,
       eventHandler: TestEventHandler,
       env: Map[String, String],
-      workingDir: Path,
       scalaNativeVersion: String
   ): TestResult = {
     val instance = CompilerResolver.getScalaNativeTestRunner(scalaNativeVersion)
@@ -504,8 +469,6 @@ object ScalaNativeTestRunner {
   }
 
   private def toScalaList(javaList: List[Any], loader: ClassLoader): Any = {
-    val listCompanion = loader.loadClass("scala.collection.immutable.List$")
-    val listObj = listCompanion.getField("MODULE$").get(null)
     val nilClass = loader.loadClass("scala.collection.immutable.Nil$")
     val nilObj = nilClass.getField("MODULE$").get(null)
     val consClass = loader.loadClass("scala.collection.immutable.$colon$colon")

--- a/bleep-bsp/src/scala/bleep/bsp/SharedWorkspaceState.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/SharedWorkspaceState.scala
@@ -28,7 +28,7 @@ object SharedWorkspaceState {
   /** Register an operation. Always succeeds — multiple operations can be active per workspace. */
   def register(workspace: Path, work: ActiveWork): Unit = {
     val ops = activeWork.computeIfAbsent(workspace, _ => new ConcurrentHashMap[String, ActiveWork]())
-    ops.put(work.operationId, work)
+    ops.put(work.operationId, work): Unit
   }
 
   /** Unregister a specific operation by ID. */
@@ -37,7 +37,7 @@ object SharedWorkspaceState {
     if (ops != null) {
       ops.remove(operationId)
       // Clean up empty inner maps to avoid memory leak
-      if (ops.isEmpty) activeWork.remove(workspace, ops)
+      if (ops.isEmpty) activeWork.remove(workspace, ops): Unit
     }
   }
 
@@ -46,7 +46,7 @@ object SharedWorkspaceState {
     val ops = activeWork.get(workspace)
     if (ops != null) {
       operationIds.foreach(ops.remove)
-      if (ops.isEmpty) activeWork.remove(workspace, ops)
+      if (ops.isEmpty) activeWork.remove(workspace, ops): Unit
     }
   }
 

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -234,8 +234,6 @@ object TestRunner {
           }
 
         case Right((suiteFiber, raceOutcome)) =>
-          val durationMs = System.currentTimeMillis() - startTime
-
           // Drain any stderr from JVM before killing it
           def drainStderrToEvents: IO[Unit] =
             jvm.drainStderr

--- a/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
@@ -77,7 +77,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
           jobs.values.toList.traverse_(_.cancel)
         }
       )
-    } yield new BleepMcpSession(client, bspConfig, lifecycle.server, lifecycle.listening, eventRoutes, diagnosticRoutes, watchJobs, watchResults, buildHistory)
+    } yield new BleepMcpSession(client, lifecycle.server, lifecycle.listening, eventRoutes, diagnosticRoutes, watchJobs, watchResults, buildHistory)
 
   private def setupBspConfig(): Either[BleepException, BspRifleConfig] =
     started.bspServerClasspathSource match {
@@ -107,14 +107,14 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
               case Left(ex) =>
                 val msg = s"Build file changed (${changedFiles.mkString(", ")}), but reload failed: ${ex.getMessage}"
                 started.logger.error(msg)
-                client.log(protocol.LoggingLevel.Error, None, msg).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+                client.log(protocol.LoggingLevel.Error, None, msg).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
               case Right(None) =>
                 () // parsed JSON identical, no actual change
               case Right(Some(newStarted)) =>
                 startedRef.set(newStarted)
                 val msg = s"Build reloaded (${changedFiles.mkString(", ")}). Project list and build model updated."
                 newStarted.logger.info(msg)
-                client.log(protocol.LoggingLevel.Info, None, msg).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+                client.log(protocol.LoggingLevel.Info, None, msg).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
             }
           }
           val thread = new Thread(() => watcher.run(FileWatching.StopWhen.Never), "mcp-build-watcher")
@@ -127,7 +127,6 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
 
   private class BleepMcpSession(
       _client: McpServer.Client[IO],
-      bspConfig: BspRifleConfig,
       bspServer: bleep.bsp.BuildServer,
       bspListening: java.util.concurrent.Future[Void],
       eventRoutes: ConcurrentHashMap[String, Queue[IO, Option[BleepBspProtocol.Event]]],
@@ -518,7 +517,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
                 case None       => run.events
               }
               val mode = run.mode
-              if (mode == "test") formatTestResult(events, None, PreviousRunState.empty, true, includeThrowables = true, args.limit, args.offset)
+              if (mode == "test") formatTestResult(events, None, PreviousRunState.empty, includeThrowables = true, args.limit, args.offset)
               else formatCompileResult(events, PreviousRunState.empty, true, args.limit, args.offset)
             case None =>
               """{"message":"No previous build results. Run bleep.compile or bleep.test first."}"""
@@ -607,7 +606,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
 
         // Register event routing for this operation
         _ <- IO.delay(eventRoutes.put(originId, eventQueue))
-        _ <- IO.delay(diagnosticRoutes.put(originId, diagnosticCallback(context)))
+        _ <- IO.delay(diagnosticRoutes.put(originId, diagnosticCallback()))
 
         // Consumer fiber: filter events, log per-project diffs to MCP, collect for final response
         consumerFiber <- consumeAndLogEvents(eventQueue, collectedEvents, previousState, context).start
@@ -667,7 +666,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
 
         // Register event routing for this operation
         _ <- IO.delay(eventRoutes.put(originId, eventQueue))
-        _ <- IO.delay(diagnosticRoutes.put(originId, diagnosticCallback(context)))
+        _ <- IO.delay(diagnosticRoutes.put(originId, diagnosticCallback()))
 
         consumerFiber <- consumeAndLogEvents(eventQueue, collectedEvents, previousState, context).start
         heartbeatFiber <- heartbeat(collectedEvents, done, "test", context).start
@@ -695,7 +694,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
                   data <- Option(result.getData)
                   jsonStr = data.toString
                   decoded <- BleepBspProtocol.TestRunResult.decode(jsonStr).toOption
-                } testRunResult.set(Some(decoded)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+                } testRunResult.set(Some(decoded)).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
               }
             }
         }.guarantee(
@@ -711,7 +710,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
         trr <- testRunResult.get
         // Push to history
         _ <- buildHistory.update(_.push(BuildRun(System.currentTimeMillis(), "test", events.reverse)))
-      } yield formatTestResult(events.reverse, trr, previousState, verbose, includeThrowables = verbose, None, None)
+      } yield formatTestResult(events.reverse, trr, previousState, includeThrowables = verbose, None, None)
     }
 
     /** Start a background watch job. */
@@ -765,7 +764,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
 
           // Register event routing for this cycle
           _ <- IO.delay(eventRoutes.put(originId, eventQueue))
-          _ <- IO.delay(diagnosticRoutes.put(originId, diagnosticCallback(context)))
+          _ <- IO.delay(diagnosticRoutes.put(originId, diagnosticCallback()))
           consumerFiber <- consumeAndLogEvents(eventQueue, collectedEvents, previousState, context).start
 
           _ <- {
@@ -811,7 +810,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
           _ <- buildHistory.update(_.push(BuildRun(System.currentTimeMillis(), modeStr, reversedEvents)))
 
           summary =
-            if (mode == BleepBspProtocol.BuildMode.Test) formatTestResult(reversedEvents, None, previousState, false, includeThrowables = false, None, None)
+            if (mode == BleepBspProtocol.BuildMode.Test) formatTestResult(reversedEvents, None, previousState, includeThrowables = false, None, None)
             else formatCompileResult(reversedEvents, previousState, false, None, None)
           watchMode = new WatchMode(if (mode == BleepBspProtocol.BuildMode.Test) "test" else "compile")
           _ <- watchResults.update(_ + (jobId -> WatchCycleResult(jobId, watchMode, summary, System.currentTimeMillis())))
@@ -1281,7 +1280,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
     /** Diagnostic callback — no-op since we stream errors per-project via CompileFinished events in streamDiffLine. Per-diagnostic streaming was too verbose (N
       * individual JSON objects flooding the agent's context).
       */
-    private def diagnosticCallback(context: CallContext[IO]): bsp4j.PublishDiagnosticsParams => Unit = _ => ()
+    private def diagnosticCallback(): bsp4j.PublishDiagnosticsParams => Unit = _ => ()
 
     // ========================================================================
     // Filtering
@@ -1384,7 +1383,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
           }
           fields += "newErrors" -> Json.fromInt(totalNew)
           fields += "fixedErrors" -> Json.fromInt(totalFixed)
-          fields += "summary" -> Json.fromString(BuildDiff.formatCompileSummary(compileEvents.size, errorCount, warningCount, totalNew, totalFixed))
+          fields += "summary" -> Json.fromString(BuildDiff.formatCompileSummary(compileEvents.size, errorCount, totalNew, totalFixed))
         } else {
           val summaryParts = List.newBuilder[String]
           if (success) summaryParts += s"Build succeeded (${compileEvents.size} projects)"
@@ -1417,7 +1416,6 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
         events: List[BleepBspProtocol.Event],
         testRunResult: Option[BleepBspProtocol.TestRunResult],
         previousState: PreviousRunState,
-        verbose: Boolean,
         includeThrowables: Boolean,
         limit: Option[Int],
         offset: Option[Int]
@@ -1560,11 +1558,11 @@ private[mcp] class SharedMcpBspClient(
             val targetQueue = originId.flatMap(id => Option(eventRoutes.get(id)))
             targetQueue match {
               case Some(queue) =>
-                queue.offer(Some(event)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+                queue.offer(Some(event)).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
               case None =>
                 // No specific route — broadcast to all active consumers
                 eventRoutes.values().forEach { queue =>
-                  queue.offer(Some(event)).unsafeRunSync()(cats.effect.unsafe.implicits.global)
+                  queue.offer(Some(event)).unsafeRunSync()(using cats.effect.unsafe.implicits.global)
                 }
             }
           case Left(_) => ()

--- a/bleep-cli/src/scala-3/bleep/mcp/McpServerRunner.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/McpServerRunner.scala
@@ -40,7 +40,7 @@ object McpServerRunner {
         .as(bleep.ExitCode.Success)
 
       try {
-        program.unsafeRunSync()
+        program.unsafeRunSync(): Unit
         return bleep.ExitCode.Success
       } catch {
         case _: InterruptedException =>

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -20,7 +20,7 @@ object Main {
   // Install SIGINFO handler on macOS (Ctrl+T) for thread dumps
   if (Properties.isMac) {
     try
-      sun.misc.Signal.handle(new sun.misc.Signal("INFO"), (_: sun.misc.Signal) => internal.ChildProcessDiagnostics.dumpAll(System.err))
+      sun.misc.Signal.handle(new sun.misc.Signal("INFO"), (_: sun.misc.Signal) => internal.ChildProcessDiagnostics.dumpAll(System.err)): Unit
     catch {
       case _: Exception => // Signal handling not available
     }
@@ -82,11 +82,11 @@ object Main {
   def hasBuildOpts(started: Started): Opts[BleepBuildCommand] = {
     val projectNamesNoCross: Opts[NonEmptyList[model.ProjectName]] =
       Opts
-        .arguments(metavars.projectNameNoCross)(argumentFrom(metavars.projectNameNoCross, Some(started.globs.projectNamesNoCrossMap)))
+        .arguments(metavars.projectNameNoCross)(using argumentFrom(metavars.projectNameNoCross, Some(started.globs.projectNamesNoCrossMap)))
 
     val projectNames: Opts[Array[model.CrossProjectName]] =
       Opts
-        .arguments(metavars.projectName)(argumentFrom(metavars.projectName, Some(started.globs.projectNameMap)))
+        .arguments(metavars.projectName)(using argumentFrom(metavars.projectName, Some(started.globs.projectNameMap)))
         .map(_.toList.toArray.flatten)
         .orNone
         .map(started.chosenProjects)
@@ -94,27 +94,27 @@ object Main {
     /** Like projectNames but returns empty array when nothing specified, so publish commands can auto-discover publishable projects. */
     val publishProjectNames: Opts[Array[model.CrossProjectName]] =
       Opts
-        .arguments(metavars.projectName)(argumentFrom(metavars.projectName, Some(started.globs.projectNameMap)))
+        .arguments(metavars.projectName)(using argumentFrom(metavars.projectName, Some(started.globs.projectNameMap)))
         .map(_.toList.toArray.flatten)
         .orNone
         .map(_.getOrElse(Array.empty))
 
     val projectNameNoCross: Opts[model.ProjectName] =
-      Opts.argument(metavars.projectNameNoCross)(argumentFrom(metavars.projectNameNoCross, Some(started.globs.projectNamesNoCrossMap)))
+      Opts.argument(metavars.projectNameNoCross)(using argumentFrom(metavars.projectNameNoCross, Some(started.globs.projectNamesNoCrossMap)))
 
     val projectName: Opts[model.CrossProjectName] =
-      Opts.argument(metavars.projectNameExact)(argumentFrom(metavars.projectNameExact, Some(started.globs.exactProjectMap)))
+      Opts.argument(metavars.projectNameExact)(using argumentFrom(metavars.projectNameExact, Some(started.globs.exactProjectMap)))
 
     val projectNamesNoExpand: Opts[Option[List[String]]] =
       Opts
-        .arguments(metavars.projectName)(argumentFrom(metavars.projectName, Some(started.globs.projectNameMap).map(_.map { case (s, _) => (s, s) })))
+        .arguments(metavars.projectName)(using argumentFrom(metavars.projectName, Some(started.globs.projectNameMap).map(_.map { case (s, _) => (s, s) })))
         .map(_.toList)
         .orNone
 
     /** Accepts all project names. When none given, defaults to test projects only. Non-test projects will just be compiled. */
     val testProjectNames: Opts[Array[model.CrossProjectName]] =
       Opts
-        .arguments(metavars.projectName)(argumentFrom(metavars.projectName, Some(started.globs.projectNameMap)))
+        .arguments(metavars.projectName)(using argumentFrom(metavars.projectName, Some(started.globs.projectNameMap)))
         .map(_.toList.toArray.flatten)
         .orNone
         .map {
@@ -141,7 +141,7 @@ object Main {
 
     val hasSourcegenProjectNames: Opts[Array[model.CrossProjectName]] =
       Opts
-        .arguments(metavars.hasSourceGenProject)(argumentFrom(metavars.hasSourceGenProject, Some(started.globs.hasSourceGenProjectNameMap)))
+        .arguments(metavars.hasSourceGenProject)(using argumentFrom(metavars.hasSourceGenProject, Some(started.globs.hasSourceGenProjectNameMap)))
         .map(_.toList.toArray.flatten)
         .orNone
         .map(started.chosenHasSourceGenProjects)
@@ -405,7 +405,7 @@ object Main {
           ),
           Opts.subcommand("run", "run project or script")(
             (
-              Opts.argument[String](metavars.projectOrScriptName)(
+              Opts.argument[String](metavars.projectOrScriptName)(using
                 Argument.fromMap(
                   metavars.projectOrScriptName,
                   started.globs.exactProjectMap.map { case (k, _) => k -> k } ++
@@ -803,12 +803,14 @@ object Main {
           }
           .withDefault(commands.BuildCreateNew.Language.Scala),
         Opts
-          .options("platform", "specify wanted platform(s) (Scala only)", metavar = metavars.platformName, short = "p")(
+          .options("platform", "specify wanted platform(s) (Scala only)", metavar = metavars.platformName, short = "p")(using
             Argument.fromMap(metavars.platformName, model.PlatformId.All.map(p => (p.value, p)).toMap)
           )
           .withDefault(NonEmptyList.of(model.PlatformId.Jvm)),
         Opts
-          .options("scala", "specify scala version(s) (Scala only)", "s", metavars.scalaVersion)(Argument.fromMap(metavars.scalaVersion, possibleScalaVersions))
+          .options("scala", "specify scala version(s) (Scala only)", "s", metavars.scalaVersion)(using
+            Argument.fromMap(metavars.scalaVersion, possibleScalaVersions)
+          )
           .withDefault(NonEmptyList.of(model.VersionScala.Scala3)),
         Opts.argument[String]("wanted project name")
       ).mapN { case (language, platforms, scalas, name) =>
@@ -844,7 +846,7 @@ object Main {
                 case Left(buildException) =>
                   fatal("couldn't download bleep release", logger, buildException)
                 case Right(binaryPath) if OsArch.current.os == model.Os.Windows || !isGraalvmNativeImage =>
-                  val status = scala.sys.process.Process(binaryPath.toString :: args.toList, FileUtils.cwd.toFile, sys.env.toSeq: _*).!<
+                  val status = scala.sys.process.Process(binaryPath.toString :: args.toList, FileUtils.cwd.toFile, sys.env.toSeq*).!<
                   sys.exit(status)
                 case Right(path) =>
                   Execve.execve(path.toString, path.toString +: args, sys.env.map { case (k, v) => s"$k=$v" }.toArray)
@@ -1134,7 +1136,7 @@ object Main {
             case ryddig.LogLevel.info  => target.info(msg)
             case ryddig.LogLevel.warn  => target.warn(msg)
             case ryddig.LogLevel.error => target.error(msg)
-            case _                     => target.info(msg)
+            case null                  => target.info(msg)
           }
         }
       case _ => ()

--- a/bleep-cli/src/scala/bleep/bsp/BspProxy.scala
+++ b/bleep-cli/src/scala/bleep/bsp/BspProxy.scala
@@ -48,7 +48,7 @@ object BspProxy {
         val stdinToServer = new Thread("bsp-stdin-to-server") {
           setDaemon(true)
           override def run(): Unit =
-            try System.in.transferTo(connection.output)
+            try System.in.transferTo(connection.output): Unit
             catch { case _: Exception => () }
             finally
               try connection.output.close()
@@ -57,7 +57,7 @@ object BspProxy {
         val serverToStdout = new Thread("bsp-server-to-stdout") {
           setDaemon(true)
           override def run(): Unit =
-            try connection.input.transferTo(System.out)
+            try connection.input.transferTo(System.out): Unit
             catch { case _: Exception => () }
             finally
               try System.out.close()

--- a/bleep-cli/src/scala/bleep/commands/ConfigAuthSetup.scala
+++ b/bleep-cli/src/scala/bleep/commands/ConfigAuthSetup.scala
@@ -102,7 +102,7 @@ case class ConfigAuthSetup(logger: Logger, userPaths: UserPaths) extends BleepCo
         out = cli.Out.ViaLogger(logger),
         in = cli.In.No,
         env = pathEnv
-      )
+      ): Unit
       logger.info("GitHub CLI is authenticated. No additional bleep configuration needed.")
       logger.info("Just add github://owner/repo to your bleep.yaml resolvers.")
       Right(())
@@ -126,7 +126,7 @@ case class ConfigAuthSetup(logger: Logger, userPaths: UserPaths) extends BleepCo
         out = cli.Out.ViaLogger(logger),
         in = cli.In.No,
         env = pathEnv
-      )
+      ): Unit
       logger.info("GitLab CLI is authenticated. No additional bleep configuration needed.")
       logger.info("Just add gitlab://host/path to your bleep.yaml resolvers.")
       Right(())
@@ -146,5 +146,5 @@ case class ConfigAuthSetup(logger: Logger, userPaths: UserPaths) extends BleepCo
         val updated = existing.copy(configs = existing.configs + (uri -> entry))
         config.copy(authentications = Some(updated))
       }
-      .orThrow
+      .orThrow: Unit
 }

--- a/bleep-cli/src/scala/bleep/commands/Fmt.scala
+++ b/bleep-cli/src/scala/bleep/commands/Fmt.scala
@@ -167,7 +167,7 @@ case class Fmt(check: Boolean, projects: Array[model.CrossProjectName]) extends 
   override def run(started: Started): Either[BleepException, Unit] = {
     val selectedProjects =
       if (projects.isEmpty) started.build.explodedProjects.keys
-      else projects.toIterable
+      else projects.toSeq
 
     val sourcesDirs: Set[Path] =
       selectedProjects

--- a/bleep-cli/src/scala/bleep/commands/PublishSetup.scala
+++ b/bleep-cli/src/scala/bleep/commands/PublishSetup.scala
@@ -431,7 +431,7 @@ case class PublishSetup(logger: Logger, userPaths: UserPaths, maybeStarted: Opti
         out = cli.Out.ViaLogger(logger),
         in = cli.In.No,
         env = pathEnv
-      )
+      ): Unit
       logger.info("Public key uploaded successfully.")
     } catch {
       case e: BleepException.Text =>
@@ -501,7 +501,7 @@ case class PublishSetup(logger: Logger, userPaths: UserPaths, maybeStarted: Opti
         val updated = existing.copy(configs = existing.configs + (uri -> entry))
         config.copy(authentications = Some(updated))
       }
-      .orThrow
+      .orThrow: Unit
 
   /** Add a named resolver to bleep.yaml if we have build access and it doesn't already exist. */
   private def addResolverToBuild(name: String, repo: Repository): Unit =

--- a/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
+++ b/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
@@ -324,7 +324,6 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
     val maxConcurrent = if (events.jvm.nonEmpty) events.jvm.map(_.get("concurrent_compiles").getAsInt).max else 0
     val maxHeap = if (events.jvm.nonEmpty) events.jvm.map(_.get("heap_used_mb").getAsLong).max else 0L
     val heapMax = if (events.jvm.nonEmpty) events.jvm.head.get("heap_max_mb").getAsLong else 0L
-    val totalBuilds = events.buildEnd.size + events.buildStart.size - events.buildEnd.size // count started builds
     val completedBuilds = events.buildEnd.size
     val avgBuildMs = if (completedBuilds > 0) events.buildEnd.map(_.get("duration_ms").getAsLong).sum.toDouble / completedBuilds else 0.0
 

--- a/bleep-cli/src/scala/bleep/internal/Version.scala
+++ b/bleep-cli/src/scala/bleep/internal/Version.scala
@@ -128,7 +128,7 @@ final case class Version(value: String) {
       case _                         => false
     } || Rfc5234.hexdig.rep(8).string.filterNot(startsWithDate).parse(value).isRight
 
-  private[this] def alnumComponentsWithoutPreRelease: List[Version.Component] =
+  private def alnumComponentsWithoutPreRelease: List[Version.Component] =
     alnumComponents.takeWhile {
       case a: Version.Component.Alpha => !a.isPreReleaseIdent
       case _                          => true

--- a/bleep-cli/src/scala/bleep/internal/parseBloopFile.scala
+++ b/bleep-cli/src/scala/bleep/internal/parseBloopFile.scala
@@ -5,5 +5,5 @@ import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 
 object parseBloopFile {
   def apply(contents: String): Config.File =
-    readFromString(contents)(ConfigCodecs.codecFile)
+    readFromString(contents)(using ConfigCodecs.codecFile)
 }

--- a/bleep-cli/src/scala/bleep/mavenimport/MavenImportOptions.scala
+++ b/bleep-cli/src/scala/bleep/mavenimport/MavenImportOptions.scala
@@ -49,13 +49,13 @@ object MavenImportOptions {
     List(model.VersionScala.Scala3, model.VersionScala.Scala213, model.VersionScala.Scala212).map(v => (v.binVersion.replace("\\.", ""), v)).toMap
 
   val filterPlatforms: Opts[Option[NonEmptyList[model.PlatformId]]] = Opts
-    .options("platform", "only import projects for specified platform(s)", metavar = "platform", short = "p")(
+    .options("platform", "only import projects for specified platform(s)", metavar = "platform", short = "p")(using
       Argument.fromMap("platform", model.PlatformId.All.map(p => (p.value, p)).toMap)
     )
     .orNone
 
   val filterScalaVersions: Opts[Option[NonEmptyList[model.VersionScala]]] = Opts
-    .options("scala", "only import projects for specified scala version(s)", "s", "scala version")(
+    .options("scala", "only import projects for specified scala version(s)", "s", "scala version")(using
       Argument.fromMap("scala version", possibleScalaVersions)
     )
     .orNone

--- a/bleep-cli/src/scala/bleep/sbtimport/ImportOptions.scala
+++ b/bleep-cli/src/scala/bleep/sbtimport/ImportOptions.scala
@@ -67,13 +67,13 @@ object ImportOptions {
     List(model.VersionScala.Scala3, model.VersionScala.Scala213, model.VersionScala.Scala212).map(v => (v.binVersion.replace("\\.", ""), v)).toMap
 
   val filterPlatforms: Opts[Option[NonEmptyList[model.PlatformId]]] = Opts
-    .options("platform", "only import projects for specified platform(s)", metavar = "platform", short = "p")(
+    .options("platform", "only import projects for specified platform(s)", metavar = "platform", short = "p")(using
       Argument.fromMap("platform", model.PlatformId.All.map(p => (p.value, p)).toMap)
     )
     .orNone
 
   val filterScalaVersions: Opts[Option[NonEmptyList[model.VersionScala]]] = Opts
-    .options("scala", "only import projects for specified scala version(s)", "s", "scala version")(
+    .options("scala", "only import projects for specified scala version(s)", "s", "scala version")(using
       Argument.fromMap("scala version", possibleScalaVersions)
     )
     .orNone

--- a/bleep-cli/src/scala/bleep/sbtimport/ReadSbtExportFile.scala
+++ b/bleep-cli/src/scala/bleep/sbtimport/ReadSbtExportFile.scala
@@ -58,7 +58,7 @@ object ReadSbtExportFile {
       override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): ExportedProject =
         jsOpt match {
           case Some(j) =>
-            unbuilder.beginObject(j)
+            unbuilder.beginObject(j): Unit
             val organization = unbuilder.readField[String]("organization")
             val bloopName = unbuilder.readField[String]("bloopName")
             val sbtName = unbuilder.readField[String]("sbtName")

--- a/bleep-core/src/scala/bleep/BspQuery.scala
+++ b/bleep-core/src/scala/bleep/BspQuery.scala
@@ -86,5 +86,5 @@ object BspQuery {
     started.build.explodedProjects.keys.find(_.value == name.getUri.split("=").last)
 
   def buildTargets(buildPaths: BuildPaths, projects: Array[model.CrossProjectName]): util.List[bsp4j.BuildTargetIdentifier] =
-    util.List.of(projects.map(p => buildTarget(buildPaths, p)): _*)
+    util.List.of(projects.map(p => buildTarget(buildPaths, p))*)
 }

--- a/bleep-core/src/scala/bleep/CoursierResolver.scala
+++ b/bleep-core/src/scala/bleep/CoursierResolver.scala
@@ -3,7 +3,7 @@ package bleep
 import bleep.depcheck.CheckEvictions
 import bleep.internal.codecs.*
 import bleep.internal.FileUtils
-import coursier.cache.{CacheDefaults, FileCache}
+import coursier.cache.CacheDefaults
 import coursier.core.*
 import coursier.error.CoursierError
 import coursier.ivy.IvyRepository
@@ -150,10 +150,10 @@ object CoursierResolver {
 
     // break circular structure
     private implicit lazy val encoderMap: Encoder[Map[String, Artifact]] =
-      Encoder.instance(a => Encoder.encodeMap(KeyEncoder.encodeKeyString, codecArtifact).apply(a))
+      Encoder.instance(a => Encoder.encodeMap(using KeyEncoder.encodeKeyString, codecArtifact).apply(a))
 
     private implicit lazy val decoderMap: Decoder[Map[String, Artifact]] =
-      Decoder.instance(c => Decoder.decodeMap(KeyDecoder.decodeKeyString, codecArtifact).apply(c))
+      Decoder.instance(c => Decoder.decodeMap(using KeyDecoder.decodeKeyString, codecArtifact).apply(c))
 
     implicit lazy val codecArtifact: Codec[Artifact] =
       Codec.forProduct6[Artifact, String, Map[String, String], Map[String, Artifact], Boolean, Boolean, Option[Authentication]]("url", "checksumUrls", "extra", "changing", "optional", "authentication")(Artifact.apply)(x => (x.url, x.checksumUrls, x.extra, x.changing, x.optional, x.authentication))
@@ -280,7 +280,7 @@ object CoursierResolver {
           .withDependencies(deps)
           .withResolutionParams(resolutionParams)
           .withMainArtifacts(true)
-          .addClassifiers(newClassifiers: _*)
+          .addClassifiers(newClassifiers*)
           .eitherResult() match {
           case Left(coursierError) if remainingAttempts > 0 =>
             val newRemainingAttempts = remainingAttempts - 1

--- a/bleep-core/src/scala/bleep/TarGz.scala
+++ b/bleep-core/src/scala/bleep/TarGz.scala
@@ -71,7 +71,7 @@ object TarGz {
 
           if (name.nonEmpty && size >= 0) {
             val content = new Array[Byte](size.toInt)
-            readFully(gzIn, content)
+            readFully(gzIn, content): Unit
 
             // Skip padding to 512-byte boundary
             val padding = (512 - (size % 512).toInt) % 512
@@ -79,7 +79,7 @@ object TarGz {
 
             val targetFile = tmpDir.resolve(name)
             Files.createDirectories(targetFile.getParent)
-            Files.write(targetFile, content)
+            Files.write(targetFile, content): Unit
           }
         }
       }
@@ -88,15 +88,17 @@ object TarGz {
 
       // Move extracted files into target dir
       Files.createDirectories(targetDir)
-      scala.util.Using(Files.list(tmpDir)) { stream =>
-        stream.forEach { entry =>
-          val dest = targetDir.resolve(tmpDir.relativize(entry))
-          // Delete existing target if present, then move
-          if (Files.isDirectory(dest)) internal.FileUtils.deleteDirectory(dest)
-          else Files.deleteIfExists(dest)
-          Files.move(entry, dest, java.nio.file.StandardCopyOption.ATOMIC_MOVE)
+      scala.util
+        .Using(Files.list(tmpDir)) { stream =>
+          stream.forEach { entry =>
+            val dest = targetDir.resolve(tmpDir.relativize(entry))
+            // Delete existing target if present, then move
+            if (Files.isDirectory(dest)) internal.FileUtils.deleteDirectory(dest)
+            else Files.deleteIfExists(dest)
+            Files.move(entry, dest, java.nio.file.StandardCopyOption.ATOMIC_MOVE): Unit
+          }
         }
-      }
+        .get
     } finally
       // Clean up temp dir
       try internal.FileUtils.deleteDirectory(tmpDir)
@@ -137,9 +139,9 @@ object TarGz {
     // Type: regular file
     header(156) = '0'.toByte
     // USTAR magic
-    "ustar\u0000".getBytes("UTF-8").copyToArray(header, 257)
+    "ustar\u0000".getBytes("UTF-8").copyToArray(header, 257): Unit
     // USTAR version
-    "00".getBytes("UTF-8").copyToArray(header, 263)
+    "00".getBytes("UTF-8").copyToArray(header, 263): Unit
 
     // Compute checksum (sum of all bytes in header, treating checksum field as spaces)
     java.util.Arrays.fill(header, 148, 156, ' '.toByte)
@@ -157,7 +159,7 @@ object TarGz {
 
   private def writeOctal(buf: Array[Byte], offset: Int, length: Int, value: Long): Unit = {
     val octal = String.format(s"%${length - 1}o", value).replace(' ', '0')
-    octal.getBytes("UTF-8").copyToArray(buf, offset)
+    octal.getBytes("UTF-8").copyToArray(buf, offset): Unit
     buf(offset + length - 1) = 0
   }
 

--- a/bleep-core/src/scala/bleep/TuiPicker.scala
+++ b/bleep-core/src/scala/bleep/TuiPicker.scala
@@ -2,7 +2,6 @@ package bleep
 
 import bleep.testing.FancyBuildDisplay.Palette
 import tui._
-import tui.crossterm.CrosstermJni
 import tui.widgets.{BlockWidget, ListWidget, ParagraphWidget}
 
 /** Reusable single-select picker using tui-scala. Returns the selected index, or None if user cancelled (Esc). */

--- a/bleep-core/src/scala/bleep/bsp/BspServerBuilder.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspServerBuilder.scala
@@ -131,8 +131,7 @@ object BspServerBuilder {
     buildData.foreach { data =>
       params.setDataKind(BspBuildData.DataKind)
       val jsonStr = BspBuildData.Payload.encode(data)
-      val gsonParser = new com.google.gson.JsonParser()
-      val jsonElement = gsonParser.parse(jsonStr)
+      val jsonElement = com.google.gson.JsonParser.parseString(jsonStr)
       params.setData(jsonElement)
     }
 

--- a/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
@@ -37,7 +37,7 @@ object BspServerOperations {
       val prevOutputFile = socketDir.resolve("output.prev")
       Files.deleteIfExists(prevOutputFile)
       if (Files.exists(outputFile)) {
-        Files.move(outputFile, prevOutputFile)
+        Files.move(outputFile, prevOutputFile): Unit
       }
 
       val command = buildServerCommand(config)
@@ -289,13 +289,13 @@ object BspServerOperations {
   /** Send shutdown signal to process */
   private def sendShutdownSignal(pid: Long): IO[Unit] = IO.blocking {
     ProcessHandle.of(pid).ifPresent { handle =>
-      handle.destroy() // SIGTERM on Unix
+      handle.destroy(): Unit // SIGTERM on Unix
     }
   }
 
   /** Force kill a process */
   def forceKill(pid: Long): IO[Unit] = IO.blocking {
-    ProcessHandle.of(pid).ifPresent(_.destroyForcibly())
+    ProcessHandle.of(pid).ifPresent { h => h.destroyForcibly(); () }
   }
 
   /** Wait for a process to exit */
@@ -352,7 +352,7 @@ object BspServerOperations {
       Files.createDirectories(dir)
       // Set restrictive permissions on Unix
       try
-        Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------"))
+        Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------")): Unit
       catch {
         case _: UnsupportedOperationException => () // Windows
       }
@@ -395,8 +395,8 @@ object BspServerOperations {
             // If it still hasn't exited after 5s, try killing descendants too
             IO.blocking {
               ProcessHandle.of(pid).ifPresent { handle =>
-                handle.descendants().forEach(_.destroyForcibly())
-                handle.destroyForcibly()
+                handle.descendants().forEach { h => h.destroyForcibly(); () }
+                handle.destroyForcibly(): Unit
               }
             } >> IO.sleep(500.millis)
           } >>

--- a/bleep-core/src/scala/bleep/bsp/SetupBleepBsp.scala
+++ b/bleep-core/src/scala/bleep/bsp/SetupBleepBsp.scala
@@ -149,7 +149,7 @@ object SetupBleepBsp {
             Try {
               Files.createDirectories(cacheFile.getParent)
               Files.writeString(cacheFile, paths.map(_.toString).mkString(java.io.File.pathSeparator))
-            }
+            }: Unit
             Right(paths)
         }
     }
@@ -177,18 +177,18 @@ object SetupBleepBsp {
               PosixFilePermission.OWNER_READ,
               PosixFilePermission.OWNER_WRITE
             )
-          )
+          ): Unit
         }
         try
-          Files.move(tmpDir, dir, StandardCopyOption.ATOMIC_MOVE)
+          Files.move(tmpDir, dir, StandardCopyOption.ATOMIC_MOVE): Unit
         catch {
           case _: AtomicMoveNotSupportedException =>
-            try Files.move(tmpDir, dir)
+            try Files.move(tmpDir, dir): Unit
             catch { case _: FileAlreadyExistsException => () }
           case _: FileAlreadyExistsException => ()
         }
       } finally
-        try Files.deleteIfExists(tmpDir)
+        try Files.deleteIfExists(tmpDir): Unit
         catch { case _: Exception => () }
     }
 

--- a/bleep-core/src/scala/bleep/cli.scala
+++ b/bleep-core/src/scala/bleep/cli.scala
@@ -34,9 +34,9 @@ object cli {
       def apply(writtenLine: WrittenLine): Unit =
         writtenLine match {
           case WrittenLine.StdErr(line) =>
-            logger.warn(line)(implicitly, l, f, e)
+            logger.warn(line)(using implicitly, l, f, e)
           case WrittenLine.StdOut(line) =>
-            logger.info(line)(implicitly, l, f, e)
+            logger.info(line)(using implicitly, l, f, e)
         }
 
       def withAction(action: String): ViaLogger =
@@ -60,7 +60,7 @@ object cli {
     }
 
     val process = Process {
-      val builder = new java.lang.ProcessBuilder(patchedCmd: _*)
+      val builder = new java.lang.ProcessBuilder(patchedCmd*)
       builder.directory(cwd.toFile)
       builder.environment().clear()
       env.foreach { case (k, v) => builder.environment.put(k, v) }

--- a/bleep-core/src/scala/bleep/commands/CompileDisplay.scala
+++ b/bleep-core/src/scala/bleep/commands/CompileDisplay.scala
@@ -131,9 +131,9 @@ object CompileDisplay {
 
       case CompileEvent.DiagnosticEmitted(project, file, line, severity, message, timestamp) =>
         val logFn = severity.toLowerCase match {
-          case "error"   => logError _
-          case "warning" => logWarn _
-          case _         => log _
+          case "error"   => logError
+          case "warning" => logWarn
+          case _         => log
         }
         val sevColor = severity.toLowerCase match {
           case "error"   => SConsole.RED

--- a/bleep-core/src/scala/bleep/commands/ListTests.scala
+++ b/bleep-core/src/scala/bleep/commands/ListTests.scala
@@ -5,6 +5,7 @@ import bleep.bsp.BuildServer
 import ch.epfl.scala.bsp4j
 import ch.epfl.scala.bsp4j.ScalaTestClassesParams
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters.*
 
 case class ListTests(projects: Array[model.CrossProjectName], outputMode: OutputMode) extends BleepBuildCommand {
@@ -34,6 +35,7 @@ case class ListTests(projects: Array[model.CrossProjectName], outputMode: Output
       Right(())
     }
 
+  @nowarn("msg=buildTargetScalaTestClasses")
   private def testsByCrossProject(started: Started, server: BuildServer): Iterator[(model.CrossProjectName, String)] = {
     val targets = BspQuery.buildTargets(started.buildPaths, projects)
     val result: bsp4j.ScalaTestClassesResult = server.buildTargetScalaTestClasses(new ScalaTestClassesParams(targets)).get()

--- a/bleep-core/src/scala/bleep/commands/Publish.scala
+++ b/bleep-core/src/scala/bleep/commands/Publish.scala
@@ -1,7 +1,6 @@
 package bleep
 package commands
 
-import bleep.internal.traverseish
 import bleep.packaging.*
 import bleep.publishing.MavenRemotePublisher
 import coursier.core.Info
@@ -105,7 +104,6 @@ object Publish {
   /** Render a dry-run report showing what would be published. */
   def renderDryRun(
       logger: ryddig.Logger,
-      projects: Array[model.CrossProjectName],
       version: String,
       target: Target,
       allArtifacts: Map[model.CrossProjectName, Map[RelPath, Array[Byte]]]
@@ -208,7 +206,7 @@ case class Publish(watch: Boolean, options: Publish.Options, buildOpts: CommonBu
           cancel = buildOpts.cancel
         )
         .run(started)
-      version <- resolveVersion(started)
+      version <- resolveVersion()
       _ <- checkAssertRelease(version)
       _ <-
         if (options.dryRun) dryRun(started, projects, version)
@@ -221,7 +219,7 @@ case class Publish(watch: Boolean, options: Publish.Options, buildOpts: CommonBu
           }
     } yield ()
 
-  private def resolveVersion(started: Started): Either[BleepException, String] =
+  private def resolveVersion(): Either[BleepException, String] =
     options.versionOverride
       .orElse(options.versionFallback.map(_.apply()))
       .toRight(new BleepException.Text("No --version specified and no git tags found for automatic versioning."): BleepException)
@@ -262,16 +260,17 @@ case class Publish(watch: Boolean, options: Publish.Options, buildOpts: CommonBu
       version: String
   ): Either[BleepException, Unit] = {
     val firstProject = started.build.explodedProjects(projects.head)
-    val publishConfig = firstProject.publish.getOrElse(
-      return Left(new BleepException.Text(s"Project ${projects.head.value} has no 'publish' config"))
-    )
-    val info = Publish.toInfo(publishConfig, None)
-
-    packageAll(started, projects, version, PublishLayout.Maven(info)).map { packagedLibraries =>
-      val allArtifacts = packagedLibraries.map { case (pName, PackagedLibrary(_, files)) =>
-        pName -> Checksums(files.all, List(Checksums.Algorithm.Md5, Checksums.Algorithm.Sha1))
-      }
-      Publish.renderDryRun(started.logger, projects, version, options.target, allArtifacts)
+    firstProject.publish match {
+      case None =>
+        Left(new BleepException.Text(s"Project ${projects.head.value} has no 'publish' config"))
+      case Some(publishConfig) =>
+        val info = Publish.toInfo(publishConfig, None)
+        packageAll(started, projects, version, PublishLayout.Maven(info)).map { packagedLibraries =>
+          val allArtifacts = packagedLibraries.map { case (pName, PackagedLibrary(_, files)) =>
+            pName -> Checksums(files.all, List(Checksums.Algorithm.Md5, Checksums.Algorithm.Sha1))
+          }
+          Publish.renderDryRun(started.logger, version, options.target, allArtifacts)
+        }
     }
   }
 
@@ -328,23 +327,25 @@ case class Publish(watch: Boolean, options: Publish.Options, buildOpts: CommonBu
     val publisher = new MavenRemotePublisher(started.logger)
 
     val firstProject = started.build.explodedProjects(projects.head)
-    val publishConfig = firstProject.publish.getOrElse(
-      return Left(new BleepException.Text(s"Project ${projects.head.value} has no 'publish' config"))
-    )
-    val info = Publish.toInfo(publishConfig, None)
+    firstProject.publish match {
+      case None =>
+        Left(new BleepException.Text(s"Project ${projects.head.value} has no 'publish' config"))
+      case Some(publishConfig) =>
+        val info = Publish.toInfo(publishConfig, None)
 
-    packageAll(started, projects, version, PublishLayout.Maven(info)).map { packagedLibraries =>
-      packagedLibraries.foreach { case (pName, PackagedLibrary(_, files)) =>
-        val artifacts =
-          if (resolved.uploadChecksums) Checksums(files.all, List(Checksums.Algorithm.Md5, Checksums.Algorithm.Sha1))
-          else files.all
-        val projectLogger = started.logger
-          .withContext("projectName", pName.value)
-          .withContext("version", version)
-          .withContext("repository", resolved.httpsUri)
-        projectLogger.info(s"Publishing ${artifacts.size} files")
-        publisher.publish(resolved.httpsUri, artifacts, resolved.authentication)
-      }
+        packageAll(started, projects, version, PublishLayout.Maven(info)).map { packagedLibraries =>
+          packagedLibraries.foreach { case (pName, PackagedLibrary(_, files)) =>
+            val artifacts =
+              if (resolved.uploadChecksums) Checksums(files.all, List(Checksums.Algorithm.Md5, Checksums.Algorithm.Sha1))
+              else files.all
+            val projectLogger = started.logger
+              .withContext("projectName", pName.value)
+              .withContext("version", version)
+              .withContext("repository", resolved.httpsUri)
+            projectLogger.info(s"Publishing ${artifacts.size} files")
+            publisher.publish(resolved.httpsUri, artifacts, resolved.authentication)
+          }
+        }
     }
   }
 }

--- a/bleep-core/src/scala/bleep/commands/PublishSonatype.scala
+++ b/bleep-core/src/scala/bleep/commands/PublishSonatype.scala
@@ -7,7 +7,6 @@ import bleep.plugin.cirelease.CiReleasePlugin
 import bleep.plugin.dynver.DynVerPlugin
 import bleep.plugin.pgp.PgpPlugin
 import bleep.plugin.sonatype.Sonatype
-import coursier.core.Info
 
 import scala.collection.immutable.SortedMap
 

--- a/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
+++ b/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
@@ -164,7 +164,7 @@ case class ReactiveBsp(
 
     try {
       val summary = program.unsafeRunSync()
-      resultFromSummary(started, summary)
+      resultFromSummary(summary)
     } catch {
       case ex: Exception =>
         Left(new BleepException.Cause(ex, "Build failed"))
@@ -412,7 +412,7 @@ case class ReactiveBsp(
     try {
       val summary = program.unsafeRunSync()
       summaryOpt = Some(summary)
-      resultFromSummary(started, summary)
+      resultFromSummary(summary)
     } catch {
       case ex: Exception =>
         errorOpt = Some(ex)
@@ -617,7 +617,7 @@ case class ReactiveBsp(
     }
 
   /** Convert build summary to result. Shared by runWithBleepBsp and runInProcess. */
-  private def resultFromSummary(started: Started, summary: BuildSummary): Either[BleepException, Unit] =
+  private def resultFromSummary(summary: BuildSummary): Either[BleepException, Unit] =
     summary.toEither
 
   /** Build target identifier for a project */

--- a/bleep-core/src/scala/bleep/commands/RemoteCache.scala
+++ b/bleep-core/src/scala/bleep/commands/RemoteCache.scala
@@ -6,7 +6,6 @@ import bleep.analysis.{NoopManifestStore, ProjectCompileSuccess, ProjectLanguage
 import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, Future as JFuture}
-import scala.collection.immutable.SortedMap
 import scala.jdk.StreamConverters.*
 
 /** Remote build cache: pull pre-compiled classes from S3, push after building.
@@ -77,7 +76,7 @@ object RemoteCache {
             }
           }
 
-          futures.forEach(_.get())
+          futures.forEach { f => f.get(); () }
           executor.shutdown()
 
           started.logger.info(
@@ -140,7 +139,7 @@ object RemoteCache {
                       case head :: _ =>
                         errors.add(
                           s"${crossName.value}: analysis contains ${absolutePaths.size} absolute path(s), e.g. '$head'. Kill BSP servers and recompile."
-                        )
+                        ): Unit
                       case Nil =>
                         val archive = TarGz.pack(projectPaths.targetDir, packFilter)
                         semaphore.acquire()
@@ -155,7 +154,7 @@ object RemoteCache {
             }
           }
 
-          futures.forEach(_.get())
+          futures.forEach { f => f.get(); () }
           executor.shutdown()
 
           val errorList = scala.jdk.CollectionConverters.IterableHasAsScala(errors).asScala.toList
@@ -247,7 +246,7 @@ object RemoteCache {
       language = maybeLanguage.get,
       ecjVersion = None,
       result = result
-    )
+    ): Unit
     started.logger.debug(s"${crossName.value}: regenerated noop manifest")
   }
 }

--- a/bleep-core/src/scala/bleep/depcheck/UpdateRun.scala
+++ b/bleep-core/src/scala/bleep/depcheck/UpdateRun.scala
@@ -42,7 +42,7 @@ object UpdateRun {
       }
       .groupBy(_.withConfiguration(Configuration.empty))
       .map { case (dep, l) =>
-        dep.withConfiguration(Configuration.join(l.map(_.configuration).toSeq: _*))
+        dep.withConfiguration(Configuration.join(l.map(_.configuration).toSeq*))
       }
       .toSet
 

--- a/bleep-core/src/scala/bleep/discoverMain.scala
+++ b/bleep-core/src/scala/bleep/discoverMain.scala
@@ -5,9 +5,11 @@ import ch.epfl.scala.bsp4j
 import ryddig.Logger
 
 import java.util
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters.*
 
 object discoverMain {
+  @nowarn("msg=buildTargetScalaMainClasses")
   def apply(logger: Logger, server: BuildServer, inProject: bsp4j.BuildTargetIdentifier): Either[BleepException, String] = {
     val req = new bsp4j.ScalaMainClassesParams(util.List.of[bsp4j.BuildTargetIdentifier](inProject))
     logger.debug(req.toString)

--- a/bleep-core/src/scala/bleep/internal/ChildProcessDiagnostics.scala
+++ b/bleep-core/src/scala/bleep/internal/ChildProcessDiagnostics.scala
@@ -78,7 +78,7 @@ object ChildProcessDiagnostics {
         }
       case None =>
         // No jstack — try kill -QUIT and note it
-        Try(Runtime.getRuntime.exec(Array("kill", "-QUIT", pid.toString)))
+        Try(Runtime.getRuntime.exec(Array("kill", "-QUIT", pid.toString))): Unit
         out.println(s"  (sent SIGQUIT — dump appears in child's stderr)")
     }
   }

--- a/bleep-core/src/scala/bleep/javaapi/JModel.scala
+++ b/bleep-core/src/scala/bleep/javaapi/JModel.scala
@@ -4,7 +4,6 @@ import bleep.model
 import bleep.packaging.ManifestCreator
 
 import java.util
-import java.util.Optional
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 

--- a/bleep-core/src/scala/bleep/packaging/GenLayout.scala
+++ b/bleep-core/src/scala/bleep/packaging/GenLayout.scala
@@ -4,8 +4,10 @@ package packaging
 import coursier.core.{Configuration, Dependency, Info}
 
 import java.nio.charset.StandardCharsets
+import scala.annotation.nowarn
 import scala.xml.{Elem, NodeSeq}
 
+@nowarn("msg=unused value of type scala.xml.NodeBuffer")
 object GenLayout {
   val p = new scala.xml.PrettyPrinter(120, 2)
 
@@ -57,7 +59,7 @@ object GenLayout {
     (prelude + p.format(xml)).getBytes(StandardCharsets.UTF_8)
   }
 
-  def ivyFile(self: Dependency, deps: List[Dependency]): Elem =
+  def ivyFile(self: Dependency, deps: List[Dependency]): Elem = {
     <ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
       <info organisation={self.module.organization.value}
             module={self.module.name.value}
@@ -97,6 +99,7 @@ object GenLayout {
     }
       </dependencies>
     </ivy-module>
+  }
 
   implicit class OptionOps[T](ot: Option[T]) {
     def render(asXml: T => Elem): NodeSeq =
@@ -111,7 +114,7 @@ object GenLayout {
       if (ts.isEmpty) NodeSeq.Empty else asXml(ts)
   }
 
-  def pomFile(self: Dependency, dependencies: List[Dependency], info: Info): Elem =
+  def pomFile(self: Dependency, dependencies: List[Dependency], info: Info): Elem = {
     <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
       <modelVersion>4.0.0</modelVersion>
       <groupId>{self.module.organization.value}</groupId>
@@ -189,4 +192,5 @@ object GenLayout {
     }
       </dependencies>
     </project>
+  }
 }

--- a/bleep-core/src/scala/bleep/publishing/MavenRemotePublisher.scala
+++ b/bleep-core/src/scala/bleep/publishing/MavenRemotePublisher.scala
@@ -35,7 +35,6 @@ class MavenRemotePublisher(logger: Logger) {
   ): Unit = {
     val total = artifacts.size
     var uploaded = 0
-    var failed = 0
 
     artifacts.foreach { case (relPath, content) =>
       val targetUri = resolveArtifactUri(baseUri, relPath)
@@ -50,7 +49,6 @@ class MavenRemotePublisher(logger: Logger) {
           uploaded += 1
           logger.debug(s"  $code OK ($uploaded/$total)")
         case code =>
-          failed += 1
           val body = response.body()
           throw new BleepException.Text(
             s"Failed to publish $relPath to $targetUri: HTTP $code\n$body"

--- a/bleep-core/src/scala/bleep/testing/BuildDiff.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDiff.scala
@@ -249,7 +249,6 @@ object BuildDiff {
   def formatCompileSummary(
       totalProjects: Int,
       totalErrors: Int,
-      totalWarnings: Int,
       newErrors: Int,
       fixedErrors: Int
   ): String =

--- a/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
@@ -537,8 +537,8 @@ object BuildDisplay {
     private val activePhase: mutable.Map[CrossProjectName, (bleep.bsp.protocol.CompilePhase, String, Long)] = mutable.Map.empty
 
     private val progressMonitor: Option[LoggerFn] = logger match {
-      case tl: TypedLogger[?] => tl.progressMonitor
-      case _                  => None
+      case tl: TypedLogger[?] => tl.progressMonitor: @scala.annotation.nowarn("msg=progressMonitor")
+      case null               => None
     }
 
     private def renderCompileProgress(): Unit = progressMonitor.foreach { pm =>
@@ -664,7 +664,7 @@ object BuildDisplay {
         IO.unit
 
       case BuildEvent.TestFinished(_, suite, test, status, durationMs, _, _, _) =>
-        if (!quietMode) printTestResult(suite, test, status, durationMs) else IO.unit
+        if (!quietMode) printTestResult(test, status) else IO.unit
 
       case BuildEvent.SuiteFinished(_, suite, passed, failed, skipped, ignored, durationMs, _) =>
         if (!quietMode) printSuiteResult(suite, passed, failed, skipped, ignored, durationMs) else IO.unit
@@ -793,10 +793,8 @@ object BuildDisplay {
       } yield ()
 
     private def printTestResult(
-        @annotation.nowarn("msg=is never used") suite: SuiteName,
         test: TestName,
-        status: TestStatus,
-        durationMs: Long
+        status: TestStatus
     ): IO[Unit] = {
       val icon = status match {
         case TestStatus.Passed           => SConsole.GREEN + "+" + SConsole.RESET
@@ -1072,7 +1070,7 @@ object BuildDisplay {
               diff.fixedErrors
             }.sum
             val totalErrors = s.compileFailures.flatMap(_.diagnostics).count(_.severity == DiagnosticSeverity.Error)
-            log(BuildDiff.formatCompileSummary(s.compilesCompleted, totalErrors, 0, totalNew, totalFixed))
+            log(BuildDiff.formatCompileSummary(s.compilesCompleted, totalErrors, totalNew, totalFixed))
 
           case BuildMode.Test =>
             val newFailures = allTests.count { t =>

--- a/bleep-core/src/scala/bleep/testing/FancyBuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/FancyBuildDisplay.scala
@@ -199,7 +199,7 @@ object FancyBuildDisplay {
           restoreTerminal()
           // Remove shutdown hook if we cleaned up normally
           if (shutdownHook != null) {
-            try Runtime.getRuntime.removeShutdownHook(shutdownHook)
+            try Runtime.getRuntime.removeShutdownHook(shutdownHook): Unit
             catch { case _: IllegalStateException => () } // JVM already shutting down
           }
         }
@@ -381,7 +381,7 @@ object FancyBuildDisplay {
     // Use FancyBuildDisplay's own runningSuites for cancellation tracking
     // (runningTests might be empty between tests even when suite is running)
     val summary = state.core.toSummary(durationMs = state.elapsedMs, wasCancelled = userCancelled)
-    summary.copy(currentlyRunning = state.runningSuites.values.map(_.suite).toList.sorted(SuiteName.ordering))
+    summary.copy(currentlyRunning = state.runningSuites.values.map(_.suite).toList.sorted(using SuiteName.ordering))
   }
 
   private def processEvent(state: State, event: BuildEvent): State = {
@@ -768,36 +768,6 @@ object FancyBuildDisplay {
       titleColor: Color,
       borderColor: Color
   )
-
-  /** Compute pane heights to fit available rows. Each pane needs itemCount + 2 (borders). */
-  private def fitPaneHeights(itemCounts: Array[Int], available: Int): Array[Int] = {
-    if (itemCounts.isEmpty) return Array.empty
-    val desired = itemCounts.map(_ + 2)
-    val total = desired.sum
-    if (total <= available) {
-      desired
-    } else {
-      val minPerPane = 3 // 1 item + 2 borders
-      val totalMin = minPerPane * desired.length
-      if (available <= totalMin) {
-        Array.fill(desired.length)(math.max(minPerPane, available / math.max(1, desired.length)))
-      } else {
-        val extra = available - totalMin
-        val totalAboveMin = desired.map(d => math.max(0, d - minPerPane)).sum
-        if (totalAboveMin == 0) {
-          Array.fill(desired.length)(minPerPane)
-        } else {
-          val result = desired.map { d =>
-            val aboveMin = math.max(0, d - minPerPane)
-            minPerPane + (aboveMin.toDouble / totalAboveMin * extra).toInt
-          }
-          val shortfall = available - result.sum
-          if (shortfall > 0 && result.nonEmpty) result(result.length - 1) += shortfall
-          result
-        }
-      }
-    }
-  }
 
   private def renderPane(f: Frame, area: Rect, title: String, titleColor: Color, borderColor: Color, items: Array[ListWidget.Item]): Unit = {
     val list = ListWidget(
@@ -1351,7 +1321,7 @@ object FancyBuildDisplay {
         val inThumb = i >= thumbPos && i < thumbPos + thumbHeight
         val ch = if (inThumb) "\u2503" else "\u2502" // ┃ for thumb, │ for track
         val style = if (inThumb) s(Palette.info) else s(Palette.border)
-        f.buffer.setString(x, y, ch, style)
+        f.buffer.setString(x, y, ch, style): Unit
       }
     }
   }

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -2,7 +2,6 @@ package bleep.testing
 
 import cats.effect._
 import cats.effect.std.{Queue, Semaphore}
-import cats.syntax.all._
 import fs2.Stream
 
 import java.io._
@@ -150,21 +149,20 @@ object JvmPool {
     private val stderrBuffer = new java.util.concurrent.ConcurrentLinkedDeque[String]()
     private val stderrBufferCap = 2048
 
-    private val stderrDrainThread: Thread = {
+    locally {
       val t = new Thread(s"jvm-stderr-drain-${process.pid}") {
         override def run(): Unit =
           try {
             var line = stderr.readLine()
             while (line != null) {
               stderrBuffer.addLast(line)
-              while (stderrBuffer.size > stderrBufferCap) stderrBuffer.pollFirst()
+              while (stderrBuffer.size > stderrBufferCap) stderrBuffer.pollFirst(): Unit
               line = stderr.readLine()
             }
           } catch { case NonFatal(_) => () }
       }
       t.setDaemon(true)
       t.start()
-      t
     }
 
     def isAlive: Boolean =
@@ -202,7 +200,7 @@ object JvmPool {
             try {
               var line = reader.readLine()
               while (line != null) {
-                buffer.synchronized(buffer += line)
+                buffer.synchronized(buffer += line): Unit
                 line = reader.readLine()
               }
             } catch { case NonFatal(_) => () }
@@ -210,7 +208,7 @@ object JvmPool {
         drainer.setDaemon(true)
         drainer.start()
         val finished = p.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)
-        if (!finished) p.destroyForcibly()
+        if (!finished) p.destroyForcibly(): Unit
         drainer.join(1000)
         buffer.synchronized(buffer.toList)
       } catch { case NonFatal(_) => Nil }
@@ -228,13 +226,13 @@ object JvmPool {
         process
           .descendants()
           .forEach(ph =>
-            try ph.destroyForcibly()
+            try ph.destroyForcibly(): Unit
             catch { case _: Exception => () }
           )
       catch { case NonFatal(_) => }
       process.destroyForcibly()
       try
-        process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
+        process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS): Unit
       catch { case NonFatal(_) => }
     }
 
@@ -243,7 +241,7 @@ object JvmPool {
       val sb = new StringBuilder
       var line = stderrBuffer.pollFirst()
       while (line != null) {
-        sb.append(line).append("\n")
+        sb.append(line).append("\n"): Unit
         line = stderrBuffer.pollFirst()
       }
       sb.toString()
@@ -346,11 +344,11 @@ object JvmPool {
             else
               List(javaPath.toString) ++ jvmOptions ++ List("-cp", cpString, runnerClass)
 
-          val pb = new ProcessBuilder(cmd: _*)
+          val pb = new ProcessBuilder(cmd*)
           pb.directory(cwdOverride.getOrElse(workingDirectory).toFile)
           pb.redirectErrorStream(false)
           if (useEnvClasspath) {
-            pb.environment().put("CLASSPATH", cpString)
+            pb.environment().put("CLASSPATH", cpString): Unit
           }
           environment.foreach { case (k, v) => pb.environment().put(k, v) }
 
@@ -364,7 +362,7 @@ object JvmPool {
         .flatTap(jvm => allJvms.update(_ + jvm))
         .flatTap(jvm =>
           waitForReady(jvm).onError { case _ =>
-            IO(spawnFailures.updateWith(jvm.key) { case Some(n) => Some(n + 1); case None => Some(1) })
+            IO(spawnFailures.updateWith(jvm.key) { case Some(n) => Some(n + 1); case None => Some(1) }).void
           }
         )
         .flatTap(jvm => IO(spawnFailures.remove(jvm.key))) // Reset on success

--- a/bleep-core/src/scala/bleep/testing/ReactiveTestRunner.scala
+++ b/bleep-core/src/scala/bleep/testing/ReactiveTestRunner.scala
@@ -11,7 +11,6 @@ import coursier._
 
 import java.nio.file.{Files, Path, Paths}
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
 
 /** Reactive test runner that starts tests as soon as their dependencies compile.
   *
@@ -111,7 +110,7 @@ object ReactiveTestRunner {
             )
           }
 
-          runSuites.flatMap { results =>
+          runSuites.flatMap { _ =>
             for {
               _ <- display.printSummary
               summary <- display.summary
@@ -268,9 +267,8 @@ object ReactiveTestRunner {
       threadDump <- threadDumpResult match {
         case Left((outcome, timerFiber)) =>
           // Thread dump completed - cancel timer and get result
-          timerFiber.cancel >> outcome.embedError.map { dump =>
-            IO(debugLog(s"Thread dump received for $suiteKey: ${dump.map(d => s"${d.threads.size} threads").getOrElse("None")}"))
-            dump
+          timerFiber.cancel >> outcome.embedError.flatMap { dump =>
+            IO(debugLog(s"Thread dump received for $suiteKey: ${dump.map(d => s"${d.threads.size} threads").getOrElse("None")}")).as(dump)
           }
         case Right((dumpFiber, _)) =>
           // Timer won - abandon thread dump attempt (don't wait for it)

--- a/bleep-core/src/scala/bleep/testing/SuiteScheduler.scala
+++ b/bleep-core/src/scala/bleep/testing/SuiteScheduler.scala
@@ -248,7 +248,7 @@ object SuiteScheduler {
   /** Result of a tick */
   case class TickResult(
       state: SuiteSchedulerState,
-      actions: List[SchedulerAction[_]]
+      actions: List[SchedulerAction[?]]
   )
 
   /** Apply a single event to the state */
@@ -360,8 +360,8 @@ object SuiteScheduler {
   /** Timeout for getting thread dump before giving up */
   private val ThreadDumpTimeoutMs = 5000L
 
-  private def checkTimeouts(state: SuiteSchedulerState, nowMs: Long): (SuiteSchedulerState, List[SchedulerAction[_]]) = {
-    var actions = List.empty[SchedulerAction[_]]
+  private def checkTimeouts(state: SuiteSchedulerState, nowMs: Long): (SuiteSchedulerState, List[SchedulerAction[?]]) = {
+    var actions = List.empty[SchedulerAction[?]]
     var updatedJvms = state.jvms
 
     state.jvms.foreach { case (jvmId, jvmState) =>
@@ -403,10 +403,10 @@ object SuiteScheduler {
     (state.copy(jvms = updatedJvms), actions)
   }
 
-  private def scheduleWork(state: SuiteSchedulerState, nowMs: Long): (SuiteSchedulerState, List[SchedulerAction[_]]) = {
+  private def scheduleWork(state: SuiteSchedulerState, nowMs: Long): (SuiteSchedulerState, List[SchedulerAction[?]]) = {
     if (!state.canScheduleWork) return (state, Nil)
 
-    var actions = List.empty[SchedulerAction[_]]
+    var actions = List.empty[SchedulerAction[?]]
     var updatedJvms = state.jvms
     var remainingQueue = state.pendingSuites
     var slotsUsed = 0

--- a/bleep-core/src/scala/bleep/testing/TestDiscovery.scala
+++ b/bleep-core/src/scala/bleep/testing/TestDiscovery.scala
@@ -4,6 +4,7 @@ import bleep.bsp.BuildServer
 import bleep.model.CrossProjectName
 import ch.epfl.scala.bsp4j
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 /** A discovered test suite ready to be executed */
@@ -42,7 +43,7 @@ object TestDiscovery {
     val params = new bsp4j.ScalaTestClassesParams(targets)
 
     val result: bsp4j.ScalaTestClassesResult =
-      server.buildTargetScalaTestClasses(params).get()
+      callScalaTestClasses(server, params)
 
     result.getItems.asScala.toList.flatMap { item =>
       val targetId = item.getTarget
@@ -88,7 +89,7 @@ object TestDiscovery {
     val params = new bsp4j.ScalaTestClassesParams(List(buildTarget).asJava)
 
     val result: bsp4j.ScalaTestClassesResult =
-      server.buildTargetScalaTestClasses(params).get()
+      callScalaTestClasses(server, params)
 
     result.getItems.asScala.toList.flatMap { item =>
       val framework = Option(item.getFramework).getOrElse("unknown")
@@ -103,6 +104,10 @@ object TestDiscovery {
       }
     }
   }
+
+  @nowarn("msg=buildTargetScalaTestClasses")
+  private def callScalaTestClasses(server: BuildServer, params: bsp4j.ScalaTestClassesParams): bsp4j.ScalaTestClassesResult =
+    server.buildTargetScalaTestClasses(params).get()
 
   /** Group discovered suites by project */
   def groupByProject(suites: List[DiscoveredSuite]): Map[CrossProjectName, List[DiscoveredSuite]] =

--- a/bleep-model/src/scala/bleep/BleepException.scala
+++ b/bleep-model/src/scala/bleep/BleepException.scala
@@ -80,7 +80,7 @@ object BleepException {
       case Right(value) => value
     }
 
-    def orThrowWithError[Th <: Throwable with L](error: String)(implicit ev0: L =:= Th, ev: BleepException.Not[Th]): R = e match {
+    def orThrowWithError[Th <: Throwable & L](error: String)(implicit ev0: L =:= Th, ev: BleepException.Not[Th]): R = e match {
       case Left(th)     => throw new BleepException.Cause[Th](th, error)
       case Right(value) => value
     }

--- a/bleep-model/src/scala/bleep/BleepFileCache.scala
+++ b/bleep-model/src/scala/bleep/BleepFileCache.scala
@@ -31,9 +31,9 @@ object BleepFileCache {
   /** Idempotent. Sets the JVM-wide HTTP/HTTPS connect/read timeouts unless the user already set them. */
   def ensureSystemPropertyDefaults(): Unit = {
     if (System.getProperty("sun.net.client.defaultConnectTimeout") == null)
-      System.setProperty("sun.net.client.defaultConnectTimeout", connectTimeoutMs.toString)
+      System.setProperty("sun.net.client.defaultConnectTimeout", connectTimeoutMs.toString): Unit
     if (System.getProperty("sun.net.client.defaultReadTimeout") == null)
-      System.setProperty("sun.net.client.defaultReadTimeout", readTimeoutMs.toString)
+      System.setProperty("sun.net.client.defaultReadTimeout", readTimeoutMs.toString): Unit
   }
 
   def apply(): FileCache[Task] = FileCache[Task]()

--- a/bleep-model/src/scala/bleep/FetchGoogleJavaFormat.scala
+++ b/bleep-model/src/scala/bleep/FetchGoogleJavaFormat.scala
@@ -1,7 +1,7 @@
 package bleep
 
-import coursier.cache.{CacheLogger, FileCache}
-import coursier.util.{Artifact, Task}
+import coursier.cache.CacheLogger
+import coursier.util.Artifact
 
 import java.nio.file.Path
 import scala.concurrent.duration.Duration

--- a/bleep-model/src/scala/bleep/FetchJvm.scala
+++ b/bleep-model/src/scala/bleep/FetchJvm.scala
@@ -1,6 +1,6 @@
 package bleep
 
-import coursier.cache.{ArchiveCache, CacheLogger, FileCache}
+import coursier.cache.{ArchiveCache, CacheLogger}
 import coursier.jvm.{JavaHome, JvmCache, JvmChannel}
 import coursier.util.Task
 

--- a/bleep-model/src/scala/bleep/FetchNode.scala
+++ b/bleep-model/src/scala/bleep/FetchNode.scala
@@ -1,6 +1,6 @@
 package bleep
 
-import coursier.cache.{ArchiveCache, CacheLogger, FileCache}
+import coursier.cache.{ArchiveCache, CacheLogger}
 import coursier.util.{Artifact, Task}
 
 import java.nio.file.Path

--- a/bleep-model/src/scala/bleep/FetchSbt.scala
+++ b/bleep-model/src/scala/bleep/FetchSbt.scala
@@ -1,6 +1,6 @@
 package bleep
 
-import coursier.cache.{ArchiveCache, CacheLogger, FileCache}
+import coursier.cache.{ArchiveCache, CacheLogger}
 import coursier.jvm.JvmChannel
 import coursier.util.{Artifact, Task}
 

--- a/bleep-model/src/scala/bleep/RelPath.scala
+++ b/bleep-model/src/scala/bleep/RelPath.scala
@@ -6,7 +6,6 @@ import java.nio.file.Path
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
 
-@scala.annotation.nowarn("cat=scala3-migration")
 case class RelPath private (segments: Array[String]) {
   def mapSegments(f: String => String): RelPath =
     RelPath(segments.map(f))

--- a/bleep-model/src/scala/bleep/bsp/BspBuildData.scala
+++ b/bleep-model/src/scala/bleep/bsp/BspBuildData.scala
@@ -38,9 +38,9 @@ object BspBuildData {
 
     // Map encoder/decoder for CrossProjectName keys
     private implicit val mapEncoder: Encoder[Map[model.CrossProjectName, List[Path]]] =
-      Encoder.encodeMap[model.CrossProjectName, List[Path]](model.CrossProjectName.keyEncodes, Encoder.encodeList[Path])
+      Encoder.encodeMap[model.CrossProjectName, List[Path]](using model.CrossProjectName.keyEncodes, Encoder.encodeList[Path])
     private implicit val mapDecoder: Decoder[Map[model.CrossProjectName, List[Path]]] =
-      Decoder.decodeMap[model.CrossProjectName, List[Path]](model.CrossProjectName.keyDecodes, Decoder.decodeList[Path])
+      Decoder.decodeMap[model.CrossProjectName, List[Path]](using model.CrossProjectName.keyDecodes, Decoder.decodeList[Path])
 
     implicit val encoder: Encoder[Payload] = deriveEncoder
     implicit val decoder: Decoder[Payload] = deriveDecoder

--- a/bleep-model/src/scala/bleep/internal/compat.scala
+++ b/bleep-model/src/scala/bleep/internal/compat.scala
@@ -26,7 +26,7 @@ object compat {
 
   implicit class ListCompatOps[A](private val as: List[A]) extends AnyVal {
     def maxOptionCompat[B >: A](implicit ord: Ordering[B]): Option[A] =
-      if (as.isEmpty) None else Some(as.max(ord))
+      if (as.isEmpty) None else Some(as.max(using ord))
   }
 
   implicit class IteratorCompatOps[A](private val as: Array[A]) extends AnyVal {

--- a/bleep-model/src/scala/bleep/model/AnnotationProcessorOptions.scala
+++ b/bleep-model/src/scala/bleep/model/AnnotationProcessorOptions.scala
@@ -27,7 +27,7 @@ object AnnotationProcessorOptions {
   val empty: AnnotationProcessorOptions = AnnotationProcessorOptions(SortedMap.empty)
 
   implicit val decodes: Decoder[AnnotationProcessorOptions] =
-    Decoder.decodeOption(Decoder.decodeMap[String, String].map(m => AnnotationProcessorOptions(SortedMap.from(m)))).map(_.getOrElse(empty))
+    Decoder.decodeOption(using Decoder.decodeMap[String, String].map(m => AnnotationProcessorOptions(SortedMap.from(m)))).map(_.getOrElse(empty))
 
   implicit val encodes: Encoder[AnnotationProcessorOptions] =
     Encoder.encodeMap[String, String].contramap(_.value)

--- a/bleep-model/src/scala/bleep/model/Authentications.scala
+++ b/bleep-model/src/scala/bleep/model/Authentications.scala
@@ -65,9 +65,9 @@ object Authentications {
             val uri = URI.create(uriStr)
             val entryResult =
               if (PrivateRepoScheme.isPrivateScheme(uri))
-                valueJson.as[AuthEntry.PrivateRepo](privateRepoCodec).map(x => x: AuthEntry)
+                valueJson.as[AuthEntry.PrivateRepo](using privateRepoCodec).map(x => x: AuthEntry)
               else
-                valueJson.as[Authentication](authenticationCodec).map(a => AuthEntry.Static(a): AuthEntry)
+                valueJson.as[Authentication](using authenticationCodec).map(a => AuthEntry.Static(a): AuthEntry)
             entryResult.map(entry => uri -> entry)
           }
           results.foldLeft(Right(Map.empty[URI, AuthEntry]): Either[DecodingFailure, Map[URI, AuthEntry]]) { case (acc, entry) =>
@@ -88,7 +88,7 @@ object Authentications {
         }
         uri.toString -> valueJson
       }
-      Json.obj(fields: _*)
+      Json.obj(fields*)
     }
 
   implicit val codec: Codec[Authentications] =

--- a/bleep-model/src/scala/bleep/model/Build.scala
+++ b/bleep-model/src/scala/bleep/model/Build.scala
@@ -151,15 +151,15 @@ object Build {
 
     // Explicit encoder/decoder for Map[CrossProjectName, Project]
     private implicit val mapCPNProjectEncoder: Encoder[Map[CrossProjectName, Project]] =
-      Encoder.encodeMap[CrossProjectName, Project](CrossProjectName.keyEncodes, Project.encodes)
+      Encoder.encodeMap[CrossProjectName, Project](using CrossProjectName.keyEncodes, Project.encodes)
     private implicit val mapCPNProjectDecoder: Decoder[Map[CrossProjectName, Project]] =
-      Decoder.decodeMap[CrossProjectName, Project](CrossProjectName.keyDecodes, Project.decodes)
+      Decoder.decodeMap[CrossProjectName, Project](using CrossProjectName.keyDecodes, Project.decodes)
 
     // Explicit encoder/decoder for Map[ScriptName, JsonList[ScriptDef]]
     private implicit val mapScriptEncoder: Encoder[Map[ScriptName, JsonList[ScriptDef]]] =
-      Encoder.encodeMap[ScriptName, JsonList[ScriptDef]](ScriptName.keyEncodes, JsonList.encodes[ScriptDef])
+      Encoder.encodeMap[ScriptName, JsonList[ScriptDef]](using ScriptName.keyEncodes, JsonList.encodes[ScriptDef])
     private implicit val mapScriptDecoder: Decoder[Map[ScriptName, JsonList[ScriptDef]]] =
-      Decoder.decodeMap[ScriptName, JsonList[ScriptDef]](ScriptName.keyDecodes, JsonList.decodes[ScriptDef])
+      Decoder.decodeMap[ScriptName, JsonList[ScriptDef]](using ScriptName.keyDecodes, JsonList.decodes[ScriptDef])
 
     implicit val encodes: Encoder[Exploded] = deriveEncoder
     implicit val decodes: Decoder[Exploded] = deriveDecoder

--- a/bleep-model/src/scala/bleep/model/BuildFile.scala
+++ b/bleep-model/src/scala/bleep/model/BuildFile.scala
@@ -28,10 +28,10 @@ object BuildFile {
         templateIdDecoder = TemplateId.decoder(templateIds)
         projectNames <- c.downField("projects").as[Option[JsonObject]].map(_.fold(Iterable.empty[ProjectName])(_.keys.map(ProjectName.apply)))
         projectNameDecoder = ProjectName.decoder(projectNames)
-        projectDecoder = Project.decodes(templateIdDecoder, projectNameDecoder)
+        projectDecoder = Project.decodes(using templateIdDecoder, projectNameDecoder)
 
-        templates <- c.downField("templates").as[JsonMap[TemplateId, Project]](JsonMap.decodes(TemplateId.keyDecodes, projectDecoder))
-        projects <- c.downField("projects").as[JsonMap[ProjectName, Project]](JsonMap.decodes(ProjectName.keyDecodes, projectDecoder))
+        templates <- c.downField("templates").as[JsonMap[TemplateId, Project]](using JsonMap.decodes(using TemplateId.keyDecodes, projectDecoder))
+        projects <- c.downField("projects").as[JsonMap[ProjectName, Project]](using JsonMap.decodes(using ProjectName.keyDecodes, projectDecoder))
         scripts <- c.downField("scripts").as[JsonMap[ScriptName, JsonList[ScriptDef]]]
         resolvers <- c.downField("resolvers").as[JsonList[Repository]]
         jvm <- c.downField("jvm").as[Option[Jvm]]

--- a/bleep-model/src/scala/bleep/model/EnvironmentVars.scala
+++ b/bleep-model/src/scala/bleep/model/EnvironmentVars.scala
@@ -24,7 +24,7 @@ object EnvironmentVars {
   val empty: EnvironmentVars = EnvironmentVars(SortedMap.empty)
 
   implicit val decodes: Decoder[EnvironmentVars] =
-    Decoder.decodeOption(Decoder.decodeMap[String, String].map(m => EnvironmentVars(SortedMap.from(m)))).map(_.getOrElse(empty))
+    Decoder.decodeOption(using Decoder.decodeMap[String, String].map(m => EnvironmentVars(SortedMap.from(m)))).map(_.getOrElse(empty))
 
   implicit val encodes: Encoder[EnvironmentVars] =
     Encoder.encodeMap[String, String].contramap(_.value)

--- a/bleep-model/src/scala/bleep/model/JsonList.scala
+++ b/bleep-model/src/scala/bleep/model/JsonList.scala
@@ -40,7 +40,7 @@ object JsonList {
         )
       } yield ts
     )
-    Decoder.decodeOption(base).map(_.getOrElse(empty))
+    Decoder.decodeOption(using base).map(_.getOrElse(empty))
   }
 
   implicit def encodes[T: Encoder]: Encoder[JsonList[T]] =

--- a/bleep-model/src/scala/bleep/model/JsonMap.scala
+++ b/bleep-model/src/scala/bleep/model/JsonMap.scala
@@ -52,7 +52,7 @@ object JsonMap {
   def empty[K, V <: SetLike[V]]: JsonMap[K, V] = JsonMap(Map.empty)
 
   implicit def decodes[K: KeyDecoder, V <: SetLike[V]: Decoder]: Decoder[JsonMap[K, V]] =
-    Decoder.decodeOption(Decoder.decodeMap[K, V].map(JsonMap.apply)).map(_.getOrElse(empty))
+    Decoder.decodeOption(using Decoder.decodeMap[K, V].map(JsonMap.apply)).map(_.getOrElse(empty))
 
   implicit def encodes[K: KeyEncoder, V <: SetLike[V]: Encoder]: Encoder[JsonMap[K, V]] =
     Encoder.encodeMap[K, V].contramap(_.value)

--- a/bleep-model/src/scala/bleep/model/JsonSet.scala
+++ b/bleep-model/src/scala/bleep/model/JsonSet.scala
@@ -49,7 +49,7 @@ object JsonSet {
         )
       } yield ts
     )
-    Decoder.decodeOption(base).map(_.getOrElse(empty))
+    Decoder.decodeOption(using base).map(_.getOrElse(empty))
   }
 
   implicit def encodes[T: Encoder]: Encoder[JsonSet[T]] =

--- a/bleep-model/src/scala/bleep/model/Kotlin.scala
+++ b/bleep-model/src/scala/bleep/model/Kotlin.scala
@@ -55,8 +55,8 @@ case class Kotlin(
       options = options.union(other.options),
       jvmTarget = jvmTarget.orElse(other.jvmTarget),
       compilerPlugins = compilerPlugins.union(other.compilerPlugins),
-      js = List(js, other.js).flatten.reduceOption(_ union _),
-      native = List(native, other.native).flatten.reduceOption(_ union _)
+      js = List(js, other.js).flatten.reduceOption(_ `union` _),
+      native = List(native, other.native).flatten.reduceOption(_ `union` _)
     )
 
   override def isEmpty: Boolean =

--- a/bleep-model/src/scala/bleep/model/Project.scala
+++ b/bleep-model/src/scala/bleep/model/Project.scala
@@ -90,17 +90,17 @@ case class Project(
       resources = resources.union(other.resources),
       dependencies = dependencies.union(other.dependencies),
       jars = jars.union(other.jars),
-      java = List(java, other.java).flatten.reduceOption(_ union _),
-      scala = List(scala, other.scala).flatten.reduceOption(_ union _),
-      kotlin = List(kotlin, other.kotlin).flatten.reduceOption(_ union _),
+      java = List(java, other.java).flatten.reduceOption(_ `union` _),
+      scala = List(scala, other.scala).flatten.reduceOption(_ `union` _),
+      kotlin = List(kotlin, other.kotlin).flatten.reduceOption(_ `union` _),
       // may throw
-      platform = List(platform, other.platform).flatten.reduceOption(_ union _),
+      platform = List(platform, other.platform).flatten.reduceOption(_ `union` _),
       isTestProject = isTestProject.orElse(other.isTestProject),
       testFrameworks = testFrameworks.union(other.testFrameworks),
       sourcegen = sourcegen.union(other.sourcegen),
       libraryVersionSchemes = libraryVersionSchemes.union(other.libraryVersionSchemes),
       ignoreEvictionErrors = ignoreEvictionErrors.orElse(other.ignoreEvictionErrors),
-      publish = List(publish, other.publish).flatten.reduceOption(_ union _)
+      publish = List(publish, other.publish).flatten.reduceOption(_ `union` _)
     )
 
   override def isEmpty: Boolean = this match {

--- a/bleep-model/src/scala/bleep/model/Scala.scala
+++ b/bleep-model/src/scala/bleep/model/Scala.scala
@@ -33,7 +33,7 @@ case class Scala(
     Scala(
       version = version.orElse(other.version),
       options = options.union(other.options),
-      setup = List(setup, other.setup).flatten.reduceOption(_ union _),
+      setup = List(setup, other.setup).flatten.reduceOption(_ `union` _),
       compilerPlugins = compilerPlugins.union(other.compilerPlugins),
       strict = strict.orElse(other.strict)
     )

--- a/bleep-model/src/scala/bleep/rewrites/BuildPatch.scala
+++ b/bleep-model/src/scala/bleep/rewrites/BuildPatch.scala
@@ -120,8 +120,8 @@ object BuildPatch {
         val remainingValues =
           crossProjectNamesList
             .map(build.explodedProjects.apply)
-            .optReduce(_ intersectDropEmpty _)
-            .foldLeft(values)(_ removeAll _)
+            .optReduce(_ `intersectDropEmpty` _)
+            .foldLeft(values)(_ `removeAll` _)
 
         if (remainingValues.isEmpty) build
         else
@@ -183,7 +183,7 @@ object BuildPatch {
         build.explodedProjects
           // note: all cross projects are not necessarily chosen. this finds all
           .collect { case (model.CrossProjectName(`projectName`, _), p) => p }
-          .reduce(_ intersect _)
+          .reduce(_ `intersect` _)
 
       values.removeAll(sharedBetweenCrossProjects)
     }
@@ -285,7 +285,7 @@ object BuildPatch {
 
     val newProjects = build.file.projects.map { case (name, project) =>
       val beforeCross = {
-        val project1 = pushedValues.get(model.CrossProjectName(name, None)).foldLeft(project)(_ union _)
+        val project1 = pushedValues.get(model.CrossProjectName(name, None)).foldLeft(project)(_ `union` _)
 
         if (!affected.projectNames(name)) project1
         else {

--- a/bleep-model/src/scala/bleep/rewrites/BuildRewrite.scala
+++ b/bleep-model/src/scala/bleep/rewrites/BuildRewrite.scala
@@ -85,7 +85,7 @@ object BuildRewrite {
       val newProjects = bf.projects.map {
         // non-empty cross, as well as all represented in current project (as opposed to being all inherited)
         case (name, p) if p.cross.value.size >= 2 && patched.explodedProjectsByName(name).size == p.cross.value.size =>
-          val shared = p.cross.value.values.reduce(_ intersect _)
+          val shared = p.cross.value.values.reduce(_ `intersect` _)
           val newCross = p.cross.map { case (crossId, p) => (crossId, p.removeAll(shared)) }
           (name, p.union(shared).copy(cross = newCross))
         case unchanged => unchanged

--- a/bleep-nosbt/src/scala/bleep/nosbt/io/IO.scala
+++ b/bleep-nosbt/src/scala/bleep/nosbt/io/IO.scala
@@ -60,8 +60,8 @@ object IO {
   def relativize(base: File, file: File): Option[String] = {
     val basePath = (if (base.isAbsolute) base else base.getCanonicalFile).toPath
     val filePath = (if (file.isAbsolute) file else file.getCanonicalFile).toPath
-    if ((filePath startsWith basePath) || (filePath.normalize() startsWith basePath.normalize())) {
-      val relativePath = catching(classOf[IllegalArgumentException]) opt (basePath relativize filePath)
+    if ((filePath `startsWith` basePath) || (filePath.normalize() `startsWith` basePath.normalize())) {
+      val relativePath = catching(classOf[IllegalArgumentException]) opt (basePath `relativize` filePath)
       relativePath map (_.toString)
     } else None
   }

--- a/bleep-nosbt/src/scala/bleep/nosbt/librarymanagement/ivy/Credentials.scala
+++ b/bleep-nosbt/src/scala/bleep/nosbt/librarymanagement/ivy/Credentials.scala
@@ -50,12 +50,12 @@ object Credentials {
     } else
       Left("Credentials file " + path + " does not exist")
 
-  private[this] val RealmKeys = List("realm")
-  private[this] val HostKeys = List("host", "hostname")
-  private[this] val UserKeys = List("user", "user.name", "username")
-  private[this] val PasswordKeys = List("password", "pwd", "pass", "passwd")
+  private val RealmKeys = List("realm")
+  private val HostKeys = List("host", "hostname")
+  private val UserKeys = List("user", "user.name", "username")
+  private val PasswordKeys = List("password", "pwd", "pass", "passwd")
 
-  private[this] def read(from: File): Map[String, String] = {
+  private def read(from: File): Map[String, String] = {
     val properties = new java.util.Properties
     IO.load(properties, from)
     val b = Map.newBuilder[String, String]

--- a/bleep-tests/src/scala/bleep/TemplateTest.scala
+++ b/bleep-tests/src/scala/bleep/TemplateTest.scala
@@ -67,7 +67,7 @@ class TemplateTest extends SnapshotTest {
     val content = Files.readString(path)
 
     implicit val foo: Decoder[model.Project] =
-      model.Project.decodes(model.TemplateId.decoder(Nil), Decoder[String].map(model.ProjectName.apply))
+      model.Project.decodes(using model.TemplateId.decoder(Nil), Decoder[String].map(model.ProjectName.apply))
 
     val Right(projects) = io.circe.parser.decode[Map[model.CrossProjectName, model.Project]](content): @unchecked
     run(projects, "bug.yaml", ignoreWhenInferringTemplates = Set(b.name))

--- a/bleep-tests/src/scala/bleep/testing/GenBloopFiles.scala
+++ b/bleep-tests/src/scala/bleep/testing/GenBloopFiles.scala
@@ -16,7 +16,7 @@ object GenBloopFiles {
   def encodedFiles(buildPaths: BuildPaths, resolved: ResolveProjects.Projects): Map[Path, String] =
     resolved.map { case (projectName, lazyResolved) =>
       val bloopFile = BloopConversions.toBloopConfig(lazyResolved.forceGet)
-      val string = writeToString(bloopFile, WriterConfig.withIndentionStep(2))(ConfigCodecs.codecFile)
+      val string = writeToString(bloopFile, WriterConfig.withIndentionStep(2))(using ConfigCodecs.codecFile)
       val file = buildPaths.bloopFile(projectName)
       (file, string)
     }

--- a/bleep-tests/src/scala/com/monovore/decline/CompleterTest.scala
+++ b/bleep-tests/src/scala/com/monovore/decline/CompleterTest.scala
@@ -92,10 +92,10 @@ class CompleterTest extends AnyFunSuite with TypeCheckedTripleEquals {
         Opts.subcommand("cmd2", "")(
           (
             Opts
-              .options("platform", platformHelp, metavar = platformMetavar, short = "p")(Argument.fromMap(platformMetavar, platforms))
+              .options("platform", platformHelp, metavar = platformMetavar, short = "p")(using Argument.fromMap(platformMetavar, platforms))
               .withDefault(NonEmptyList.of("jvm")),
             Opts
-              .options("foo", fooHelp, metavar = fooMetavar, short = "f")(Argument.fromMap(fooMetavar, foos))
+              .options("foo", fooHelp, metavar = fooMetavar, short = "f")(using Argument.fromMap(fooMetavar, foos))
               .withDefault(NonEmptyList.of("one")),
             Opts.argument[String]("bar")
           ).mapN((_, _, _) => ())

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -412,5 +412,5 @@ templates:
     libraryVersionSchemes: org.scala-lang.modules::scala-parallel-collections:always
   template-scala-3:
     scala:
-      options: -source 3.4 -no-indent -Wconf:name=PatternMatchExhaustivity:error
+      options: -source 3.8 -no-indent -Wconf:name=PatternMatchExhaustivity:error
       version: 3.8.3

--- a/scripts-dev/src/scala/bleep/scripts/dev/GenCliDocs.scala
+++ b/scripts-dev/src/scala/bleep/scripts/dev/GenCliDocs.scala
@@ -2,7 +2,7 @@ package bleep.scripts.dev
 
 import bleep.{model, BleepScript, Commands, Started}
 import com.monovore.decline.CliDocsWalker
-import com.monovore.decline.CliDocsWalker.{ArgumentDoc, CommandDoc, FlagDoc}
+import com.monovore.decline.CliDocsWalker.{CommandDoc, FlagDoc}
 
 import java.nio.file.{Files, Path}
 import scala.jdk.CollectionConverters.*
@@ -113,7 +113,7 @@ object GenCliDocs extends BleepScript("GenCliDocs") {
     sb.append("---\n\n")
     sb.append(autoGenBanner)
     sb.append(s"# `$title`\n\n")
-    sb.append(renderDescription(cmd.description)).append("\n\n")
+    sb.append(renderDescription(cmd.description)).append("\n\n"): Unit
     renderBody(cmd, sb, parentPath, headingLevel = 2)
     sb.toString
   }
@@ -129,7 +129,7 @@ object GenCliDocs extends BleepScript("GenCliDocs") {
     sb.append("---\n\n")
     sb.append(autoGenBanner)
     sb.append(s"# `$parentPath`\n\n")
-    sb.append(renderDescription(cmd.description)).append("\n\n")
+    sb.append(renderDescription(cmd.description)).append("\n\n"): Unit
 
     sb.append("## Synopsis\n\n")
     sb.append("```bash\n")
@@ -171,7 +171,7 @@ object GenCliDocs extends BleepScript("GenCliDocs") {
       sb.append("```bash\n")
       sb.append(parentPath)
       if (subPart.nonEmpty) sb.append(subPart)
-      if (argsPart.nonEmpty) sb.append(" ").append(argsPart)
+      if (argsPart.nonEmpty) sb.append(" ").append(argsPart): Unit
       if (flagsPart.nonEmpty) sb.append(flagsPart)
       sb.append("\n```\n\n")
     }
@@ -198,7 +198,7 @@ object GenCliDocs extends BleepScript("GenCliDocs") {
       cmd.subcommands.foreach { sub =>
         val subPath = s"$parentPath ${sub.name}"
         sb.append(s"$h `$subPath`\n\n")
-        if (sub.description.trim.nonEmpty) sb.append(renderDescription(sub.description)).append("\n\n")
+        if (sub.description.trim.nonEmpty) sb.append(renderDescription(sub.description)).append("\n\n"): Unit
         renderBody(sub, sb, subPath, headingLevel + 1)
       }
     }


### PR DESCRIPTION
## Summary

Scala 3-only build cleanup. Bumps scalafmt to 3.11.1, runs `bleep fmt` across the entire tree (now including `liberated/`) in scala3 dialect, applies `-source 3.4-migration -rewrite` so `private[this]`, context bounds, splat syntax, etc. match Scala 3.4 idioms, and eliminates every warning the build then emitted (132 → 0).

Bumps every `liberated/*` submodule pointer to the corresponding squashed reformat commit (one commit per submodule, freshly pushed to their respective default branches).

## How warnings were addressed

- Removed unused params/locals/private members at definition **and** call sites.
- Replaced deprecated APIs: `JsonParser.parseString` for `new JsonParser().parse`, `OSMXBean.getCpuLoad` for `getSystemCpuLoad`.
- Converted three non-local `return` patterns to plain `if/else` / inverted `match`.
- Ascribed discarded non-Unit values with `: Unit`; used `.get` on `Using { ... }` blocks to fail loudly (per the project's "no fallback code" rule).
- Switched `case _ =>` to `case null =>` for matches over closed hierarchies (ryddig `Logger`, `LogLevel`).
- Replaced wildcard `_` in type positions with `?` (Scala 3 syntax).
- Method-call form (`.shouldBe(x)`) instead of alphanumeric infix in tests.
- Targeted `@nowarn` only where the deprecation has no real replacement: BSP `buildTargetScalaTestClasses` / `buildTargetScalaMainClasses` (bleep is both the BSP server and client, so we keep using these), `ThreadDeath` (still needed in fatal-error matchers), PGP `EC` algorithm tag (constant carried for keyring compatibility).

## Test plan

- [x] `bleep clean && bleep compile` — green, 0 warnings (was 132).
- [x] `bleep fmt` — clean.
- [ ] CI: full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)