### PR TITLE
Warn when sources sit under sbt/Maven layout that bleep won't pick up

### DIFF
--- a/bleep-core/src/scala/bleep/bootstrap.scala
+++ b/bleep-core/src/scala/bleep/bootstrap.scala
@@ -85,6 +85,8 @@ object bootstrap {
               Some(chosen).filter(_.nonEmpty)
             }
 
+          internal.CheckMisplacedSources(pre.logger, pre.buildPaths, finalBuild)
+
           val td = System.currentTimeMillis() - t0
           pre.logger.info(s"bootstrapped in $td ms")
 

--- a/bleep-core/src/scala/bleep/internal/CheckMisplacedSources.scala
+++ b/bleep-core/src/scala/bleep/internal/CheckMisplacedSources.scala
@@ -1,0 +1,53 @@
+package bleep
+package internal
+
+import ryddig.Logger
+
+import java.nio.file.{Files, Path}
+
+/** Warns when a project has source files under sbt/Maven-style `src/{main,test}/{scala,java,kotlin}/` paths that bleep is not picking up.
+  *
+  * Bleep's default source layout resolves to `src/<lang>/` (because `sbt-scope` defaults to empty), so files placed under `src/main/<lang>/` or
+  * `src/test/<lang>/` are silently invisible to the build unless the user explicitly sets `sources:` or `sbt-scope:`. This check surfaces that situation early
+  * with an actionable message instead of letting the user discover it via a missing-class error at runtime.
+  */
+object CheckMisplacedSources {
+
+  private case class Suspect(scope: String, lang: String, extension: String)
+
+  private val suspects: List[Suspect] = for {
+    scope <- List("main", "test")
+    (lang, ext) <- List("scala" -> ".scala", "java" -> ".java", "kotlin" -> ".kt")
+  } yield Suspect(scope, lang, ext)
+
+  def apply(logger: Logger, buildPaths: BuildPaths, build: model.Build): Unit =
+    build.explodedProjects.foreach { case (crossName, project) =>
+      val projectPaths = buildPaths.project(crossName, project)
+      val coveredDirs: Set[Path] = projectPaths.sourcesDirs.all.toSet ++ projectPaths.resourcesDirs.all.toSet
+
+      // A project that has either an explicit `sources:` list OR an explicit `sbt-scope:` has opted into custom layout — assume the user knows what they're
+      // doing and skip the heuristic entirely.
+      val hasUserOverride = project.sources.values.nonEmpty || project.`sbt-scope`.isDefined
+      if (!hasUserOverride) {
+        suspects.foreach { suspect =>
+          val candidate = projectPaths.dir / "src" / suspect.scope / suspect.lang
+          if (Files.isDirectory(candidate) && !coveredDirs.contains(candidate) && containsSourceFile(candidate, suspect.extension)) {
+            logger
+              .withContext("project", crossName.value)
+              .withContext("path", candidate.toString)
+              .warn(
+                s"found ${suspect.lang} sources under sbt/Maven-style 'src/${suspect.scope}/${suspect.lang}/' that bleep is NOT picking up. " +
+                  s"Either move them to 'src/${suspect.lang}/' (bleep's default), set `sources: ./src/${suspect.scope}/${suspect.lang}` " +
+                  s"on this project, or set `sbt-scope: ${suspect.scope}` to opt into the sbt-style layout."
+              )
+          }
+        }
+      }
+    }
+
+  private def containsSourceFile(dir: Path, extension: String): Boolean = {
+    val stream = Files.walk(dir)
+    try stream.anyMatch(p => Files.isRegularFile(p) && p.toString.endsWith(extension))
+    finally stream.close()
+  }
+}

