### PR TITLE
Fix zinc under-invalidation, silent test-runner zeros, OOM bricking, and fork storms

### DIFF
--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
@@ -366,10 +366,7 @@ object BleepBspProtocol {
     case class SuiteFinished(
         project: CrossProjectName,
         suite: SuiteName,
-        passed: Int,
-        failed: Int,
-        skipped: Int,
-        ignored: Int,
+        outcome: SuiteOutcome,
         durationMs: Long,
         timestamp: Long
     ) extends Event

--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/SuiteOutcome.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/SuiteOutcome.scala
@@ -1,0 +1,107 @@
+package bleep.bsp.protocol
+
+import io.circe._
+import io.circe.syntax._
+
+/** The terminal outcome of running one test suite.
+  *
+  * Replaces the old `(passed, failed, skipped, ignored)` tuple, whose all-zero value meant three unrelated things at once — a suite with no tests, a suite
+  * whose tests never ran, and an errored suite — all of which a caller then had to disambiguate with ad-hoc count arithmetic. The distinction is only knowable
+  * at the forked runner (it alone sees whether the framework produced tests and whether they executed), so it is captured there and carried verbatim to the
+  * summary.
+  *
+  * Note the level: this is about ONE suite. A whole project with zero *discovered* suites is a success and never produces a SuiteOutcome at all — that case is
+  * the absence of suites, not an [[SuiteOutcome.Empty]] suite.
+  */
+sealed trait SuiteOutcome {
+
+  /** True when this suite must not count as a passing suite: it failed tests, ran nothing, matched no framework, or errored. */
+  def isFailure: Boolean = this match {
+    case e: SuiteOutcome.Executed => e.failed > 0
+    case _                        => true // Empty, NoFrameworkMatched, Errored are all failures
+  }
+
+  // Count accessors — non-zero only for Executed. Convenience for display/report sites that aggregate.
+  def passedCount: Int = this match { case e: SuiteOutcome.Executed => e.passed; case _ => 0 }
+  def failedCount: Int = this match { case e: SuiteOutcome.Executed => e.failed; case _ => 0 }
+  def skippedCount: Int = this match { case e: SuiteOutcome.Executed => e.skipped; case _ => 0 }
+  def ignoredCount: Int = this match { case e: SuiteOutcome.Executed => e.ignored; case _ => 0 }
+}
+
+object SuiteOutcome {
+
+  /** The framework executed tests; counts are authoritative. By construction `passed + failed + skipped + ignored > 0` — a completed suite that produced no
+    * test events is [[Empty]], not `Executed(0,0,0,0)`.
+    */
+  case class Executed(passed: Int, failed: Int, skipped: Int, ignored: Int) extends SuiteOutcome
+
+  /** The framework recognized the suite class but it registered/ran zero tests (an empty suite). A defect, not a pass. */
+  case object Empty extends SuiteOutcome
+
+  /** No engine claimed the suite class — e.g. a JUnit 4 (`@org.junit.Test`) class with no junit-vintage-engine on the test classpath. A misconfiguration. */
+  case object NoFrameworkMatched extends SuiteOutcome
+
+  /** The suite could not run to completion: a class-load/link error, or a Throwable escaped the framework's task execution. */
+  case class Errored(message: String, throwable: Option[String]) extends SuiteOutcome
+
+  /** Build an outcome from bare counts. Used by runners that only produce counts (Scala.js/Native/Kotlin): all-zero means the suite ran nothing → [[Empty]],
+    * never a silent pass.
+    */
+  def fromCounts(passed: Int, failed: Int, skipped: Int, ignored: Int): SuiteOutcome =
+    if (passed + failed + skipped + ignored == 0) Empty
+    else Executed(passed, failed, skipped, ignored)
+
+  /** Wire discriminator string for an outcome — the inverse of the `kind` field [[fromWire]] reads. */
+  def tagOf(o: SuiteOutcome): String = o match {
+    case _: Executed        => "executed"
+    case Empty              => "empty"
+    case NoFrameworkMatched => "noFrameworkMatched"
+    case _: Errored         => "errored"
+  }
+
+  /** Parse the forked runner's wire discriminator (see `TestProtocol.encodeSuite*`). Counts are only consulted for `"executed"`. */
+  def fromWire(kind: String, passed: Int, failed: Int, skipped: Int, ignored: Int, message: Option[String], throwable: Option[String]): SuiteOutcome =
+    kind match {
+      case "executed"           => Executed(passed, failed, skipped, ignored)
+      case "empty"              => Empty
+      case "noFrameworkMatched" => NoFrameworkMatched
+      case "errored"            => Errored(message.getOrElse("suite errored"), throwable)
+      case other                => Errored(s"unknown suite outcome '$other'", None)
+    }
+
+  implicit val encoder: Encoder[SuiteOutcome] = Encoder.instance {
+    case e: Executed =>
+      Json.obj(
+        "kind" -> "executed".asJson,
+        "passed" -> e.passed.asJson,
+        "failed" -> e.failed.asJson,
+        "skipped" -> e.skipped.asJson,
+        "ignored" -> e.ignored.asJson
+      )
+    case Empty              => Json.obj("kind" -> "empty".asJson)
+    case NoFrameworkMatched => Json.obj("kind" -> "noFrameworkMatched".asJson)
+    case e: Errored         => Json.obj("kind" -> "errored".asJson, "message" -> e.message.asJson, "throwable" -> e.throwable.asJson)
+  }
+
+  implicit val decoder: Decoder[SuiteOutcome] = Decoder.instance { cursor =>
+    cursor.downField("kind").as[String].flatMap {
+      case "executed" =>
+        for {
+          p <- cursor.downField("passed").as[Int]
+          f <- cursor.downField("failed").as[Int]
+          s <- cursor.downField("skipped").as[Int]
+          i <- cursor.downField("ignored").as[Int]
+        } yield Executed(p, f, s, i)
+      case "empty"              => Right(Empty)
+      case "noFrameworkMatched" => Right(NoFrameworkMatched)
+      case "errored"            =>
+        for {
+          m <- cursor.downField("message").as[String]
+          t <- cursor.downField("throwable").as[Option[String]]
+        } yield Errored(m, t)
+      case other => Left(DecodingFailure(s"Unknown SuiteOutcome kind: $other", cursor.history))
+    }
+  }
+
+  implicit val codec: Codec[SuiteOutcome] = Codec.from(decoder, encoder)
+}

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BuildDiffTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BuildDiffTest.scala
@@ -1,6 +1,6 @@
 package bleep.analysis
 
-import bleep.bsp.protocol.{BleepBspProtocol, CompileStatus, DiagnosticSeverity, OutputChannel, TestStatus}
+import bleep.bsp.protocol.{BleepBspProtocol, CompileStatus, DiagnosticSeverity, OutputChannel, SuiteOutcome, TestStatus}
 import bleep.model.{CrossProjectName, ProjectName, SuiteName, TestName}
 import bleep.testing._
 import org.scalatest.funsuite.AnyFunSuite
@@ -82,7 +82,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
       BuildEvent.SuiteStarted(cpn("proj"), sn("MySuite"), ts),
       testFinished(cpn("proj"), sn("MySuite"), tn("test1"), TestStatus.Passed),
       testFinished(cpn("proj"), sn("MySuite"), tn("test2"), TestStatus.Failed),
-      BuildEvent.SuiteFinished(cpn("proj"), sn("MySuite"), passed = 1, failed = 1, skipped = 0, ignored = 0, durationMs = 100, ts + 1)
+      BuildEvent.SuiteFinished(cpn("proj"), sn("MySuite"), SuiteOutcome.Executed(1, 1, 0, 0), 100, ts + 1)
     )
 
     val state = PreviousRunState.fromEvents(events)
@@ -256,7 +256,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
       testFinished(cpn("proj"), sn("MySuite"), tn("test2"), TestStatus.Passed)
     )
 
-    val diff = BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, Map.empty, passed = 2, failed = 0, skipped = 0, ignored = 0, durationMs = 100)
+    val diff = BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, Map.empty, SuiteOutcome.Executed(2, 0, 0, 0), 100)
 
     diff.passed shouldBe 2
     diff.failed shouldBe 0
@@ -276,7 +276,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 1, failed = 1, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(1, 1, 0, 0), 100)
 
     diff.newFailures shouldBe List(tn("test2"))
     diff.fixedTests shouldBe empty
@@ -294,7 +294,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 2, failed = 0, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(2, 0, 0, 0), 100)
 
     diff.fixedTests shouldBe List(tn("test2"))
     diff.newFailures shouldBe empty
@@ -310,7 +310,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 0, failed = 1, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(0, 1, 0, 0), 100)
 
     diff.stillFailing shouldBe List(tn("testBad"))
     diff.newFailures shouldBe empty
@@ -327,7 +327,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 1, failed = 1, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(1, 1, 0, 0), 100)
 
     diff.newFailures shouldBe List(tn("testNew"))
   }
@@ -342,7 +342,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 2, failed = 0, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(2, 0, 0, 0), 100)
 
     diff.newFailures shouldBe empty
     diff.fixedTests shouldBe empty
@@ -360,7 +360,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 2, failed = 0, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(2, 0, 0, 0), 100)
 
     diff.fixedTests should contain(tn("testErr"))
     diff.fixedTests should contain(tn("testTimeout"))
@@ -379,7 +379,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 1, failed = 2, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(1, 2, 0, 0), 100)
 
     diff.newFailures shouldBe List(tn("test1"))
     diff.fixedTests shouldBe List(tn("test2"))
@@ -641,7 +641,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 1, failed = 0, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(1, 0, 0, 0), 100)
 
     diff.fixedTests shouldBe List(tn("testCancel"))
   }
@@ -655,7 +655,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
     )
 
     val diff =
-      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, passed = 1, failed = 0, skipped = 0, ignored = 0, durationMs = 100)
+      BuildDiff.diffSuite(cpn("proj"), sn("MySuite"), currentTests, previousResults, SuiteOutcome.Executed(1, 0, 0, 0), 100)
 
     // skipped -> passed is not a "fix" (skipped was never a failure)
     diff.fixedTests shouldBe empty

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BuildStateReducerTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BuildStateReducerTest.scala
@@ -1,6 +1,6 @@
 package bleep.analysis
 
-import bleep.bsp.protocol.{OutputChannel, TestStatus}
+import bleep.bsp.protocol.{OutputChannel, SuiteOutcome, TestStatus}
 import bleep.model.{CrossProjectName, ProjectName, SuiteName, TestName}
 import bleep.testing._
 import org.scalatest.funsuite.AnyFunSuite
@@ -29,7 +29,7 @@ class BuildStateReducerTest extends AnyFunSuite with Matchers {
       BuildEvent.SuiteStarted(cpn("proj"), sn("com.example.MySuite"), ts),
       BuildEvent.Output(cpn("proj"), sn("com.example.MySuite"), "error line 1", OutputChannel.Stderr, ts + 1),
       BuildEvent.Output(cpn("proj"), sn("com.example.MySuite"), "at com.example.MySuite.test(MySuite.scala:42)", OutputChannel.Stderr, ts + 2),
-      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), passed = 0, failed = 2, skipped = 0, ignored = 0, durationMs = 100, ts + 3)
+      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), SuiteOutcome.Executed(0, 2, 0, 0), 100, ts + 3)
     )
 
     state.failures should have size 1
@@ -57,7 +57,7 @@ class BuildStateReducerTest extends AnyFunSuite with Matchers {
         throwable = None,
         ts + 2
       ),
-      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), passed = 0, failed = 1, skipped = 0, ignored = 0, durationMs = 100, ts + 3)
+      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), SuiteOutcome.Executed(0, 1, 0, 0), 100, ts + 3)
     )
 
     state.failures should have size 1
@@ -79,12 +79,54 @@ class BuildStateReducerTest extends AnyFunSuite with Matchers {
       BuildEvent.TestStarted(cpn("proj"), sn("com.example.MySuite"), tn("test3"), ts + 5),
       BuildEvent
         .TestFinished(cpn("proj"), sn("com.example.MySuite"), tn("test3"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 6),
-      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), passed = 3, failed = 0, skipped = 0, ignored = 0, durationMs = 100, ts + 7)
+      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), SuiteOutcome.Executed(3, 0, 0, 0), 100, ts + 7)
     )
 
     state.failures shouldBe empty
     state.suitesFailed shouldBe 0
     state.testsPassed shouldBe 3
+  }
+
+  test("SuiteFinished(Empty) — a discovered suite that ran nothing — is a failure") {
+    val state = reduce(
+      BuildEvent.SuiteStarted(cpn("proj"), sn("com.example.EmptySuite"), ts),
+      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.EmptySuite"), SuiteOutcome.Empty, durationMs = 42, ts + 1)
+    )
+    state.suitesCompleted shouldBe 1
+    state.suitesFailed shouldBe 1
+    state.testsFailed shouldBe 1
+    state.failures should have size 1
+    state.failures.head.test shouldBe tn("(suite failed)")
+  }
+
+  test("SuiteFinished(NoFrameworkMatched) is a failure") {
+    val state = reduce(
+      BuildEvent.SuiteStarted(cpn("proj"), sn("com.example.JUnit4Suite"), ts),
+      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.JUnit4Suite"), SuiteOutcome.NoFrameworkMatched, durationMs = 5, ts + 1)
+    )
+    state.suitesFailed shouldBe 1
+    state.testsFailed shouldBe 1
+    state.failures.head.message.exists(_.contains("framework")) shouldBe true
+  }
+
+  test("SuiteFinished(Errored) surfaces the error message as the failure") {
+    val state = reduce(
+      BuildEvent.SuiteStarted(cpn("proj"), sn("com.example.BrokenSuite"), ts),
+      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.BrokenSuite"), SuiteOutcome.Errored("NoClassDefFoundError: Foo", None), durationMs = 9, ts + 1)
+    )
+    state.suitesFailed shouldBe 1
+    state.testsFailed shouldBe 1
+    state.failures.head.message shouldBe Some("NoClassDefFoundError: Foo")
+  }
+
+  test("SuiteFinished(Executed) with all passing tests is green") {
+    val state = reduce(
+      BuildEvent.SuiteStarted(cpn("proj"), sn("com.example.OkSuite"), ts),
+      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.OkSuite"), SuiteOutcome.Executed(5, 0, 0, 0), durationMs = 10, ts + 1)
+    )
+    state.suitesFailed shouldBe 0
+    state.testsFailed shouldBe 0
+    state.failures shouldBe empty
   }
 
   test("SuiteFinished clears pending output for suite") {
@@ -100,7 +142,7 @@ class BuildStateReducerTest extends AnyFunSuite with Matchers {
     // After SuiteFinished, pending output should be cleared
     val stateAfterFinished = BuildStateReducer.reduce(
       stateWithOutput,
-      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), passed = 1, failed = 0, skipped = 0, ignored = 0, durationMs = 100, ts + 2)
+      BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), SuiteOutcome.Executed(1, 0, 0, 0), 100, ts + 2)
     )
     stateAfterFinished.pendingOutput.contains(key) shouldBe false
   }
@@ -137,7 +179,7 @@ class BuildStateReducerTest extends AnyFunSuite with Matchers {
       BuildEvent.SuiteStarted(cpn("proj"), sn("suite1"), ts),
       BuildEvent.TestStarted(cpn("proj"), sn("suite1"), tn("test1"), ts + 1),
       BuildEvent.TestFinished(cpn("proj"), sn("suite1"), tn("test1"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 2),
-      BuildEvent.SuiteFinished(cpn("proj"), sn("suite1"), passed = 1, failed = 0, skipped = 0, ignored = 0, durationMs = 50, ts + 3)
+      BuildEvent.SuiteFinished(cpn("proj"), sn("suite1"), SuiteOutcome.Executed(1, 0, 0, 0), 50, ts + 3)
     )
 
     // TestRunCompleted with authoritative counts that differ from accumulated

--- a/bleep-bsp-tests/src/scala/bleep/analysis/JvmTestRunnerIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/JvmTestRunnerIntegrationTest.scala
@@ -1,7 +1,7 @@
 package bleep.analysis
 
 import bleep.bsp.TaskDag
-import bleep.bsp.protocol.{BleepBspProtocol, OutputChannel, TestStatus}
+import bleep.bsp.protocol.{BleepBspProtocol, OutputChannel, SuiteOutcome, TestStatus}
 import bleep.model.{CrossProjectName, ProjectName, SuiteName, TestName}
 import bleep.testing.TestProtocol
 import org.scalatest.funsuite.AnyFunSuite
@@ -95,10 +95,7 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
     failAfter(quickTimeout) {
       val response = TestProtocol.TestResponse.SuiteDone(
         suite = "com.example.MySuite",
-        passed = 10,
-        failed = 2,
-        skipped = 1,
-        ignored = 0,
+        outcome = SuiteOutcome.Executed(10, 2, 1, 0),
         durationMs = 5432
       )
       val encoded = TestProtocol.encodeResponse(response)
@@ -106,6 +103,22 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
 
       decoded shouldBe Right(response)
       encoded should include("SuiteDone")
+    }
+  }
+
+  test("TestProtocol: SuiteDone round-trips every outcome variant") {
+    failAfter(quickTimeout) {
+      val outcomes = List(
+        SuiteOutcome.Executed(3, 1, 2, 0),
+        SuiteOutcome.Empty,
+        SuiteOutcome.NoFrameworkMatched,
+        SuiteOutcome.Errored("boom", Some("stack\ntrace"))
+      )
+      outcomes.foreach { o =>
+        val response = TestProtocol.TestResponse.SuiteDone(suite = "com.example.MySuite", outcome = o, durationMs = 1)
+        val decoded = TestProtocol.decodeResponse(TestProtocol.encodeResponse(response))
+        decoded shouldBe Right(response)
+      }
     }
   }
 
@@ -335,18 +348,12 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
       val event = TaskDag.DagEvent.SuiteFinished(
         project = CrossProjectName(ProjectName("my-project"), None),
         suite = SuiteName("MySuite"),
-        passed = 10,
-        failed = 2,
-        skipped = 1,
-        ignored = 0,
+        outcome = SuiteOutcome.Executed(10, 2, 1, 0),
         durationMs = 5000,
         timestamp = ts
       )
 
-      event.passed shouldBe 10
-      event.failed shouldBe 2
-      event.skipped shouldBe 1
-      event.ignored shouldBe 0
+      event.outcome shouldBe SuiteOutcome.Executed(10, 2, 1, 0)
       event.durationMs shouldBe 5000
     }
   }

--- a/bleep-bsp/src/scala/bleep/analysis/ZincBridge.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ZincBridge.scala
@@ -1,5 +1,6 @@
 package bleep.analysis
 
+import bleep.bsp.protocol.KillReason
 import cats.effect.IO
 import java.io.{File, IOException}
 import java.lang.ref.SoftReference
@@ -323,22 +324,25 @@ object ZincBridge {
       case None    => return None
     }
 
-    // Check source directory stats — detects file add/delete/rename
+    // The configured source roots must all be recorded — otherwise the build's `sources`
+    // changed since the manifest was written and none of the recorded stats describe it.
     val normalizedDirs = removeNestedDirs(sourceDirs)
-    if (normalizedDirs.size != manifest.sourceDirStats.size) return None
-    val dirIter = normalizedDirs.iterator
+    if (!normalizedDirs.forall(manifest.sourceDirStats.contains)) return None
+
+    // Check every recorded source directory (roots + nested subdirs) — a dir's mtime moves
+    // when a file is added/deleted/renamed directly inside it. Iterating the *recorded* set
+    // rather than walking the tree keeps this O(dirs) pure stats, and still catches
+    // additions: the new file's parent dir is itself recorded. A recorded dir that no
+    // longer exists is likewise a miss.
+    val dirIter = manifest.sourceDirStats.iterator
     while (dirIter.hasNext) {
-      val dir = dirIter.next()
-      manifest.sourceDirStats.get(dir) match {
-        case None           => return None
-        case Some(expected) =>
-          if (!Files.isDirectory(dir)) return None
-          val stat = statFile(dir)
-          if (
-            stat.ctimeMillis != expected.ctimeMillis ||
-            stat.mtimeMillis != expected.mtimeMillis
-          ) return None
-      }
+      val (dir, expected) = dirIter.next()
+      if (!Files.isDirectory(dir)) return None
+      val stat = statFile(dir)
+      if (
+        stat.ctimeMillis != expected.ctimeMillis ||
+        stat.mtimeMillis != expected.mtimeMillis
+      ) return None
     }
 
     // Check per-source file stats (from manifest's recorded paths — no directory walk)
@@ -517,8 +521,7 @@ object ZincBridge {
       dependencyAnalyses,
       progressListener,
       cancellationToken,
-      diagnosticListener,
-      !hasPrevAnalysis
+      diagnosticListener
     )
 
     val compiler = incrementalCompiler
@@ -566,10 +569,20 @@ object ZincBridge {
         diagnosticListener.onCompilationReason(config.name, CompilationReason.UpToDate)
       }
 
+      // Zinc swallows cancellation: `Incremental.compile` catches `xsbti.CompileCancelled`
+      // and returns `(hasModified = false, previous)` — i.e. a cancelled compile is
+      // indistinguishable from an up-to-date one by return value alone. Ask the token
+      // instead. Persisting anything here would record the *edited* sources as up-to-date
+      // against the *old* analysis, so the edit stays invisible until its content changes
+      // again. Fail loudly rather than cache a lie.
+      if (cancellationToken.isCancelled) {
+        debug(s"[ZincBridge] Compilation cancelled for ${config.name} — discarding analysis and noop manifest")
+        return ProjectCompileCancelled(KillReason.UserRequest)
+      }
+
       // Save analysis when compilation produced changes OR when there was no previous