--- a/bleep-tests/src/scala/bleep/CheckMisplacedSourcesTest.scala
+++ b/bleep-tests/src/scala/bleep/CheckMisplacedSourcesTest.scala
@@ -1,0 +1,137 @@
+package bleep
+
+import bleep.internal.{CheckMisplacedSources, FileUtils}
+import org.scalatest.funsuite.AnyFunSuite
+import ryddig.LogLevel
+
+import java.nio.file.{Files, Path, Paths}
+
+class CheckMisplacedSourcesTest extends AnyFunSuite {
+
+  private val prelude =
+    """$schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
+      |$version: dev
+      |""".stripMargin
+
+  private def runCheck(yaml: String, files: List[String]): List[String] = {
+    val tempDir = Files.createTempDirectory("bleep-misplaced-")
+    try {
+      Files.writeString(tempDir.resolve("bleep.yaml"), prelude ++ yaml)
+      files.foreach { rel =>
+        val target = tempDir.resolve(rel)
+        Files.createDirectories(target.getParent)
+        Files.writeString(target, "")
+      }
+
+      val existing = BuildLoader.find(tempDir).existing.orThrow
+      val build = model.Build.FileBacked(existing.buildFile.forceGet.orThrow)
+      val buildPaths = BuildPaths(cwd = tempDir, existing, model.BuildVariant.Normal)
+
+      val logger = ThreadSafeStoringLogger().withMinLogLevel(LogLevel.debug)
+      CheckMisplacedSources(logger, buildPaths, build)
+      logger.underlying.toList.filter(_.metadata.logLevel == LogLevel.warn).map(_.message.plainText)
+    } finally FileUtils.deleteDirectory(tempDir)
+  }
+
+  private val kotlinYaml =
+    """projects:
+      |  myapp:
+      |    source-layout: kotlin
+      |    kotlin:
+      |      version: 2.1.20
+      |    platform:
+      |      name: jvm
+      |""".stripMargin
+
+  test("kotlin source under src/main/kotlin warns") {
+    val warns = runCheck(kotlinYaml, List("myapp/src/main/kotlin/test/Foo.kt"))
+    assert(warns.size === 1, warns)
+    assert(warns.head.contains("kotlin"))
+    assert(warns.head.contains("src/main/kotlin"))
+  }
+
+  test("kotlin source at the correct src/kotlin does not warn") {
+    val warns = runCheck(kotlinYaml, List("myapp/src/kotlin/test/Foo.kt"))
+    assert(warns === Nil)
+  }
+
+  test("empty src/main/kotlin directory does not warn") {
+    val tempDir = Files.createTempDirectory("bleep-misplaced-empty-")
+    try {
+      Files.createDirectories(tempDir.resolve("myapp/src/main/kotlin/test"))
+      Files.writeString(tempDir.resolve("bleep.yaml"), prelude ++ kotlinYaml)
+      val existing = BuildLoader.find(tempDir).existing.orThrow
+      val build = model.Build.FileBacked(existing.buildFile.forceGet.orThrow)
+      val buildPaths = BuildPaths(cwd = tempDir, existing, model.BuildVariant.Normal)
+      val logger = ThreadSafeStoringLogger().withMinLogLevel(LogLevel.debug)
+      CheckMisplacedSources(logger, buildPaths, build)
+      val warns = logger.underlying.toList.filter(_.metadata.logLevel == LogLevel.warn)
+      assert(warns === Nil)
+    } finally FileUtils.deleteDirectory(tempDir)
+  }
+
+  test("project with explicit sources: override does not warn") {
+    val yaml =
+      """projects:
+        |  myapp:
+        |    source-layout: kotlin
+        |    kotlin:
+        |      version: 2.1.20
+        |    platform:
+        |      name: jvm
+        |    sources: ./src/main/kotlin
+        |""".stripMargin
+    val warns = runCheck(yaml, List("myapp/src/main/kotlin/test/Foo.kt"))
+    assert(warns === Nil)
+  }
+
+  test("project with sbt-scope: main does not warn") {
+    val yaml =
+      """projects:
+        |  myapp:
+        |    source-layout: kotlin
+        |    sbt-scope: main
+        |    kotlin:
+        |      version: 2.1.20
+        |    platform:
+        |      name: jvm
+        |""".stripMargin
+    val warns = runCheck(yaml, List("myapp/src/main/kotlin/test/Foo.kt"))
+    assert(warns === Nil)
+  }
+
+  test("java source under src/main/java warns") {
+    val yaml =
+      """projects:
+        |  myapp:
+        |    java: {}
+        |    platform:
+        |      name: jvm
+        |""".stripMargin
+    val warns = runCheck(yaml, List("myapp/src/main/java/test/Foo.java"))
+    assert(warns.size === 1, warns)
+    assert(warns.head.contains("java"))
+    assert(warns.head.contains("src/main/java"))
+  }
+
+  test("scala source under src/main/scala warns") {
+    val yaml =
+      """projects:
+        |  myapp:
+        |    scala:
+        |      version: 3.3.3
+        |    platform:
+        |      name: jvm
+        |""".stripMargin
+    val warns = runCheck(yaml, List("myapp/src/main/scala/test/Foo.scala"))
+    assert(warns.size === 1, warns)
+    assert(warns.head.contains("scala"))
+    assert(warns.head.contains("src/main/scala"))
+  }
+
+  test("src/test/<lang> is also caught") {
+    val warns = runCheck(kotlinYaml, List("myapp/src/test/kotlin/test/Foo.kt"))
+    assert(warns.size === 1, warns)
+    assert(warns.head.contains("src/test/kotlin"))
+  }
+}


### PR DESCRIPTION
## Summary

- Best-effort heuristic at bootstrap: for each project without an explicit \`sources:\` or \`sbt-scope:\`, scan for the six common sbt/Maven-style source paths (\`src/{main,test}/{scala,java,kotlin}\`). If any exists, contains at least one source file, and is not already in the project's resolved \`sourcesDirs\` → emit one \`warn\` per offender pointing at the file and listing three fixes (move, set \`sources:\`, or set \`sbt-scope:\`).
- Catches the exact footgun that silently neutered \`KotlinIT\` for months. Until #595 lands, \`KotlinIT\` files at \`src/main/kotlin/\` are never compiled and the suite passes as a no-op. With this PR, that situation is loud at bootstrap.
- Cost: at most 6 \`Files.isDirectory\` probes per project, then one short-circuited \`Files.walk(...).anyMatch(...)\` per existing suspect dir. Zero false positives on bleep's own multi-project build.

## Relationship to #595

This PR catches the layout footgun in general; #595 fixes the specific \`KotlinIT\` paths that exposed it. They are independent — either can land first. If #595 lands first, the suspect-paths check has nothing in this repo to warn about; if this lands first, \`KotlinIT\` runs will print warnings until #595 merges (tests still pass; warnings are not errors).

## Test plan

- [x] New \`CheckMisplacedSourcesTest\` with 8 unit cases (kotlin/java/scala warn; correct layout no-warn; empty dir no-warn; \`sources:\` override no-warn; \`sbt-scope: main\` no-warn; \`src/test/<lang>\` also caught). Suite passes in 628ms.
- [x] Smoke-tested on bleep's own multi-project build — no false positives across the dozens of projects with mixed \`sources:\` overrides and default layouts.
- [x] \`bleep fmt --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)