-      // analysis (clean build). On clean builds the cycle guard may short-circuit Zinc's
-      // shouldDoIncrementalCompilation, causing hasModified=false even though compilation
-      // happened. Without saving, downstream projects get a missing/null analysis → NPE.
+      // analysis (clean build). Without saving, downstream projects get a missing/null
+      // analysis → NPE.
       if (result.hasModified || !hasPrevAnalysis) {
         diagnosticListener.onCompilePhase(config.name, CompilePhase.SavingAnalysis)
         debug(s"[ZincBridge] Saving analysis for ${config.name}")
@@ -894,8 +907,7 @@ object ZincBridge {
       dependencyAnalyses: Map[Path, Path],
       progressListener: ProgressListener,
       cancellationToken: CancellationToken,
-      diagnosticListener: DiagnosticListener,
-      isCleanBuild: Boolean
+      diagnosticListener: DiagnosticListener
   ): Inputs = {
     val outputDir = config.outputDir
     // Include output directory in classpath for incremental Java compilation.
@@ -983,10 +995,24 @@ object ZincBridge {
       }
     }
 
-    // Detect Zinc incremental cycle bugs:
-    // 1. After a clean build, Zinc should never want another cycle — the analysis is fresh.
-    // 2. If Zinc re-invalidates the exact same classes after recompiling them, it will never converge.
-    // In both cases: stop the cycle and warn.
+    // Detect Zinc incremental cycle bugs: if Zinc re-invalidates the exact same classes
+    // after recompiling them, it will never converge — stop the cycle and warn.
+    //
+    // Zinc calls shouldDoIncrementalCompilation from two sites with different meanings
+    // (zinc 1.12.0), and only the second is a cycle:
+    //
+    //   1. IncrementalCommon.scala:430, inside detectInitialChanges — exactly once per
+    //      compile (Incremental.scala:340), before any compilation, carrying changed
+    //      *external* (upstream) class names. Returning false makes zinc replace them
+    //      with `new APIChanges(Nil)`, silently discarding every upstream API change.
+    //   2. IncrementalCommon.scala:192, inside cycle — once per invalidation cycle,
+    //      carrying the *internal* classes zinc wants to recompile next. Guarded upstream
+    //      by `nextInvalidations.nonEmpty`, so this set is never empty.
+    //
+    // The two carry different namespaces, so comparing one against the other is
+    // meaningless. Site 1 is always the first call, so discriminate on that and never
+    // suppress upstream API changes.
+    var seenInitialProbe = false
     var previousInvalidations: Option[Set[String]] = None
     // Extend ExternalLookup directly (not NoopExternalLookup) because NoopExternalLookup
     // narrows lookupAnalyzedClass return type to None.type which we can't widen back.
@@ -1005,25 +1031,26 @@ object ZincBridge {
       override def shouldDoIncrementalCompilation(
           changedClasses: Set[String],
           analysis: CompileAnalysis
-      ): Boolean = {
-        val isBug = if (isCleanBuild && previousInvalidations.isEmpty) {
-          // Clean build just finished — any invalidation is a Zinc bug
+      ): Boolean =
+        if (!seenInitialProbe) {
+          // Site 1: the upstream-API gate, not a cycle. Never suppress it — returning
+          // false here is how upstream API changes go missing. Deliberately does not
+          // record previousInvalidations: external class names are a different namespace
+          // from the internal invalidations site 2 compares against.
+          seenInitialProbe = true
           true
-        } else {
-          previousInvalidations match {
-            case Some(prev) if prev == changedClasses => true
-            case _                                    => false
-          }
+        } else cycleCheck(changedClasses)
+
+      private def cycleCheck(changedClasses: Set[String]): Boolean = {
+        val isBug = previousInvalidations match {
+          case Some(prev) if prev == changedClasses => true
+          case _                                    => false
         }
 
         if (isBug) {
           val classes = changedClasses.toList.sorted.take(20).mkString(", ")
           val more = if (changedClasses.size > 20) s" (and ${changedClasses.size - 20} more)" else ""
-          val reason =
-            if (isCleanBuild && previousInvalidations.isEmpty)
-              "after a clean build"
-            else
-              "after recompiling, re-invalidated the exact same class(es)"
+          val reason = "after recompiling, re-invalidated the exact same class(es)"
           System.err.println(
             s"[ZincBridge] WARNING: Zinc incremental compilation bug in ${config.name}: " +
               s"$reason. ${changedClasses.size} class(es): $classes$more"

--- a/bleep-bsp/src/scala/bleep/bsp/BspMetrics.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspMetrics.scala
@@ -61,6 +61,12 @@ object BspMetrics {
       throwable match {
         case oom: OutOfMemoryError =>
           recordOomCrash(thread.getName, oom.getMessage)
+          // An OOM on a worker thread (CE pool, io-compute) is otherwise only logged, and the
+          // server keeps serving with poisoned static initializers — every later compile then
+          // fails with NoClassDefFoundError. Force-exit so BspRifle restarts a clean server.
+          // (-XX:+ExitOnOutOfMemoryError usually beats us to it; this is the belt-and-suspenders.)
+          System.err.println(s"[FATAL] OutOfMemoryError on thread ${thread.getName} — halting for restart")
+          Runtime.getRuntime.halt(1)
         case _ => ()
       }
       if (previousHandler != null) previousHandler.uncaughtException(thread, throwable)

--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -3,7 +3,7 @@ package bleep.bsp
 import libdaemonjvm._
 import libdaemonjvm.internal.{LockProcess, SocketHandler}
 import libdaemonjvm.server._
-import ryddig.{LogPatterns, Logger, Loggers}
+import ryddig.{LogLevel, LogPatterns, Logger, Loggers}
 import ryddig.jul.RyddigJulBridge
 
 import java.nio.file.{Files, Path, Paths}
@@ -93,8 +93,12 @@ object BspServerDaemon {
   }
 
   def run(config: DaemonConfig): Unit = {
-    // Create daemon-level logger that writes to stderr (ProcessBuilder redirects to socketDir/output)
-    val logger = Loggers.stderr(LogPatterns.logFile)
+    // Create daemon-level logger that writes to stderr (ProcessBuilder redirects to socketDir/output).
+    // Filter to Info+: this is a long-lived shared daemon and its `output` file only rotates at
+    // startup, so per-event debug tracing (every test event, every line of test stdout) otherwise
+    // grows it into the hundreds of MB over a multi-hour session. Info keeps compile/test lifecycle
+    // and all warnings/errors.
+    val logger = Loggers.stderr(LogPatterns.logFile).withMinLogLevel(LogLevel.info)
 
     // Install JUL bridge so library logging (e.g. lsp4j) goes through ryddig
     val rootJulLogger = java.util.logging.Logger.getLogger("")

--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -347,8 +347,12 @@ object BspServerDaemon {
       logger.info("Client disconnected normally")
     } catch {
       case e: OutOfMemoryError =>
+        // -XX:+ExitOnOutOfMemoryError (BspRifleConfig) normally force-exits the JVM the instant an
+        // OOM is thrown, so we rarely reach here. If we do (e.g. that flag was overridden), exit
+        // explicitly: continuing after an OOM risks a server with poisoned static initializers that
+        // fails every subsequent compile. A rethrow alone does NOT exit — it only kills this thread.
         System.err.println(s"[FATAL] OutOfMemoryError in handleClient: ${e.getMessage}")
-        throw e // Let JVM handle OOM
+        Runtime.getRuntime.halt(1)
       case e: Throwable =>
         logger.error(s"Error handling client: ${e.getClass.getName}: ${e.getMessage}", e)
         System.err.println(s"[BSP] handleClient failed: ${e.getClass.getName}: ${e.getMessage}")

--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -206,7 +206,12 @@ object BspServerDaemon {
     // contention, which is the wrong tradeoff for a mixed-traffic build server.
     val numCores = Runtime.getRuntime.availableProcessors()
     val compileSemaphore = new java.util.concurrent.Semaphore(numCores, /* fair = */ true)
-    logger.info(s"Compile semaphore: $numCores permits (based on available processors, fair)")
+    // Server-wide cap on concurrent forked test JVMs. Each client's test run creates its own
+    // JvmPool, so without a shared limit two clients testing at once fork 2× the per-pool budget —
+    // the fork storm behind "JVM process terminated before sending Ready" under multi-agent load.
+    // Sized like the compile semaphore; fair for the same mixed-traffic reason.
+    val testForkSemaphore = new java.util.concurrent.Semaphore(numCores, /* fair = */ true)
+    logger.info(s"Compile + test-fork semaphores: $numCores permits each (based on available processors, fair)")
 
     // NOTE: Do NOT redirect stdout — Zinc writes massive amounts of data to
     // stdout which would bloat the log file to tens of GB.
@@ -270,7 +275,8 @@ object BspServerDaemon {
                   clientSocket.getInputStream,
                   clientSocket.getOutputStream,
                   logger.withContext("client", connId),
-                  compileSemaphore
+                  compileSemaphore,
+                  testForkSemaphore
                 )
               finally BspMetrics.recordConnectionClose(connId)
               try clientSocket.close()
@@ -285,7 +291,8 @@ object BspServerDaemon {
                       clientSocket.getInputStream,
                       clientSocket.getOutputStream,
                       logger.withContext("client", connId),
-                      compileSemaphore
+                      compileSemaphore,
+                      testForkSemaphore
                     )
                   finally {
                     BspMetrics.recordConnectionClose(connId)
@@ -333,7 +340,8 @@ object BspServerDaemon {
       input: java.io.InputStream,
       output: java.io.OutputStream,
       logger: Logger,
-      compileSemaphore: java.util.concurrent.Semaphore
+      compileSemaphore: java.util.concurrent.Semaphore,
+      testForkSemaphore: java.util.concurrent.Semaphore
   ): Unit =
     try {
       // Create multi-workspace server using the daemon-level logger
@@ -342,6 +350,7 @@ object BspServerDaemon {
         output,
         logger,
         compileSemaphore = compileSemaphore,
+        testForkSemaphore = testForkSemaphore,
         heapMonitor = HeapMonitor.system
       )
 

--- a/bleep-bsp/src/scala/bleep/bsp/HeapPressureGate.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/HeapPressureGate.scala
@@ -10,6 +10,12 @@ object HeapPressureGate {
   /** Minimum scaling factor — even at 0% heap, wait at least this fraction of retryMs */
   val MinDelayFraction: Double = 0.10
 
+  /** Hard cap on how long this gate will stall a single compile. Past this the compile proceeds under pressure rather than looping forever: an unbounded stall
+    * wedges the whole build with no diagnostic, whereas proceeding risks at worst an OOM — which now exits cleanly (see -XX:+ExitOnOutOfMemoryError in
+    * BspRifleConfig) and is restarted, not bricked.
+    */
+  val MaxWaitMs: Long = 60000L
+
   /** Callback for when compilation waits for memory */
   trait Listener {
     def onWait(project: String, used: HeapMb, max: HeapMb, delayMs: Long, now: EpochMs): Unit
@@ -57,6 +63,10 @@ object HeapPressureGate {
             }
           } else if (waitStart.isDefined && usage.fraction < threshold) {
             // Already waited at least one cycle and heap is below threshold — proceed
+            val waitedFor = DurationMs(nowMs.value - waitStart.get.value)
+            IO(listener.onResume(projectName, usage.usedMb, usage.maxMb, waitedFor, nowMs))
+          } else if (waitStart.exists(start => nowMs.value - start.value >= MaxWaitMs)) {
+            // Deadline reached while still under pressure — proceed anyway rather than loop forever.
             val waitedFor = DurationMs(nowMs.value - waitStart.get.value)
             IO(listener.onResume(projectName, usage.usedMb, usage.maxMb, waitedFor, nowMs))
           } else {

--- a/bleep-bsp/src/scala/bleep/bsp/InProcessBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/InProcessBspServer.scala
@@ -32,9 +32,18 @@ object InProcessBspServer {
           override def run(): Unit = {
             var exitCode: java.lang.Integer = 0
             try {
-              val semaphore = new java.util.concurrent.Semaphore(Runtime.getRuntime.availableProcessors(), /* fair = */ true)
+              val numCores = Runtime.getRuntime.availableProcessors()
+              val semaphore = new java.util.concurrent.Semaphore(numCores, /* fair = */ true)
+              val testForkSemaphore = new java.util.concurrent.Semaphore(numCores, /* fair = */ true)
               val server =
-                new MultiWorkspaceBspServer(serverIn, serverOut, logger, compileSemaphore = semaphore, heapMonitor = HeapMonitor.system)
+                new MultiWorkspaceBspServer(
+                  serverIn,
+                  serverOut,
+                  logger,
+                  compileSemaphore = semaphore,
+                  testForkSemaphore = testForkSemaphore,
+                  heapMonitor = HeapMonitor.system
+                )
               server.run()
             } catch {
               case e: Throwable =>

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -49,6 +49,7 @@ class MultiWorkspaceBspServer(
     out: OutputStream,
     logger: Logger,
     compileSemaphore: java.util.concurrent.Semaphore,
+    testForkSemaphore: java.util.concurrent.Semaphore,
     heapMonitor: HeapMonitor
 ) {
   import MultiWorkspaceBspServer.DebugLogging
@@ -1947,8 +1948,9 @@ class MultiWorkspaceBspServer(
         // Create kill signal from cancellation token
         killSignal <- Outcome.fromCancellationToken(cancellation)
 
-        // Create JVM pool for test execution
-        testResult <- JvmPool.create(maxParallelism, started.jvmCommand, started.buildPaths.buildDir).use { jvmPool =>
+        // Create JVM pool for test execution. The server-wide testForkSemaphore caps concurrent
+        // forks across ALL clients — the per-pool maxParallelism only bounds this one test run.
+        testResult <- JvmPool.create(maxParallelism, started.jvmCommand, started.buildPaths.buildDir, testForkSemaphore).use { jvmPool =>
           // Per-test-run map populated by the AP DAG handler and read by the compile handler. KSP runs as a separate process and emits files directly; no
           // intermediate compile-time data flow, so no equivalent map.
           val apResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, AnnotationProcessorResult]()

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -3483,9 +3483,9 @@ class MultiWorkspaceBspServer(
           .withContext("status", e.status.wireValue)
           .withContext("project", e.project.value)
           .withContext("durationMs", e.durationMs)
-          .warn("sendTestEvent: CompileFinished")
+          .debug("sendTestEvent: CompileFinished")
       case e: E.CompileStarted =>
-        logger.withContext("n", n).withContext("taskId", taskId).withContext("project", e.project.value).warn("sendTestEvent: CompileStarted")
+        logger.withContext("n", n).withContext("taskId", taskId).withContext("project", e.project.value).debug("sendTestEvent: CompileStarted")
       case e: E.TestFinished =>
         logger
           .withContext("n", n)
@@ -3494,7 +3494,7 @@ class MultiWorkspaceBspServer(
           .withContext("project", e.project.value)
           .withContext("suite", e.suite.value)
           .withContext("test", e.test.value)
-          .warn("sendTestEvent: TestFinished")
+          .debug("sendTestEvent: TestFinished")
       case e: E.SuiteFinished =>
         logger
           .withContext("n", n)
@@ -3504,7 +3504,7 @@ class MultiWorkspaceBspServer(
           .withContext("outcome", SuiteOutcome.tagOf(e.outcome))
           .withContext("passed", e.outcome.passedCount)
           .withContext("failed", e.outcome.failedCount)
-          .warn("sendTestEvent: SuiteFinished")
+          .debug("sendTestEvent: SuiteFinished")
       case e: E.SuiteError =>
         logger
           .withContext("n", n)
@@ -3512,14 +3512,14 @@ class MultiWorkspaceBspServer(
           .withContext("project", e.project.value)
           .withContext("suite", e.suite.value)
           .withContext("error", e.error)
-          .warn("sendTestEvent: SuiteError")
+          .debug("sendTestEvent: SuiteError")
       case e: E.SuiteCancelled =>
         logger
           .withContext("n", n)
           .withContext("taskId", taskId)
           .withContext("project", e.project.value)
           .withContext("suite", e.suite.value)
-          .warn("sendTestEvent: SuiteCancelled")
+          .debug("sendTestEvent: SuiteCancelled")
       case e: E.SuiteTimedOut =>
         logger
           .withContext("n", n)
@@ -3527,10 +3527,10 @@ class MultiWorkspaceBspServer(
           .withContext("project", e.project.value)
           .withContext("suite", e.suite.value)
           .withContext("timeoutMs", e.timeoutMs)
-          .warn("sendTestEvent: SuiteTimedOut")
-      case _: E.CompileProgress => () // too noisy
-      case _                    =>
-        logger.withContext("n", n).withContext("taskId", taskId).withContext("event", event.getClass.getSimpleName).warn("sendTestEvent")
+          .debug("sendTestEvent: SuiteTimedOut")
+      case _: E.CompileProgress | _: E.Output => () // too noisy (Output = every line of test stdout)
+      case _                                  =>
+        logger.withContext("n", n).withContext("taskId", taskId).withContext("event", event.getClass.getSimpleName).debug("sendTestEvent")
     }
     sendEvent(originId, taskId, event)
   }

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -2341,7 +2341,11 @@ class MultiWorkspaceBspServer(
           // Noop projects skip all waiting and don't consume concurrency slots.
           val apFlags: List[String] = Option(apResults.get(compileTask.project)).fold(List.empty[String])(_.javacFlags)
           val config = BleepBuildConverter.toProjectConfig(compileTask.project, started.resolvedProject(compileTask.project), started, apFlags)
-          val depAnalyses = computeDependencyAnalyses(started, compileTask.projectDependencies)
+          // Transitive, not `compileTask.projectDependencies` (direct edges only): the compile
+          // classpath is transitive, so an API change two hops upstream is just as breaking as
+          // one hop. It is also invisible via the intermediate project's analysis mtime, because
+          // an intermediate that is itself a noop never rewrites its analysis.zip.
+          val depAnalyses = computeDependencyAnalyses(started, started.build.transitiveDependenciesFor(compileTask.project).keySet)
           val noopResult = config.language match {
             case sl: ProjectLanguage.ScalaJava => ZincBridge.isNoop(config, sl, depAnalyses, None)
             case _                             => None

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -17,7 +17,7 @@ import bleep.analysis.{
   ZincBridge
 }
 import bleep.bsp.protocol.KillReason
-import bleep.bsp.protocol.{BleepBspProtocol, CompileStatus, LinkPlatformName, OutputChannel, ProcessExit}
+import bleep.bsp.protocol.{BleepBspProtocol, CompileStatus, LinkPlatformName, OutputChannel, ProcessExit, SuiteOutcome}
 import bleep.bsp.TraceCategory
 import bleep.model.{CrossProjectName, SuiteName, TestName}
 import bleep.testing.JvmPool
@@ -2801,10 +2801,7 @@ class MultiWorkspaceBspServer(
                         .SuiteFinished(
                           testTask.project,
                           testTask.suiteName,
-                          result.passed,
-                          result.failed,
-                          result.skipped,
-                          result.ignored,
+                          SuiteOutcome.fromCounts(result.passed, result.failed, result.skipped, result.ignored),
                           durationMs,
                           endTs
                         )
@@ -2816,7 +2813,7 @@ class MultiWorkspaceBspServer(
         case (result, _) =>
           val endTs = System.currentTimeMillis()
           val durationMs = endTs - startTs
-          eventQueue.offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, 0, 1, 0, 0, durationMs, endTs))).void >>
+          eventQueue.offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, erroredOutcomeOf(result), durationMs, endTs))).void >>
             IO.pure(result)
       }
     } yield taskResult
@@ -2917,10 +2914,7 @@ class MultiWorkspaceBspServer(
                           .SuiteFinished(
                             testTask.project,
                             testTask.suiteName,
-                            result.passed,
-                            result.failed,
-                            result.skipped,
-                            result.ignored,
+                            SuiteOutcome.fromCounts(result.passed, result.failed, result.skipped, result.ignored),
                             durationMs,
                             endTs
                           )
@@ -2932,7 +2926,11 @@ class MultiWorkspaceBspServer(
         case _ =>
           val endTs = System.currentTimeMillis()
           val durationMs = endTs - startTs
-          eventQueue.offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, 0, 1, 0, 0, durationMs, endTs))).void >>
+          eventQueue
+            .offer(
+              Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, SuiteOutcome.Errored("Native linking failed", None), durationMs, endTs))
+            )
+            .void >>
             IO.pure(TaskDag.TaskResult.Failure("Native linking failed", List.empty))
       }
     } yield taskResult
@@ -2960,7 +2958,14 @@ class MultiWorkspaceBspServer(
         if (!Files.exists(jsOutput)) {
           val endTs = System.currentTimeMillis()
           val durationMs = endTs - startTs
-          eventQueue.offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, 0, 1, 0, 0, durationMs, endTs))).void >>
+          eventQueue
+            .offer(
+              Some(
+                TaskDag.DagEvent
+                  .SuiteFinished(testTask.project, testTask.suiteName, SuiteOutcome.Errored(s"Kotlin/JS output not found: $jsOutput", None), durationMs, endTs)
+              )
+            )
+            .void >>
             IO.pure(TaskDag.TaskResult.Failure(s"Kotlin/JS output not found: $jsOutput", List.empty))
         } else {
           val nodeBinary = nodeBinaryFor(started, started.build.explodedProjects(testTask.project))
@@ -2977,10 +2982,7 @@ class MultiWorkspaceBspServer(
                       .SuiteFinished(
                         testTask.project,
                         testTask.suiteName,
-                        result.passed,
-                        result.failed,
-                        result.skipped,
-                        result.ignored,
+                        SuiteOutcome.fromCounts(result.passed, result.failed, result.skipped, result.ignored),
                         durationMs,
                         endTs
                       )
@@ -3022,7 +3024,19 @@ class MultiWorkspaceBspServer(
         if (!Files.exists(binary)) {
           val endTs = System.currentTimeMillis()
           val durationMs = endTs - startTs
-          eventQueue.offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, 0, 1, 0, 0, durationMs, endTs))).void >>
+          eventQueue
+            .offer(
+              Some(
+                TaskDag.DagEvent.SuiteFinished(
+                  testTask.project,
+                  testTask.suiteName,
+                  SuiteOutcome.Errored(s"Kotlin/Native binary not found: $binary", None),
+                  durationMs,
+                  endTs
+                )
+              )
+            )
+            .void >>
             IO.pure(TaskDag.TaskResult.Failure(s"Kotlin/Native binary not found: $binary", List.empty))
         } else {
           Dispatcher.sequential[IO].use { dispatcher =>
@@ -3039,10 +3053,7 @@ class MultiWorkspaceBspServer(
                       .SuiteFinished(
                         testTask.project,
                         testTask.suiteName,
-                        result.passed,
-                        result.failed,
-                        result.skipped,
-                        result.ignored,
+                        SuiteOutcome.fromCounts(result.passed, result.failed, result.skipped, result.ignored),
                         durationMs,
                         endTs
                       )
@@ -3285,8 +3296,12 @@ class MultiWorkspaceBspServer(
                 result match {
                   case TaskDag.TaskResult.Success =>
                     None // SuiteFinished already emitted by TestRunner
-                  case TaskDag.TaskResult.Failure(errorMsg, _) =>
-                    Some(BleepBspProtocol.Event.SuiteError(tt.project, tt.suiteName, errorMsg, ProcessExit.Unknown, durationMs, timestamp))
+                  case TaskDag.TaskResult.Failure(_, _) =>
+                    // A logical suite failure (failed tests / empty / no-framework / errored-from-
+                    // SuiteDone) was already conveyed by the SuiteFinished(outcome) event. Emitting a
+                    // SuiteError here too would double-count the suite. Infra failures with no
+                    // SuiteFinished come through as TaskResult.Error below.
+                    None
                   case TaskDag.TaskResult.Error(error, processExit) =>
                     val desc = processExit match {
                       case ProcessExit.Signal(sig)    => s"Process crashed (signal $sig)"
@@ -3352,12 +3367,16 @@ class MultiWorkspaceBspServer(
           case TaskDag.DagEvent.Output(project, suite, line, channel, timestamp) =>
             IO(sendTestEvent(originId, s"output:$project:$suite", BleepBspProtocol.Event.Output(project, suite, line, channel, timestamp)))
 
-          case TaskDag.DagEvent.SuiteFinished(project, suite, passed, failed, skipped, ignored, durationMs, timestamp) =>
-            val protocolEvent = BleepBspProtocol.Event.SuiteFinished(project, suite, passed, failed, skipped, ignored, durationMs, timestamp)
-            totalPassedRef.update(_ + passed) >>
-              totalFailedRef.update(_ + failed) >>
-              totalSkippedRef.update(_ + skipped) >>
-              totalIgnoredRef.update(_ + ignored) >>
+          case TaskDag.DagEvent.SuiteFinished(project, suite, outcome, durationMs, timestamp) =>
+            val protocolEvent = BleepBspProtocol.Event.SuiteFinished(project, suite, outcome, durationMs, timestamp)
+            // Reliable server-side tallies for TestRunResult. A non-Executed outcome (empty /
+            // no-framework / errored) contributes one failed suite so the authoritative summary is
+            // red even if per-test notifications were lost. Executed contributes its real counts.
+            val failedContribution = if (outcome.isFailure && outcome.failedCount == 0) 1 else outcome.failedCount
+            totalPassedRef.update(_ + outcome.passedCount) >>
+              totalFailedRef.update(_ + failedContribution) >>
+              totalSkippedRef.update(_ + outcome.skippedCount) >>
+              totalIgnoredRef.update(_ + outcome.ignoredCount) >>
               IO(sendTestEvent(originId, s"suite:$project:$suite", protocolEvent))
 
           case linkEvent: TaskDag.DagEvent.LinkStarted                       => processLinkEvent(linkEvent, originId, traceRecorder)
@@ -3482,8 +3501,9 @@ class MultiWorkspaceBspServer(
           .withContext("taskId", taskId)
           .withContext("project", e.project.value)
           .withContext("suite", e.suite.value)
-          .withContext("passed", e.passed)
-          .withContext("failed", e.failed)
+          .withContext("outcome", SuiteOutcome.tagOf(e.outcome))
+          .withContext("passed", e.outcome.passedCount)
+          .withContext("failed", e.outcome.failedCount)
           .warn("sendTestEvent: SuiteFinished")
       case e: E.SuiteError =>
         logger
@@ -3562,6 +3582,17 @@ class MultiWorkspaceBspServer(
   }
 
   /** Classify non-JVM test result into TaskResult, distinguishing test failures from process crashes. */
+  /** Outcome for a non-JVM suite that could not run (link failure, missing output) — carries the failing result's message so the client shows the reason. */
+  private def erroredOutcomeOf(result: TaskDag.TaskResult): SuiteOutcome =
+    SuiteOutcome.Errored(
+      result match {
+        case TaskDag.TaskResult.Failure(e, _) => e
+        case TaskDag.TaskResult.Error(e, _)   => e
+        case other                            => s"test suite could not run: $other"
+      },
+      None
+    )
+
   private def classifyTestResult(result: TestRunnerTypes.TestResult): TaskDag.TaskResult =
     result.terminationReason match {
       case TestRunnerTypes.TerminationReason.Completed =>

--- a/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
@@ -1,7 +1,7 @@
 package bleep.bsp
 
 import bleep.bsp.protocol.KillReason
-import bleep.bsp.protocol.{BleepBspProtocol, LinkPlatformName, OutputChannel, ProcessExit, TestStatus}
+import bleep.bsp.protocol.{BleepBspProtocol, LinkPlatformName, OutputChannel, ProcessExit, SuiteOutcome, TestStatus}
 import bleep.bsp.protocol.BleepBspProtocol.BuildMode
 import bleep.model.{CrossProjectName, KotlinJsModuleKind, ScriptDef, SuiteName, TestName}
 import cats.effect._
@@ -336,14 +336,11 @@ object TaskDag {
     // Output events
     case class Output(project: CrossProjectName, suite: SuiteName, line: String, channel: OutputChannel, timestamp: Long) extends DagEvent
 
-    // Suite completion with counts
+    // Suite completion — outcome distinguishes executed-with-counts from empty/no-framework/errored
     case class SuiteFinished(
         project: CrossProjectName,
         suite: SuiteName,
-        passed: Int,
-        failed: Int,
-        skipped: Int,
-        ignored: Int,
+        outcome: SuiteOutcome,
         durationMs: Long,
         timestamp: Long
     ) extends DagEvent

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -1,7 +1,7 @@
 package bleep.bsp
 
 import bleep.bsp.protocol.KillReason
-import bleep.bsp.protocol.{BleepBspProtocol, OutputChannel, ProcessExit, TestStatus}
+import bleep.bsp.protocol.{BleepBspProtocol, OutputChannel, ProcessExit, SuiteOutcome, TestStatus}
 import bleep.model.{CrossProjectName, SuiteName, TestName}
 import bleep.testing.{JvmPool, TestJvm, TestProtocol}
 import cats.effect._
@@ -114,6 +114,10 @@ object TestRunner {
           failedCount <- Ref.of[IO, Int](0)
           skippedCount <- Ref.of[IO, Int](0)
           failures <- Ref.of[IO, List[String]](Nil)
+          // The suite's terminal signal: Right(outcome) from an authoritative SuiteDone, or
+          // Left(message) from a protocol Error (JVM died / bad JSON). None means the stream ended
+          // without either — treated as an infrastructure error below.
+          terminal <- Ref.of[IO, Option[Either[String, SuiteOutcome]]](None)
 
           // Process each response as it arrives (streaming, not batching)
           _ <- jvm
@@ -145,13 +149,8 @@ object TestRunner {
                     )
                 }
 
-              case TestProtocol.TestResponse.SuiteDone(_, passed, failed, skipped, _, _) =>
-                // Use the higher of accumulated individual counts vs authoritative SuiteDone.
-                // Individual TestFinished events may be partially received (stream ended early),
-                // so SuiteDone provides a correction floor.
-                passedCount.update(c => math.max(c, passed)) >>
-                  failedCount.update(c => math.max(c, failed)) >>
-                  skippedCount.update(c => math.max(c, skipped))
+              case TestProtocol.TestResponse.SuiteDone(_, outcome, _) =>
+                terminal.set(Some(Right(outcome)))
 
               case TestProtocol.TestResponse.Log(level, message, suite) =>
                 val isError = level == "error" || level == "stderr"
@@ -159,9 +158,9 @@ object TestRunner {
                 now.flatMap(ts => emit(TaskDag.DagEvent.Output(project, SuiteName(effectiveSuite), message, OutputChannel.fromIsError(isError), ts)))
 
               case TestProtocol.TestResponse.Error(message, _) =>
-                // Protocol errors - emit as test failure
-                failedCount.update(_ + 1) >>
-                  failures.update(s"[Error] $message" :: _)
+                // Infrastructure error (JVM died mid-stream, or malformed response) — no authoritative
+                // SuiteDone. Record it as the terminal signal so we emit SuiteError, not a green suite.
+                terminal.set(Some(Left(message)))
 
               case TestProtocol.TestResponse.Ready =>
                 IO.unit
@@ -176,7 +175,8 @@ object TestRunner {
           failed <- failedCount.get
           skipped <- skippedCount.get
           failureList <- failures.get
-        } yield SuiteResult(passed, failed, skipped, failureList.reverse)
+          term <- terminal.get
+        } yield SuiteResult(term, passed, failed, skipped, failureList.reverse)
 
       // Idle timeout: polls lastActivityAt every second and fires when no activity for idleTimeout duration
       idleTimeoutIO = {
@@ -207,48 +207,34 @@ object TestRunner {
             .handleError(e => System.err.println(s"[TestRunner] stderr drain failed: ${e.getClass.getName}: ${e.getMessage}")) >> outcome.embedError.flatMap {
             result =>
               val durationMs = System.currentTimeMillis() - startTime
-              val ranNothing = result.passed + result.failed + result.skipped == 0
-              // A suite that was discovered and dispatched but executed nothing is never a real
-              // pass — it is the signature of a stale-analysis desync, a framework mismatch (e.g.
-              // JUnit 4 classes routed to JUnit Platform with no vintage engine), or a task that
-              // threw before running. Report it as a suite error, not a green SuiteFinished.
-              //
-              // In the zero-test case we deliberately skip the SuiteFinished event: the
-              // TaskResult.Failure below becomes a SuiteError on the client, which does its own
-              // suite-completion counting. Emitting SuiteFinished too would double-count the
-              // suite as completed.
-              val emitSuiteFinished =
-                if (ranNothing) IO.unit
-                else
-                  now.flatMap { ts =>
-                    emit(
-                      TaskDag.DagEvent.SuiteFinished(
-                        project,
-                        SuiteName(suiteName),
-                        result.passed,
-                        result.failed,
-                        result.skipped,
-                        0,
-                        durationMs,
-                        ts
-                      )
-                    )
+              result.terminal match {
+                // Authoritative suite outcome from the forked runner. Emit exactly one SuiteFinished
+                // carrying it, then derive the TaskResult from the variant — no count arithmetic, no
+                // separate SuiteError (the TaskFinished mapping returns None for a Failure because
+                // SuiteFinished already conveyed the reason).
+                case Some(Right(rawOutcome)) =>
+                  // Reconcile Executed counts with what we streamed, in case some TestFinished events
+                  // were richer than the runner's tally (belt-and-suspenders floor).
+                  val outcome = rawOutcome match {
+                    case SuiteOutcome.Executed(p, f, s, i) =>
+                      SuiteOutcome.Executed(math.max(p, result.passed), math.max(f, result.failed), math.max(s, result.skipped), i)
+                    case other => other
                   }
+                  now.flatMap(ts => emit(TaskDag.DagEvent.SuiteFinished(project, SuiteName(suiteName), outcome, durationMs, ts))) >>
+                    IO.pure(taskResultFor(suiteName, outcome, result.failures))
 
-              emitSuiteFinished >> IO.pure {
-                if (result.failed > 0) {
-                  TaskDag.TaskResult.Failure(
-                    error = s"${result.failed} test(s) failed",
-                    diagnostics = result.failures.map(BleepBspProtocol.Diagnostic.error)
+                // Infrastructure failure: the JVM died mid-stream or sent garbage, with no SuiteDone.
+                // No SuiteFinished — return an Error so the TaskFinished mapping emits SuiteError.
+                case Some(Left(message)) =>
+                  IO.pure(TaskDag.TaskResult.Error(error = message, processExit = ProcessExit.Unknown))
+
+                case None =>
+                  IO.pure(
+                    TaskDag.TaskResult.Error(
+                      error = s"suite $suiteName produced no terminal event (forked JVM ended silently)",
+                      processExit = ProcessExit.Unknown
+                    )
                   )
-                } else if (ranNothing) {
-                  TaskDag.TaskResult.Failure(
-                    error = s"suite $suiteName was discovered but executed 0 tests",
-                    diagnostics = Nil
-                  )
-                } else {
-                  TaskDag.TaskResult.Success
-                }
               }
           }
 
@@ -319,11 +305,31 @@ object TestRunner {
     } yield result
   }
 
-  /** Result of running a suite */
+  /** Accumulated state of a suite run. `terminal` is the authoritative outcome (Right) or an infrastructure error (Left); the counts and `failures` are what we
+    * streamed from individual TestFinished events.
+    */
   private case class SuiteResult(
+      terminal: Option[Either[String, SuiteOutcome]],
       passed: Int,
       failed: Int,
       skipped: Int,
       failures: List[String]
   )
+
+  /** Map a suite outcome to a DAG task result. The single place suite pass/fail is decided — one match over the ADT, no count comparisons. Empty / no-framework
+    * / errored are all failures (a discovered suite that produced no passing tests is never green).
+    */
+  private def taskResultFor(suiteName: String, outcome: SuiteOutcome, failures: List[String]): TaskDag.TaskResult =
+    outcome match {
+      case SuiteOutcome.Executed(_, failed, _, _) if failed > 0 =>
+        TaskDag.TaskResult.Failure(error = s"$failed test(s) failed", diagnostics = failures.map(BleepBspProtocol.Diagnostic.error))
+      case _: SuiteOutcome.Executed =>
+        TaskDag.TaskResult.Success
+      case SuiteOutcome.Empty =>
+        TaskDag.TaskResult.Failure(error = s"suite $suiteName was discovered but executed 0 tests", diagnostics = Nil)
+      case SuiteOutcome.NoFrameworkMatched =>
+        TaskDag.TaskResult.Failure(error = s"no test framework/engine claimed suite $suiteName", diagnostics = Nil)
+      case SuiteOutcome.Errored(message, throwable) =>
+        TaskDag.TaskResult.Failure(error = message, diagnostics = throwable.toList.map(BleepBspProtocol.Diagnostic.error))
+    }
 }

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -207,25 +207,44 @@ object TestRunner {
             .handleError(e => System.err.println(s"[TestRunner] stderr drain failed: ${e.getClass.getName}: ${e.getMessage}")) >> outcome.embedError.flatMap {
             result =>
               val durationMs = System.currentTimeMillis() - startTime
-              // Emit SuiteFinished with actual counts
-              now.flatMap { ts =>
-                emit(
-                  TaskDag.DagEvent.SuiteFinished(
-                    project,
-                    SuiteName(suiteName),
-                    result.passed,
-                    result.failed,
-                    result.skipped,
-                    0,
-                    durationMs,
-                    ts
-                  )
-                )
-              } >> IO.pure {
+              val ranNothing = result.passed + result.failed + result.skipped == 0
+              // A suite that was discovered and dispatched but executed nothing is never a real
+              // pass — it is the signature of a stale-analysis desync, a framework mismatch (e.g.
+              // JUnit 4 classes routed to JUnit Platform with no vintage engine), or a task that
+              // threw before running. Report it as a suite error, not a green SuiteFinished.
+              //
+              // In the zero-test case we deliberately skip the SuiteFinished event: the
+              // TaskResult.Failure below becomes a SuiteError on the client, which does its own
+              // suite-completion counting. Emitting SuiteFinished too would double-count the
+              // suite as completed.
+              val emitSuiteFinished =
+                if (ranNothing) IO.unit
+                else
+                  now.flatMap { ts =>
+                    emit(
+                      TaskDag.DagEvent.SuiteFinished(
+                        project,
+                        SuiteName(suiteName),
+                        result.passed,
+                        result.failed,
+                        result.skipped,
+                        0,
+                        durationMs,
+                        ts
+                      )
+                    )
+                  }
+
+              emitSuiteFinished >> IO.pure {
                 if (result.failed > 0) {
                   TaskDag.TaskResult.Failure(
                     error = s"${result.failed} test(s) failed",
                     diagnostics = result.failures.map(BleepBspProtocol.Diagnostic.error)
+                  )
+                } else if (ranNothing) {
+                  TaskDag.TaskResult.Failure(
+                    error = s"suite $suiteName was discovered but executed 0 tests",
+                    diagnostics = Nil
                   )
                 } else {
                   TaskDag.TaskResult.Success

--- a/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
@@ -1245,15 +1245,21 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
               prevFailed && !tf.status.isFailure
             }
 
-            // Stream if there are failures or diffs
-            if (e.failed > 0 || newFailures.nonEmpty || fixedTests.nonEmpty) {
+            // Stream if the suite failed (any variant) or there are diffs
+            val isFailure = e.outcome.isFailure
+            if (isFailure || newFailures.nonEmpty || fixedTests.nonEmpty) {
               val diffParts = List.newBuilder[String]
               fixedTests.foreach(t => diffParts += s"${t.test.value} fixed")
               newFailures.foreach(t => diffParts += s"${t.test.value} new failure")
               val details = diffParts.result()
-              val countsStr = s"${e.passed} passed, ${e.failed} failed"
+              val countsStr = e.outcome match {
+                case bleep.bsp.protocol.SuiteOutcome.Executed(passed, failed, _, _) => s"$passed passed, $failed failed"
+                case bleep.bsp.protocol.SuiteOutcome.Empty                          => "discovered but executed 0 tests"
+                case bleep.bsp.protocol.SuiteOutcome.NoFrameworkMatched             => "no test framework/engine claimed this suite"
+                case bleep.bsp.protocol.SuiteOutcome.Errored(message, _)            => s"errored: $message"
+              }
               val detailStr = if (details.nonEmpty) s" (${details.mkString(", ")})" else ""
-              val level = if (e.failed > 0) protocol.LoggingLevel.Error else protocol.LoggingLevel.Info
+              val level = if (isFailure) protocol.LoggingLevel.Error else protocol.LoggingLevel.Info
               streamNotification(context, level, s"${e.project.value} ${e.suite.value}: $countsStr$detailStr")
             } else IO.unit
           }

--- a/bleep-cli/src/scala-3/bleep/mcp/McpEventFilter.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/McpEventFilter.scala
@@ -67,10 +67,11 @@ object McpEventFilter {
             "event" -> Json.fromString("SuiteFinished"),
             "project" -> e.project.asJson,
             "suite" -> e.suite.asJson,
-            "passed" -> Json.fromInt(e.passed),
-            "failed" -> Json.fromInt(e.failed),
-            "skipped" -> Json.fromInt(e.skipped),
-            "ignored" -> Json.fromInt(e.ignored),
+            "outcome" -> Json.fromString(bleep.bsp.protocol.SuiteOutcome.tagOf(e.outcome)),
+            "passed" -> Json.fromInt(e.outcome.passedCount),
+            "failed" -> Json.fromInt(e.outcome.failedCount),
+            "skipped" -> Json.fromInt(e.outcome.skippedCount),
+            "ignored" -> Json.fromInt(e.outcome.ignoredCount),
             "durationMs" -> Json.fromLong(e.durationMs)
           )
         )

--- a/bleep-core/src/scala/bleep/analysis/NoopManifestStore.scala
+++ b/bleep-core/src/scala/bleep/analysis/NoopManifestStore.scala
@@ -22,7 +22,7 @@ object NoopManifestStore {
 
   case class NoopManifest(
       sourceStats: Map[Path, FileStatEntry],
-      sourceDirStats: Map[Path, FileStatEntry], // source dir → stat (detects file add/delete)
+      sourceDirStats: Map[Path, FileStatEntry], // source dir + subdirs → stat (detects file add/delete)
       outputDirStats: Map[Path, FileStatEntry], // output dir + subdirs → stat (detects class file add/delete)
       depAnalysisStats: Map[Path, Long], // outputDir → dep analysis mtime millis
       optionsHash: Long,
@@ -36,7 +36,10 @@ object NoopManifestStore {
     !System.getProperty("os.name", "").toLowerCase.contains("win")
 
   private val NoopManifestMagic: Int = 0x4e4f4f50
-  private val NoopManifestVersion: Byte = 3
+  // v4: sourceDirStats records source roots *and every nested subdirectory*. v3 recorded
+  // only the top-level roots, so a file added in a nested package dir bumped no recorded
+  // mtime and the project was wrongly declared a noop. v3 manifests are a cache miss.
+  private val NoopManifestVersion: Byte = 4
 
   /** Path of the manifest file, sibling to the analysis file. */
   def manifestPath(analysisFile: Path): Path =
@@ -58,6 +61,20 @@ object NoopManifestStore {
     val abs = dirs.map(_.toAbsolutePath.normalize())
     abs.filter(d => !abs.exists(other => other != d && d.startsWith(other)))
   }
+
+  /** Every directory at or below `root`, inclusive. Empty when `root` is not a directory.
+    *
+    * Recording nested dirs (not just the root) is what makes file *additions* detectable by stat alone: adding `src/java/com/foo/New.java` bumps the mtime of
+    * `src/java/com/foo` only — no ancestor's mtime changes — so a manifest holding just `src/java` cannot see it.
+    */
+  def collectDirsRecursively(root: Path): Array[Path] =
+    if (!Files.isDirectory(root)) Array.empty
+    else {
+      import scala.jdk.CollectionConverters.*
+      scala.util.Using.resource(Files.walk(root)) { stream =>
+        stream.iterator().asScala.filter(Files.isDirectory(_)).toArray
+      }
+    }
 
   /** FNV-1a hash of compiler options for cheap equality check. */
   def computeOptionsHash(language: ProjectLanguage.ScalaJava, ecjVersion: Option[String]): Long = {
@@ -105,12 +122,14 @@ object NoopManifestStore {
       i += 1
     }
 
-    // Stat source directories — mtime changes on file add/delete/rename (POSIX)
-    val normalizedDirs = removeNestedDirs(sourceDirs)
-    val sourceDirStatsMap = normalizedDirs.flatMap { dir =>
-      if (Files.isDirectory(dir)) Some(dir -> statFile(dir))
-      else None
-    }.toMap
+    // Stat source directories and every nested subdirectory — a dir's mtime changes when a
+    // file is added/deleted/renamed directly inside it (POSIX), but NOT when something
+    // changes in a descendant. Recording only the roots therefore misses additions in
+    // package subdirectories, which is exactly what code generators produce.
+    val sourceDirStatsMap = removeNestedDirs(sourceDirs).iterator
+      .flatMap(collectDirsRecursively)
+      .map(dir => dir -> statFile(dir))
+      .toMap
 
     val depStats = dependencyAnalyses.map { case (outputDir, depAnalysisFile) =>
       val mtime = if (Files.exists(depAnalysisFile)) Files.getLastModifiedTime(depAnalysisFile).toMillis else 0L
@@ -120,15 +139,7 @@ object NoopManifestStore {
     // Stat output directories (outputDir + all subdirs).
     // Directory mtime changes on file add/delete — catches class file deletion cheaply.
     val outputDirStatsMap: Map[Path, FileStatEntry] =
-      if (Files.isDirectory(result.outputDir)) {
-        import scala.jdk.CollectionConverters.*
-        val dirs = scala.util
-          .Using(Files.walk(result.outputDir)) { stream =>
-            stream.iterator().asScala.filter(Files.isDirectory(_)).toArray
-          }
-          .getOrElse(Array.empty[Path])
-        dirs.map(d => d -> statFile(d)).toMap
-      } else Map.empty
+      collectDirsRecursively(result.outputDir).map(d => d -> statFile(d)).toMap
 
     val manifest = NoopManifest(
       sourceStats = {

--- a/bleep-core/src/scala/bleep/bsp/BspRifleConfig.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifleConfig.scala
@@ -76,6 +76,12 @@ object BspRifleConfig {
     "-XX:ZCollectionInterval=5",
     "-XX:+UseStringDeduplication",
     "-XX:+HeapDumpOnOutOfMemoryError",
+    // Die immediately on OOM instead of limping on. A worker-thread OOM otherwise poisons
+    // static initializers (e.g. sbt.nio.file.FileTreeView$ fails init once, then throws
+    // NoClassDefFoundError forever), silently bricking all further compiles for the server's
+    // lifetime. The OOM is typically a transient allocation spike (retained heap is far below
+    // -Xmx), so a clean exit + BspRifle restart recovers, where continuing does not.
+    "-XX:+ExitOnOutOfMemoryError",
     "-XX:+IgnoreUnrecognizedVMOptions"
   )
 

--- a/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
+++ b/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
@@ -839,8 +839,8 @@ class ReactiveBspClient(
       case PE.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp) =>
         Some(BuildEvent.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp))
 
-      case PE.SuiteFinished(project, suite, passed, failed, skipped, ignored, durationMs, timestamp) =>
-        Some(BuildEvent.SuiteFinished(project, suite, passed, failed, skipped, ignored, durationMs, timestamp))
+      case PE.SuiteFinished(project, suite, outcome, durationMs, timestamp) =>
+        Some(BuildEvent.SuiteFinished(project, suite, outcome, durationMs, timestamp))
 
       case PE.SuiteTimedOut(project, suite, timeoutMs, threadDump, timestamp) =>
         // protocol's `threadDump: Option[String]` carries the full HotSpot dump text from jstack;

--- a/bleep-core/src/scala/bleep/testing/BuildDiff.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDiff.scala
@@ -1,6 +1,6 @@
 package bleep.testing
 
-import bleep.bsp.protocol.{BleepBspProtocol, CompileStatus, DiagnosticSeverity, TestStatus}
+import bleep.bsp.protocol.{BleepBspProtocol, CompileStatus, DiagnosticSeverity, SuiteOutcome, TestStatus}
 import bleep.model.{CrossProjectName, SuiteName, TestName}
 
 /** Indexed view of a previous run's results, built from events, for fast per-project diff lookups.
@@ -205,10 +205,7 @@ object BuildDiff {
       suite: SuiteName,
       currentTests: List[BuildEvent.TestFinished],
       previousTestResults: Map[TestKey, TestStatus],
-      passed: Int,
-      failed: Int,
-      skipped: Int,
-      ignored: Int,
+      outcome: SuiteOutcome,
       durationMs: Long
   ): SuiteDiff = {
     val newFailures = List.newBuilder[TestName]
@@ -234,10 +231,10 @@ object BuildDiff {
     SuiteDiff(
       project = project,
       suite = suite,
-      passed = passed,
-      failed = failed,
-      skipped = skipped,
-      ignored = ignored,
+      passed = outcome.passedCount,
+      failed = outcome.failedCount,
+      skipped = outcome.skippedCount,
+      ignored = outcome.ignoredCount,
       newFailures = newFailures.result(),
       fixedTests = fixedTests.result(),
       stillFailing = stillFailing.result(),

--- a/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
@@ -1,6 +1,6 @@
 package bleep.testing
 
-import bleep.bsp.protocol.{BleepBspProtocol, CompileReason, DiagnosticSeverity, LinkPlatformName, ProcessExit, TestStatus}
+import bleep.bsp.protocol.{BleepBspProtocol, CompileReason, DiagnosticSeverity, LinkPlatformName, ProcessExit, SuiteOutcome, TestStatus}
 import bleep.bsp.protocol.BleepBspProtocol.BuildMode
 import bleep.model.{CrossProjectName, SuiteName, TestName}
 import bleep.testing.BleepConsole as SConsole
@@ -700,8 +700,8 @@ object BuildDisplay {
       case BuildEvent.TestFinished(_, suite, test, status, durationMs, _, _, _) =>
         if (!quietMode) printTestResult(test, status) else IO.unit
 
-      case BuildEvent.SuiteFinished(_, suite, passed, failed, skipped, ignored, durationMs, _) =>
-        if (!quietMode) printSuiteResult(suite, passed, failed, skipped, ignored, durationMs) else IO.unit
+      case BuildEvent.SuiteFinished(_, suite, outcome, durationMs, _) =>
+        if (!quietMode) printSuiteResult(suite, outcome, durationMs) else IO.unit
 
       case BuildEvent.Output(_, _, line, _, _) =>
         // Suppress test framework stdout — structural events (TestFinished, SuiteFinished)
@@ -854,21 +854,26 @@ object BuildDisplay {
 
     private def printSuiteResult(
         suite: SuiteName,
-        passed: Int,
-        failed: Int,
-        skipped: Int,
-        ignored: Int,
+        outcome: SuiteOutcome,
         durationMs: Long
     ): IO[Unit] = {
-      val ignoredStr = if (ignored > 0) s", $ignored ignored" else ""
-      // Distinguish three cases instead of binary FAILED/PASSED — a suite that reports zero tests across the board ("no tests found") used to render as green
-      // "PASSED 0 passed", which was indistinguishable from a real pass and masked the runner-anomaly bug fixed in 7d5fb0360. Now: yellow NO TESTS for "nothing
-      // ran, nothing failed" — visible to the user without claiming success.
-      val status =
-        if (failed > 0) SConsole.RED + "FAILED" + SConsole.RESET
-        else if (passed == 0 && skipped == 0 && ignored == 0) SConsole.YELLOW + "NO TESTS" + SConsole.RESET
-        else SConsole.GREEN + "PASSED" + SConsole.RESET
-      log(s"$status ${suite.value}: $passed passed, $failed failed, $skipped skipped$ignoredStr ($durationMs ms)")
+      // The outcome variant carries the distinction that used to be inferred from count arithmetic:
+      // a discovered-but-empty suite, a framework mismatch, and a hard error are each their own red
+      // line, never a green "0 passed".
+      def red(s: String) = SConsole.RED + s + SConsole.RESET
+      val line = outcome match {
+        case SuiteOutcome.Executed(passed, failed, skipped, ignored) =>
+          val ignoredStr = if (ignored > 0) s", $ignored ignored" else ""
+          val status = if (failed > 0) red("FAILED") else SConsole.GREEN + "PASSED" + SConsole.RESET
+          s"$status ${suite.value}: $passed passed, $failed failed, $skipped skipped$ignoredStr ($durationMs ms)"
+        case SuiteOutcome.Empty =>
+          s"${red("NO TESTS")} ${suite.value}: discovered but executed 0 tests ($durationMs ms)"
+        case SuiteOutcome.NoFrameworkMatched =>
+          s"${red("NO FRAMEWORK")} ${suite.value}: no test framework/engine claimed this suite ($durationMs ms)"
+        case SuiteOutcome.Errored(message, _) =>
+          s"${red("ERRORED")} ${suite.value}: $message ($durationMs ms)"
+      }
+      log(line)
     }
 
     override def summary: IO[BuildSummary] =
@@ -1061,10 +1066,7 @@ object BuildDisplay {
             sf.suite,
             suiteTests,
             previousRun.testResults,
-            sf.passed,
-            sf.failed,
-            sf.skipped,
-            sf.ignored,
+            sf.outcome,
             sf.durationMs
           )
           log(BuildDiff.formatSuiteDiff(diff))

--- a/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
@@ -106,6 +106,7 @@ case class BuildSummary(
       Left(new bleep.BleepException.Text(s"KSP processor resolution failed for $kspResolutionFailed project(s)"))
     else {
       val testProblems = testsFailed + testsTimedOut + testsCancelled
+      val testsObserved = testsPassed + testsFailed + testsSkipped + testsIgnored + testsTimedOut + testsCancelled
       if (testProblems > 0 || suitesCancelled > 0) {
         val parts = List.newBuilder[String]
         parts += s"$testsPassed passed"
@@ -114,7 +115,13 @@ case class BuildSummary(
         if (testsCancelled > 0) parts += s"$testsCancelled cancelled"
         if (suitesCancelled > 0) parts += s"$suitesCancelled suites cancelled"
         Left(new bleep.BleepException.Text(s"Tests failed: ${parts.result().mkString(", ")}"))
-      } else
+      } else if (suitesCompleted > 0 && testsObserved == 0)
+        // Suites ran to completion but not a single test of any status was observed. This is
+        // never a legitimate green build — it is the silent-zero signature (stale test
+        // discovery, a framework with no matching engine, a runner that exited 0 without
+        // executing). A `Suites: N, Tests: 0` result must not gate CI as success.
+        Left(new bleep.BleepException.Text(s"$suitesCompleted suite(s) completed but executed 0 tests"))
+      else
         Right(())
     }
 }

--- a/bleep-core/src/scala/bleep/testing/BuildEvent.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildEvent.scala
@@ -1,6 +1,6 @@
 package bleep.testing
 
-import bleep.bsp.protocol.{BleepBspProtocol, CompilePhase, CompileReason, CompileStatus, LinkPlatformName, OutputChannel, ProcessExit, TestStatus}
+import bleep.bsp.protocol.{BleepBspProtocol, CompilePhase, CompileReason, CompileStatus, LinkPlatformName, OutputChannel, ProcessExit, SuiteOutcome, TestStatus}
 import bleep.model.{CrossProjectName, SuiteName, TestName}
 import java.nio.file.Path
 
@@ -152,14 +152,11 @@ object BuildEvent {
       timestamp: Long
   ) extends BuildEvent
 
-  /** A test suite has finished execution */
+  /** A test suite has finished execution. `outcome` distinguishes executed-with-counts from empty / no-framework / errored — never conflated as `(0,0,0,0)`. */
   case class SuiteFinished(
       project: CrossProjectName,
       suite: SuiteName,
-      passed: Int,
-      failed: Int,
-      skipped: Int,
-      ignored: Int,
+      outcome: SuiteOutcome,
       durationMs: Long,
       timestamp: Long
   ) extends BuildEvent

--- a/bleep-core/src/scala/bleep/testing/BuildState.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildState.scala
@@ -1,6 +1,6 @@
 package bleep.testing
 
-import bleep.bsp.protocol.{ProcessExit, TestStatus}
+import bleep.bsp.protocol.{ProcessExit, SuiteOutcome, TestStatus}
 import bleep.model.{CrossProjectName, SuiteName, TestName}
 
 /** Canonical state for build/test progress tracking.
@@ -249,30 +249,47 @@ object BuildStateReducer {
         totalTaskTimeMs = state.totalTaskTimeMs + durationMs
       )
 
-    case BuildEvent.SuiteFinished(project, suite, _, failed, _, _, _, _) =>
+    case BuildEvent.SuiteFinished(project, suite, outcome, _, _) =>
       val key = SuiteKey(project, suite)
       // Check if SuiteError already counted this suite (SuiteError can arrive before SuiteFinished)
       val alreadyCounted = state.failures.exists(f => f.project == project && f.suite == suite && f.category == FailureCategory.ProcessError)
-      // If suite reports failures but no individual TestFinished events created TestFailure entries,
-      // create a synthetic failure so the summary shows useful info instead of "detailed info was not captured"
       val existingFailuresForSuite = state.failures.count(f => f.project == project && f.suite == suite)
-      val syntheticFailures = if (failed > 0 && existingFailuresForSuite == 0) {
-        val output = state.pendingOutput.getOrElse(key, Nil)
-        List(
-          TestFailure(
-            project = project,
-            suite = suite,
-            test = TestName("(suite failed)"),
-            message = Some(s"Suite reported $failed failure(s) but no individual test results were captured"),
-            throwable = None,
-            output = output,
-            category = FailureCategory.ProcessError
+      // The outcome variant, not count arithmetic, says why (if) the suite failed. A failing
+      // outcome with no per-test TestFinished events (Empty / NoFrameworkMatched / Errored, or a
+      // suite-level failure whose individual events were lost) gets one synthetic failure so the
+      // summary shows a reason and count-based gates (toEither) see it.
+      val failureReason: Option[String] = outcome match {
+        case SuiteOutcome.Executed(_, failed, _, _) if failed > 0 =>
+          Some(s"Suite reported $failed failure(s) but no individual test results were captured")
+        case _: SuiteOutcome.Executed         => None
+        case SuiteOutcome.Empty               => Some(s"Suite ${suite.value} was discovered but executed 0 tests")
+        case SuiteOutcome.NoFrameworkMatched  => Some(s"No test framework/engine claimed ${suite.value}")
+        case SuiteOutcome.Errored(message, _) => Some(message)
+      }
+      val syntheticFailures = failureReason match {
+        case Some(msg) if existingFailuresForSuite == 0 =>
+          List(
+            TestFailure(
+              project = project,
+              suite = suite,
+              test = TestName("(suite failed)"),
+              message = Some(msg),
+              throwable = None,
+              output = state.pendingOutput.getOrElse(key, Nil),
+              category = FailureCategory.ProcessError
+            )
           )
-        )
-      } else Nil
+        case _ => Nil
+      }
+      val isFailure = outcome.isFailure
+      // For a failing suite with no per-test failures already counted, surface one failed test so
+      // count-based gates see it even when other suites in the run passed. Executed(failed>0) whose
+      // per-test events already incremented testsFailed is excluded via existingFailuresForSuite.
+      val addFailedTest = isFailure && !alreadyCounted && existingFailuresForSuite == 0
       state.copy(
         suitesCompleted = if (alreadyCounted) state.suitesCompleted else state.suitesCompleted + 1,
-        suitesFailed = if (alreadyCounted) state.suitesFailed else state.suitesFailed + (if (failed > 0) 1 else 0),
+        suitesFailed = if (alreadyCounted) state.suitesFailed else state.suitesFailed + (if (isFailure) 1 else 0),
+        testsFailed = if (addFailedTest) state.testsFailed + 1 else state.testsFailed,
         runningSuites = state.runningSuites - key,
         suiteStartTimes = state.suiteStartTimes - key,
         pendingOutput = state.pendingOutput - key,

--- a/bleep-core/src/scala/bleep/testing/FancyBuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/FancyBuildDisplay.scala
@@ -433,7 +433,7 @@ object FancyBuildDisplay {
           if (state.recentPasses.size > 5) state.recentPasses.removeLast(): Unit
         }
 
-      case BuildEvent.SuiteFinished(project, suite, _, _, _, _, _, _) =>
+      case BuildEvent.SuiteFinished(project, suite, _, _, _) =>
         val key = SuiteKey(project, suite)
         state.runningSuites.remove(key): Unit
 

--- a/bleep-core/src/scala/bleep/testing/JUnitXmlReport.scala
+++ b/bleep-core/src/scala/bleep/testing/JUnitXmlReport.scala
@@ -209,7 +209,7 @@ class JUnitXmlCollector {
       )
       activeSuites.get(key).foreach(state => activeSuites(key) = state.copy(testCases = tc :: state.testCases))
 
-    case BuildEvent.SuiteFinished(project, suite, _, _, _, _, durationMs, _) =>
+    case BuildEvent.SuiteFinished(project, suite, _, durationMs, _) =>
       val key = SuiteKey(project, suite)
       activeSuites.remove(key).foreach { state =>
         completedSuites += TestSuiteResult(

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -99,14 +99,15 @@ object JvmPool {
   def create(
       maxConcurrency: Int,
       jvmCommand: Path,
-      workingDirectory: Path
+      workingDirectory: Path,
+      serverWideForkLimit: java.util.concurrent.Semaphore
   ): Resource[IO, JvmPool] =
     Resource.make(
       for {
         semaphore <- Semaphore[IO](maxConcurrency.toLong)
         pool <- IO(new TrieMap[JvmKey, Queue[IO, ManagedJvm]]())
         allJvms <- Ref.of[IO, Set[ManagedJvm]](Set.empty)
-      } yield new JvmPoolImpl(semaphore, pool, allJvms, new TrieMap[JvmKey, Int](), jvmCommand, workingDirectory)
+      } yield new JvmPoolImpl(semaphore, serverWideForkLimit, pool, allJvms, new TrieMap[JvmKey, Int](), jvmCommand, workingDirectory)
     )(_.shutdown)
 
   /** Key for pooling JVMs */
@@ -267,6 +268,7 @@ object JvmPool {
 
   private class JvmPoolImpl(
       semaphore: Semaphore[IO],
+      serverWideForkLimit: java.util.concurrent.Semaphore,
       pool: TrieMap[JvmKey, Queue[IO, ManagedJvm]],
       allJvms: Ref[IO, Set[ManagedJvm]],
       spawnFailures: TrieMap[JvmKey, Int],
@@ -283,17 +285,25 @@ object JvmPool {
     ): Resource[IO, TestJvm] = {
       val key = JvmKey(classpath, jvmOptions, environment, workingDirectory)
 
-      Resource
-        .make(
-          for {
-            _ <- semaphore.acquire
-            jvm <- getOrCreate(key, classpath, jvmOptions, runnerClass, environment, workingDirectory)
-          } yield (jvm, new TestJvmImpl(jvm): TestJvm)
-        ) { case (jvm, _) =>
-          // Return JVM to pool and release semaphore
-          release(jvm) >> semaphore.release
-        }
-        .map(_._2)
+      // Server-wide fork limit (shared across all clients) acquired OUTSIDE the per-pool semaphore,
+      // released last — so a permit is never held while another client waits on the pool. The
+      // separate Resource guarantees the permit is released even if getOrCreate/spawn fails.
+      val serverWidePermit: Resource[IO, Unit] =
+        Resource.make(IO.interruptible(serverWideForkLimit.acquire()))(_ => IO(serverWideForkLimit.release()))
+
+      serverWidePermit.flatMap { _ =>
+        Resource
+          .make(
+            for {
+              _ <- semaphore.acquire
+              jvm <- getOrCreate(key, classpath, jvmOptions, runnerClass, environment, workingDirectory)
+            } yield (jvm, new TestJvmImpl(jvm): TestJvm)
+          ) { case (jvm, _) =>
+            // Return JVM to pool and release semaphore
+            release(jvm) >> semaphore.release
+          }
+          .map(_._2)
+      }
     }
 
     private def getOrCreate(
@@ -389,15 +399,17 @@ object JvmPool {
       IO.interruptible {
         val line = jvm.stdout.readLine()
         if (line == null) {
-          // Process terminated - capture stderr to show actual error
+          // Process terminated before the Ready handshake. Capture the exit code and pid — with no
+          // stderr (a child SIGKILLed before writing leaves it empty) these are the only signal.
+          // Exit 137 = SIGKILL (OOM killer / fork storm), 1 = JVM startup failure, etc. Without them
+          // the failure is just "terminated before Ready (no stderr output)" — nothing to debug.
           Thread.sleep(100) // Give stderr a moment to be available
           val stderrOutput = jvm.readStderr()
-          val errorMsg = if (stderrOutput.nonEmpty) {
-            s"JVM process terminated before sending Ready. Stderr:\n$stderrOutput"
-          } else {
-            "JVM process terminated before sending Ready (no stderr output)"
-          }
-          throw new IOException(errorMsg)
+          val pid = jvm.process.pid()
+          val exited = jvm.process.waitFor(2, java.util.concurrent.TimeUnit.SECONDS)
+          val exitStr = if (exited) s"exit code ${jvm.process.exitValue()}" else "still alive after 2s (no exit)"
+          val stderrPart = if (stderrOutput.nonEmpty) s" Stderr:\n$stderrOutput" else " (no stderr output)"
+          throw new IOException(s"JVM process (pid=$pid) terminated before sending Ready — $exitStr.$stderrPart")
         }
         TestProtocol.decodeResponse(line) match {
           case Right(TestProtocol.TestResponse.Ready) => ()

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -144,6 +144,7 @@ object JvmPool {
   ) {
     @volatile private var alive = true
     @volatile private var _protocolClean = true
+    @volatile private var _suiteInFlight = false
 
     /** Buffered stderr lines collected by the drain thread. Bounded so a runaway warning storm can't OOM the parent. Oldest lines are dropped past the cap. */
     private val stderrBuffer = new java.util.concurrent.ConcurrentLinkedDeque[String]()
@@ -172,6 +173,19 @@ object JvmPool {
 
     def markProtocolDirty(): Unit =
       _protocolClean = false
+
+    /** True between sending a RunSuite command and consuming that suite's terminal response. While set, the child's stdout may still hold unread
+      * TestFinished/SuiteDone lines from the in-flight suite, so the JVM is NOT safe to hand to another acquirer — the next RunSuite would read this suite's
+      * leftover terminator and misattribute its counts. A suite that ends by cancellation (fiber killed mid-run) leaves this set precisely so [[release]] kills
+      * the JVM instead of re-pooling it.
+      */
+    def suiteInFlight: Boolean = _suiteInFlight
+
+    def markSuiteStarted(): Unit =
+      _suiteInFlight = true
+
+    def markSuiteFinished(): Unit =
+      _suiteInFlight = false
 
     def markDead(): Unit =
       alive = false
@@ -423,7 +437,7 @@ object JvmPool {
 
     /** Return a JVM to the pool for reuse */
     private def release(jvm: ManagedJvm): IO[Unit] =
-      if (jvm.isAlive && jvm.protocolClean) {
+      if (jvm.isAlive && jvm.protocolClean && !jvm.suiteInFlight) {
         for {
           queue <- IO(
             pool.getOrElseUpdate(
@@ -451,12 +465,22 @@ object JvmPool {
       ): Stream[IO, TestProtocol.TestResponse] = {
         val command = TestProtocol.TestCommand.RunSuite(className, framework, args)
 
-        Stream.eval(sendCommand(command)) >>
-          readResponses.takeThrough {
-            case _: TestProtocol.TestResponse.SuiteDone => false
-            case _: TestProtocol.TestResponse.Error     => false
-            case _                                      => true
-          }
+        val body =
+          Stream.eval(IO(jvm.markSuiteStarted()) >> sendCommand(command)) >>
+            readResponses.takeThrough {
+              case _: TestProtocol.TestResponse.SuiteDone => false
+              case _: TestProtocol.TestResponse.Error     => false
+              case _                                      => true
+            }
+
+        // Clear the in-flight flag only when the stream drains to its terminator
+        // (SuiteDone/Error consumed) — then the protocol is at a clean boundary and the JVM
+        // is safe to re-pool. On cancellation the flag stays set, so `release` kills the JVM
+        // rather than handing a mid-suite protocol stream to the next acquirer.
+        body.onFinalizeCase {
+          case Resource.ExitCase.Succeeded => IO(jvm.markSuiteFinished())
+          case _                           => IO.unit
+        }
       }
 
       private def sendCommand(cmd: TestProtocol.TestCommand): IO[Unit] =

--- a/bleep-core/src/scala/bleep/testing/ReactiveTestRunner.scala
+++ b/bleep-core/src/scala/bleep/testing/ReactiveTestRunner.scala
@@ -1,6 +1,6 @@
 package bleep.testing
 
-import bleep.bsp.protocol.{OutputChannel, TestStatus}
+import bleep.bsp.protocol.{OutputChannel, SuiteOutcome, TestStatus}
 import bleep.bsp.BuildServer
 import bleep.{model, Started}
 import bleep.model.{CrossProjectName, SuiteName, TestName}
@@ -226,12 +226,12 @@ object ReactiveTestRunner {
                 )
             }
 
-        case TestProtocol.TestResponse.SuiteDone(_, passed, failed, skipped, ignored, durationMs) =>
+        case TestProtocol.TestResponse.SuiteDone(_, outcome, durationMs) =>
           IO.realTime
             .map(_.toMillis)
             .flatMap(now =>
               display.handle(
-                BuildEvent.SuiteFinished(projectName, SuiteName(suite.className), passed, failed, skipped, ignored, durationMs, now)
+                BuildEvent.SuiteFinished(projectName, SuiteName(suite.className), outcome, durationMs, now)
               )
             ) >> suiteFinishedSent.set(true)
 
@@ -353,10 +353,7 @@ object ReactiveTestRunner {
                         BuildEvent.SuiteFinished(
                           projectName,
                           SuiteName(suite.className),
-                          result.passed,
-                          result.failed,
-                          result.skipped,
-                          result.ignored,
+                          SuiteOutcome.fromCounts(result.passed, result.failed, result.skipped, result.ignored),
                           endTime - startTime,
                           endTime
                         )

--- a/bleep-core/src/scala/bleep/testing/ReactiveTestRunner.scala
+++ b/bleep-core/src/scala/bleep/testing/ReactiveTestRunner.scala
@@ -73,60 +73,69 @@ object ReactiveTestRunner {
       options: Options
   ): IO[Result] =
 
-    JvmPool.create(options.maxParallelJvms, started.jvmCommand, started.buildPaths.buildDir).use { pool =>
-      for {
-        display <- BuildDisplay.create(options.quietMode, started.logger)
+    // Standalone (single-process) runner: the fork limit is just this run's parallelism, so a
+    // local semaphore with maxParallelJvms permits — no cross-client sharing to coordinate here.
+    JvmPool
+      .create(
+        options.maxParallelJvms,
+        started.jvmCommand,
+        started.buildPaths.buildDir,
+        new java.util.concurrent.Semaphore(options.maxParallelJvms, /* fair = */ true)
+      )
+      .use { pool =>
+        for {
+          display <- BuildDisplay.create(options.quietMode, started.logger)
 
-        // Build target lookup
-        buildTargetFor = (p: CrossProjectName) =>
-          new bsp4j.BuildTargetIdentifier(
-            started.projectPaths(p).targetDir.toUri.toASCIIString
+          // Build target lookup
+          buildTargetFor = (p: CrossProjectName) =>
+            new bsp4j.BuildTargetIdentifier(
+              started.projectPaths(p).targetDir.toUri.toASCIIString
+            )
+
+          // Discover all test suites
+          suites <- IO(
+            TestDiscovery.discoverAll(
+              server,
+              testProjects,
+              buildTargetFor
+            )
           )
 
-        // Discover all test suites
-        suites <- IO(
-          TestDiscovery.discoverAll(
-            server,
-            testProjects,
-            buildTargetFor
-          )
-        )
+          _ <- IO.delay(started.logger.info(s"Discovered ${suites.size} test suites in ${testProjects.size} projects"))
 
-        _ <- IO.delay(started.logger.info(s"Discovered ${suites.size} test suites in ${testProjects.size} projects"))
+          // Group suites by project for classpath sharing
+          suitesByProject = suites.groupBy(_.project)
 
-        // Group suites by project for classpath sharing
-        suitesByProject = suites.groupBy(_.project)
+          // Run all suites in parallel, bounded by JVM pool
+          result <- {
+            val runSuites = suitesByProject.toList.parTraverse { case (project, projectSuites) =>
+              runProjectSuites(
+                started = started,
+                project = project,
+                suites = projectSuites,
+                pool = pool,
+                display = display,
+                options = options
+              )
+            }
 
-        // Run all suites in parallel, bounded by JVM pool
-        result <- {
-          val runSuites = suitesByProject.toList.parTraverse { case (project, projectSuites) =>
-            runProjectSuites(
-              started = started,
-              project = project,
-              suites = projectSuites,
-              pool = pool,
-              display = display,
-              options = options
-            )
+            runSuites.flatMap { _ =>
+              for {
+                // ReactiveTestRunner is the legacy non-BSP path; it doesn't expose filter flags at this layer, so no FilterContext.
+                _ <- display.printSummary(None)
+                summary <- display.summary
+              } yield Result(
+                passed = summary.testsPassed,
+                failed = summary.testsFailed,
+                skipped = summary.testsSkipped,
+                ignored = summary.testsIgnored,
+                failedSuites = summary.failures.map(_.suite).distinct,
+                durationMs = summary.durationMs
+              )
+            }
           }
-
-          runSuites.flatMap { _ =>
-            for {
-              // ReactiveTestRunner is the legacy non-BSP path; it doesn't expose filter flags at this layer, so no FilterContext.
-              _ <- display.printSummary(None)
-              summary <- display.summary
-            } yield Result(
-              passed = summary.testsPassed,
-              failed = summary.testsFailed,
-              skipped = summary.testsSkipped,
-              ignored = summary.testsIgnored,
-              failedSuites = summary.failures.map(_.suite).distinct,
-              durationMs = summary.durationMs
-            )
-          }
-        }
-      } yield result
-    }
+        } yield result
+      }
 
   private def runProjectSuites(
       started: Started,

--- a/bleep-core/src/scala/bleep/testing/TestProtocol.scala
+++ b/bleep-core/src/scala/bleep/testing/TestProtocol.scala
@@ -1,5 +1,6 @@
 package bleep.testing
 
+import bleep.bsp.protocol.SuiteOutcome
 import io.circe._
 import io.circe.generic.semiauto._
 import io.circe.syntax._
@@ -75,13 +76,12 @@ object TestProtocol {
         throwable: Option[String]
     ) extends TestResponse
 
-    /** A test suite has completed */
+    /** A test suite has completed. `outcome` is reconstructed from the flat wire fields (the Java forked runner emits a `kind` discriminator plus counts) into
+      * the [[SuiteOutcome]] ADT so nothing downstream re-derives meaning from an all-zero count tuple.
+      */
     case class SuiteDone(
         suite: String,
-        passed: Int,
-        failed: Int,
-        skipped: Int,
-        ignored: Int,
+        outcome: SuiteOutcome,
         durationMs: Long
     ) extends TestResponse
 
@@ -122,8 +122,37 @@ object TestProtocol {
     implicit val testFinishedEncoder: Encoder[TestFinished] = deriveEncoder
     implicit val testFinishedDecoder: Decoder[TestFinished] = deriveDecoder
 
-    implicit val suiteDoneEncoder: Encoder[SuiteDone] = deriveEncoder
-    implicit val suiteDoneDecoder: Decoder[SuiteDone] = deriveDecoder
+    // The wire is flat (kind discriminator + counts + optional message/throwable), matching the
+    // hand-rolled JSON the Java forked runner emits; the outcome ADT is (re)constructed here.
+    implicit val suiteDoneEncoder: Encoder[SuiteDone] = Encoder.instance { sd =>
+      val base = Json.obj(
+        "suite" -> sd.suite.asJson,
+        "outcome" -> SuiteOutcome.tagOf(sd.outcome).asJson,
+        "passed" -> sd.outcome.passedCount.asJson,
+        "failed" -> sd.outcome.failedCount.asJson,
+        "skipped" -> sd.outcome.skippedCount.asJson,
+        "ignored" -> sd.outcome.ignoredCount.asJson,
+        "durationMs" -> sd.durationMs.asJson
+      )
+      sd.outcome match {
+        case SuiteOutcome.Errored(message, throwable) =>
+          base.deepMerge(Json.obj("message" -> message.asJson, "throwable" -> throwable.asJson))
+        case _ => base
+      }
+    }
+    implicit val suiteDoneDecoder: Decoder[SuiteDone] = Decoder.instance { c =>
+      for {
+        suite <- c.downField("suite").as[String]
+        kind <- c.downField("outcome").as[String]
+        passed <- c.downField("passed").as[Int]
+        failed <- c.downField("failed").as[Int]
+        skipped <- c.downField("skipped").as[Int]
+        ignored <- c.downField("ignored").as[Int]
+        durationMs <- c.downField("durationMs").as[Long]
+        message <- c.downField("message").as[Option[String]]
+        throwable <- c.downField("throwable").as[Option[String]]
+      } yield SuiteDone(suite, SuiteOutcome.fromWire(kind, passed, failed, skipped, ignored, message, throwable), durationMs)
+    }
 
     implicit val logEncoder: Encoder[Log] = deriveEncoder
     implicit val logDecoder: Decoder[Log] = deriveDecoder

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/ForkedTestRunner.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/ForkedTestRunner.java
@@ -266,10 +266,13 @@ public class ForkedTestRunner {
       }
 
       if (tasks == null || tasks.length == 0) {
-        send(TestProtocol.encodeError("No tests found for class: " + className, null));
+        // No fingerprint produced a task: the loaded framework does not recognize this class as
+        // a suite. Not an empty suite (the framework never claimed it) — a framework mismatch.
         send(
-            TestProtocol.encodeSuiteDone(
-                className, 0, 1, 0, 0, System.currentTimeMillis() - startTime));
+            TestProtocol.encodeSuiteNoFrameworkMatched(
+                className,
+                System.currentTimeMillis() - startTime,
+                "No test framework recognized " + className + " as a suite"));
         return;
       }
 
@@ -350,9 +353,15 @@ public class ForkedTestRunner {
       capturedErr.flush();
 
       long durationMs = System.currentTimeMillis() - startTime;
-      send(
-          TestProtocol.encodeSuiteDone(
-              className, passed[0], failed[0], skipped[0], ignored[0], durationMs));
+      int total = passed[0] + failed[0] + skipped[0] + ignored[0];
+      if (total == 0) {
+        // The framework claimed the class (a task ran) but no test fired an event: an empty suite.
+        send(TestProtocol.encodeSuiteEmpty(className, durationMs));
+      } else {
+        send(
+            TestProtocol.encodeSuiteExecuted(
+                className, passed[0], failed[0], skipped[0], ignored[0], durationMs));
+      }
 
     } catch (InterruptedException e) {
       // Cancelled - report and re-throw to exit the run
@@ -360,33 +369,33 @@ public class ForkedTestRunner {
       throw new RuntimeException(e);
     } catch (SecurityException e) {
       if (e.getMessage() != null && e.getMessage().contains("System.exit")) {
-        // System.exit was blocked - report failure
         send(
-            TestProtocol.encodeSuiteDone(
-                className, 0, 1, 0, 0, System.currentTimeMillis() - startTime));
+            TestProtocol.encodeSuiteErrored(
+                className,
+                System.currentTimeMillis() - startTime,
+                "Test attempted a blocked System.exit",
+                null));
       } else {
         throw e;
       }
     } catch (Throwable e) {
-      // Must catch Throwable (not just Exception) because test frameworks may let
-      // Errors (e.g. AssertionError) escape from task.execute() in some edge cases.
-      // Without this, the forked JVM crashes without sending SuiteDone, causing
-      // the parent to report "0 passed, 0 failed" regardless of actual results.
-      send(
-          TestProtocol.encodeLog(
-              "error", "Error in runSuite: " + e.getClass().getName() + ": " + e.getMessage()));
+      // Must catch Throwable (not just Exception): a framework may let an Error (AssertionError,
+      // or a LinkageError propagated from executeTasks) escape. Report it as an errored suite —
+      // NOT SuiteExecuted with faked counts — so the outcome carries the real reason.
       send(TestProtocol.encodeLog("error", stackTraceToString(e)));
-      // Send SuiteDone with counts collected so far (from EventHandler, if any events arrived
-      // before the error). If the error happened before the EventHandler was called, counts
-      // will be 0/0 and the error message below provides the failure signal.
+      Throwable reported =
+          (e instanceof SuiteExecutionException && e.getCause() != null) ? e.getCause() : e;
       send(
-          TestProtocol.encodeSuiteDone(
+          TestProtocol.encodeSuiteErrored(
               className,
-              passed[0],
-              failed[0] + 1,
-              skipped[0],
-              ignored[0],
-              System.currentTimeMillis() - startTime));
+              System.currentTimeMillis() - startTime,
+              "Error running suite "
+                  + className
+                  + ": "
+                  + reported.getClass().getName()
+                  + ": "
+                  + reported.getMessage(),
+              stackTraceToString(reported)));
     }
   }
 

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/ForkedTestRunner.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/ForkedTestRunner.java
@@ -405,14 +405,25 @@ public class ForkedTestRunner {
       } catch (InterruptedException e) {
         throw e;
       } catch (Throwable e) {
-        // Log error but continue with other tasks.
-        // Must catch Throwable (not just Exception) because test frameworks may let
-        // Errors (e.g. AssertionError) escape from task.execute() in some edge cases.
-        send(
-            TestProtocol.encodeLog(
-                "error",
-                "Task execution failed: " + e.getMessage() + "\n" + stackTraceToString(e)));
+        // Do NOT swallow and continue. A Throwable escaping task.execute — LinkageError,
+        // NoClassDefFoundError, ExceptionInInitializerError, typically from a stale sibling
+        // compile — means this suite's classpath cannot be trusted, not that one test failed.
+        // Swallowing it here let the suite fall through to SuiteDone(...,0,0,0) and be reported
+        // PASSED: a green build over a suite that never ran. Propagate so the caller's handler
+        // records a real failure with a non-zero count.
+        throw new SuiteExecutionException(e);
       }
+    }
+  }
+
+  /**
+   * Wraps a non-interruption Throwable that escaped {@code task.execute} so it propagates out of
+   * {@link #executeTasks} (whose only checked throw is InterruptedException) to runSuite's outer
+   * handler, which reports it as a suite failure.
+   */
+  private static final class SuiteExecutionException extends RuntimeException {
+    SuiteExecutionException(Throwable cause) {
+      super(cause);
     }
   }
 

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/JUnitPlatformRunner.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/JUnitPlatformRunner.java
@@ -178,21 +178,19 @@ class JUnitPlatformRunner {
 
         // Discover before executing. If no engine claims this class — the classic case is a
         // JUnit 4 (@org.junit.Test) class routed here with junit-platform present but no
-        // junit-vintage-engine on the classpath — execute() silently runs nothing and we would
-        // report SuiteDone(...,0,0,0) as a green pass. Treat an empty plan as a suite failure.
+        // junit-vintage-engine on the classpath — execute() silently runs nothing. Report it as
+        // NoFrameworkMatched, not a green pass.
         TestPlan plan = launcher.discover(request);
         long discovered = plan.countTestIdentifiers(TestIdentifier::isTest);
         if (discovered == 0) {
           send(
-              TestProtocol.encodeLog(
-                  "error",
-                  "No JUnit Platform engine executed any test in "
+              TestProtocol.encodeSuiteNoFrameworkMatched(
+                  className,
+                  System.currentTimeMillis() - startTime,
+                  "No JUnit Platform engine claimed "
                       + className
                       + ". A JUnit 4 test class needs junit-vintage-engine on the test"
                       + " classpath."));
-          send(
-              TestProtocol.encodeSuiteDone(
-                  className, 0, 1, 0, 0, System.currentTimeMillis() - startTime));
           return;
         }
 
@@ -204,24 +202,28 @@ class JUnitPlatformRunner {
       capturedErr.flush();
 
       long durationMs = System.currentTimeMillis() - startTime;
-      send(
-          TestProtocol.encodeSuiteDone(
-              className, passed[0], failed[0], skipped[0], ignored[0], durationMs));
+      int total = passed[0] + failed[0] + skipped[0] + ignored[0];
+      if (total == 0) {
+        send(TestProtocol.encodeSuiteEmpty(className, durationMs));
+      } else {
+        send(
+            TestProtocol.encodeSuiteExecuted(
+                className, passed[0], failed[0], skipped[0], ignored[0], durationMs));
+      }
 
     } catch (Throwable e) {
-      send(
-          TestProtocol.encodeLog(
-              "error",
-              "Error in JUnit Platform runner: " + e.getClass().getName() + ": " + e.getMessage()));
       send(TestProtocol.encodeLog("error", stackTraceToString(e)));
       send(
-          TestProtocol.encodeSuiteDone(
+          TestProtocol.encodeSuiteErrored(
               className,
-              passed[0],
-              failed[0] + 1,
-              skipped[0],
-              ignored[0],
-              System.currentTimeMillis() - startTime));
+              System.currentTimeMillis() - startTime,
+              "Error in JUnit Platform runner for "
+                  + className
+                  + ": "
+                  + e.getClass().getName()
+                  + ": "
+                  + e.getMessage(),
+              stackTraceToString(e)));
     }
   }
 

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/JUnitPlatformRunner.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/JUnitPlatformRunner.java
@@ -176,6 +176,26 @@ class JUnitPlatformRunner {
               }
             };
 
+        // Discover before executing. If no engine claims this class — the classic case is a
+        // JUnit 4 (@org.junit.Test) class routed here with junit-platform present but no
+        // junit-vintage-engine on the classpath — execute() silently runs nothing and we would
+        // report SuiteDone(...,0,0,0) as a green pass. Treat an empty plan as a suite failure.
+        TestPlan plan = launcher.discover(request);
+        long discovered = plan.countTestIdentifiers(TestIdentifier::isTest);
+        if (discovered == 0) {
+          send(
+              TestProtocol.encodeLog(
+                  "error",
+                  "No JUnit Platform engine executed any test in "
+                      + className
+                      + ". A JUnit 4 test class needs junit-vintage-engine on the test"
+                      + " classpath."));
+          send(
+              TestProtocol.encodeSuiteDone(
+                  className, 0, 1, 0, 0, System.currentTimeMillis() - startTime));
+          return;
+        }
+
         launcher.execute(request, listener);
       }
 

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/JUnitPlatformRunner.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/JUnitPlatformRunner.java
@@ -176,13 +176,16 @@ class JUnitPlatformRunner {
               }
             };
 
-        // Discover before executing. If no engine claims this class — the classic case is a
+        // Discover before executing. If NO engine claims this class at all — the classic case is a
         // JUnit 4 (@org.junit.Test) class routed here with junit-platform present but no
-        // junit-vintage-engine on the classpath — execute() silently runs nothing. Report it as
-        // NoFrameworkMatched, not a green pass.
+        // junit-vintage-engine — no engine contributes a root, and execute() silently runs nothing.
+        // Report NoFrameworkMatched, not a green pass.
+        //
+        // Test on getRoots() (engine descriptors), NOT countTestIdentifiers(isTest): dynamic
+        // frameworks like Kotest register their engine root here but report zero *test* identifiers
+        // until execution registers them, so an isTest count of 0 at discovery is a false negative.
         TestPlan plan = launcher.discover(request);
-        long discovered = plan.countTestIdentifiers(TestIdentifier::isTest);
-        if (discovered == 0) {
+        if (plan.getRoots().isEmpty()) {
           send(
               TestProtocol.encodeSuiteNoFrameworkMatched(
                   className,
@@ -204,6 +207,8 @@ class JUnitPlatformRunner {
       long durationMs = System.currentTimeMillis() - startTime;
       int total = passed[0] + failed[0] + skipped[0] + ignored[0];
       if (total == 0) {
+        // An engine claimed the class but ran no tests — an empty suite (or a container that
+        // registered nothing). Still not a pass.
         send(TestProtocol.encodeSuiteEmpty(className, durationMs));
       } else {
         send(

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/TestProtocol.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/TestProtocol.java
@@ -61,22 +61,63 @@ public final class TestProtocol {
     return sb.toString();
   }
 
-  public static String encodeSuiteDone(
+  /**
+   * A suite that executed tests. Counts are authoritative; total is > 0 by construction (a
+   * completed suite that produced no test events is {@link #encodeSuiteEmpty}, not this with
+   * zeros).
+   */
+  public static String encodeSuiteExecuted(
       String suite, int passed, int failed, int skipped, int ignored, long durationMs) {
-    return "{\"type\":\"SuiteDone\",\"data\":{"
-        + "\"suite\":"
-        + jsonString(suite)
-        + ",\"passed\":"
-        + passed
-        + ",\"failed\":"
-        + failed
-        + ",\"skipped\":"
-        + skipped
-        + ",\"ignored\":"
-        + ignored
-        + ",\"durationMs\":"
-        + durationMs
-        + "}}";
+    return encodeSuiteDone(
+        suite, "executed", passed, failed, skipped, ignored, durationMs, null, null);
+  }
+
+  /** A suite the framework recognized but that registered/ran zero tests. */
+  public static String encodeSuiteEmpty(String suite, long durationMs) {
+    return encodeSuiteDone(suite, "empty", 0, 0, 0, 0, durationMs, null, null);
+  }
+
+  /** A suite class no engine claimed (e.g. JUnit 4 with no junit-vintage-engine). */
+  public static String encodeSuiteNoFrameworkMatched(
+      String suite, long durationMs, String message) {
+    return encodeSuiteDone(suite, "noFrameworkMatched", 0, 0, 0, 0, durationMs, message, null);
+  }
+
+  /**
+   * A suite that could not run to completion (class-load/link error, Throwable escaped execution).
+   */
+  public static String encodeSuiteErrored(
+      String suite, long durationMs, String message, String throwable) {
+    return encodeSuiteDone(suite, "errored", 0, 0, 0, 0, durationMs, message, throwable);
+  }
+
+  private static String encodeSuiteDone(
+      String suite,
+      String outcome,
+      int passed,
+      int failed,
+      int skipped,
+      int ignored,
+      long durationMs,
+      String message,
+      String throwable) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\"type\":\"SuiteDone\",\"data\":{");
+    sb.append("\"suite\":").append(jsonString(suite));
+    sb.append(",\"outcome\":").append(jsonString(outcome));
+    sb.append(",\"passed\":").append(passed);
+    sb.append(",\"failed\":").append(failed);
+    sb.append(",\"skipped\":").append(skipped);
+    sb.append(",\"ignored\":").append(ignored);
+    sb.append(",\"durationMs\":").append(durationMs);
+    if (message != null) {
+      sb.append(",\"message\":").append(jsonString(message));
+    }
+    if (throwable != null) {
+      sb.append(",\"throwable\":").append(jsonString(throwable));
+    }
+    sb.append("}}");
+    return sb.toString();
   }
 
   public static String encodeLog(String level, String message) {


### PR DESCRIPTION
Fixes the bug reports accumulated in `~/bleep` since the M10 release, plus two follow-on pieces that grew out of them: a unified machine-resource governor and a backward-compatible protocol codec. All the reports post-date the current `master` tip, so almost none were already fixed; several were also **misdiagnosed** — the biggest correction is that **bleep has no test-result cache**, so every "stale test cache" theory in the reports is wrong. The real causes were forked-JVM protocol desync, framework mismatches, an overloaded `(0,0,0)` count tuple, and unbounded aggregate fork memory.

Themed commits, each independently reviewable. Full build compiles; the touched-area unit + integration suites are green (governor concurrency, SuiteOutcome round-trip, protocol back-compat, BuildStateReducer, BuildDiff, JvmTestRunner, ForkedTestRunnerFramework across JUnit4/5/ScalaTest/Kotest, ZincCacheRoundtrip, IncrementalCompilation, PlatformTestRunner, BspCompilation/Cancellation, SharedWorkspaceState).

## Correctness

**1. Zinc under-invalidation → silent green builds over broken sources** (`1e139fa0`)
- A cancelled compile wrote a poisoned noop manifest (Zinc swallows `CompileCancelled` and returns `hasModified=false`, indistinguishable from up-to-date).
- Source dirs were stat'd non-recursively while output dirs were walked recursively — files added in nested package dirs (what codegen produces) were invisible → project wrongly declared a noop (manifest v4).
- `dependencyAnalyses` was direct-only while the classpath is transitive; a two-hop-upstream API change was invisible, doubly so because a noop intermediate never bumps its `analysis.zip` mtime.
- The cycle guard misread Zinc's `detectInitialChanges` probe as a cycle — source of the bogus "Zinc incremental compilation bug … 0 class(es)" warning on every clean build.

**2. Test runner never reports a discovered-but-unexecuted suite as green** (`0e01e24d`)
- 0-tests → failure; `ForkedTestRunner.executeTasks` no longer swallows `Throwable`; cancelled suites kill (never re-pool) their forked JVM via a `suiteInFlight` invariant, ending the protocol desync behind the nondeterministic-subset runs; JUnit-4-with-no-vintage-engine fails loudly; plus a global `BuildSummary.toEither` backstop.

**3. SuiteOutcome ADT — ending the `(0,0,0)` overload** (`94a8725d`, `f64f0260`)
- `Executed | Empty | NoFrameworkMatched | Errored` threaded from the forked runner through the wire, server, events, and client. Removes the fake `failed+1` hacks and ad-hoc count arithmetic. A *suite* discovered-but-empty is red; a *project* with zero discovered suites is green. Follow-up fix: detect "no engine" via `plan.getRoots().isEmpty()`, not an `isTest` count at discovery, so dynamic frameworks (Kotest) aren't aborted.

## Robustness

**4. OOM is fatal-and-restart, not silent-brick** (`4a0dc5db`)
- `-XX:+ExitOnOutOfMemoryError` + `halt(1)` handlers so a worker-thread OOM restarts a clean server instead of running on with a poisoned `FileTreeView$` static init. Heap-pressure gate bounded at 60s.

**5. BSP server log no longer grows into the hundreds of MB** (`964ff87c`)
- Test-event traces dropped warn→debug, `Output` (per-line test stdout) excluded, daemon file logger filtered to Info.

**6. Machine-resource governor — unify compiles and forks** (`df71e43c`, `666cad0b`, `7686dcaa`)
- Compiles and forked JVMs (test, sourcegen, KSP) all run on the same cores and RAM, but each subsystem gated itself independently — together they oversubscribed the machine (N cores of compiles + N cores of forks, each fork free to grab ¼ of RAM → swap-death under load). Introduce one `MachineResources` governor every CPU/RAM-competing operation reserves against: CPU cores (compiles + forks compete equally) and a total fork-memory budget (each fork weighted by its `-Xmx`, so the *sum* is capped — a total cap, not a fragile per-fork `-Xmx`). Grants are work-conserving and oldest-first; load is observable via `snapshot` and periodic contention logging. Implemented purely on cats-effect (Ref + Deferred + Resource.makeFull/poll/onCancel) so a cancelled reservation dequeues cleanly. Replaces the per-subsystem compile and test-fork semaphores; forks now also carry pid + exit code on the "terminated before Ready" fork-storm error.

## Compatibility

**7. SuiteFinished BSP codec tolerates the `outcome` field across versions** (`0b23b61c`)
- Adding `outcome` as a *required* field was a breaking wire change: a long-lived server + newer client hit `DecodingFailure at .data.outcome`. The codec now carries both `outcome` and the flat counts, and reconstructs `outcome` from counts when absent — non-breaking in both directions.

## Deferred / not applicable
- **`bleep test` hang watchdog**: root causes (OOM→restart, fork-storm→governor, desync→suiteInFlight) are fixed here; an idle-deadline abort risks killing legitimately-long suites, so it's left out pending a deadline decision.
- **"cross-client shutdown cancels all clients"** report: each client gets its own server instance, so `build/shutdown` is already per-client. The only cross-client cancel is the deliberate `cancelBlockingWork` ('c' keypress). Its other half (cancelled→PASSED-partial) is fixed by #2/#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)