### PR TITLE
Protocol tolerance and honest failure reporting (split from #603)

### DIFF
--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
@@ -535,7 +535,52 @@ object BleepBspProtocol {
     implicit val suiteStartedCodec: Codec[SuiteStarted] = deriveCodec
     implicit val testStartedCodec: Codec[TestStarted] = deriveCodec
     implicit val testFinishedCodec: Codec[TestFinished] = deriveCodec
-    implicit val suiteFinishedCodec: Codec[SuiteFinished] = deriveCodec
+
+    /** Version-tolerant, hand-written so a long-lived server and a newer client (or vice versa) keep talking across the addition of `outcome` (which replaced
+      * the flat count fields). The wire carries BOTH: `outcome` (the ADT) and the flat `passed/failed/skipped/ignored` derived from it. A client that predates
+      * `outcome` reads the flat counts; a client that predates the flat counts reads `outcome`. Adding a *required* protocol field is a breaking change — this
+      * keeps it non-breaking.
+      *
+      * Tolerance runs in BOTH directions, which is the whole point: `outcome` absent (an older peer sending only counts) AND `outcome` present but naming a
+      * variant this version doesn't know (a NEWER peer) both degrade via [[SuiteOutcome.degrade]] instead of failing the event. Without the second case, the
+      * day a variant is added every older client hits `DecodingFailure` again — the exact bug this codec exists to fix, one version later.
+      */
+    implicit val suiteFinishedCodec: Codec[SuiteFinished] = {
+      val enc: Encoder[SuiteFinished] = Encoder.instance { sf =>
+        Json.obj(
+          "project" -> sf.project.asJson,
+          "suite" -> sf.suite.asJson,
+          "outcome" -> sf.outcome.asJson,
+          "passed" -> sf.outcome.passedCount.asJson,
+          "failed" -> sf.outcome.failedCount.asJson,
+          "skipped" -> sf.outcome.skippedCount.asJson,
+          "ignored" -> sf.outcome.ignoredCount.asJson,
+          "durationMs" -> sf.durationMs.asJson,
+          "timestamp" -> sf.timestamp.asJson
+        )
+      }
+      val dec: Decoder[SuiteFinished] = Decoder.instance { c =>
+        for {
+          project <- c.downField("project").as[CrossProjectName]
+          suite <- c.downField("suite").as[SuiteName]
+          durationMs <- c.downField("durationMs").as[Long]
+          timestamp <- c.downField("timestamp").as[Long]
+          outcome <- c.downField("outcome").as[SuiteOutcome] match {
+            case Right(o) => Right(o)
+            case Left(_)  =>
+              // Absent, or a variant we can't read. Either way the flat counts are on the wire.
+              for {
+                p <- c.getOrElse("passed")(0)
+                f <- c.getOrElse("failed")(0)
+                s <- c.getOrElse("skipped")(0)
+                i <- c.getOrElse("ignored")(0)
+                tag <- c.downField("outcome").downField("kind").as[Option[String]].orElse(Right(None))
+              } yield SuiteOutcome.degrade(tag, p, f, s, i)
+          }
+        } yield SuiteFinished(project, suite, outcome, durationMs, timestamp)
+      }
+      Codec.from(dec, enc)
+    }
     implicit val suiteTimedOutCodec: Codec[SuiteTimedOut] = deriveCodec
     implicit val suiteErrorCodec: Codec[SuiteError] = deriveCodec
     implicit val suiteCancelledCodec: Codec[SuiteCancelled] = deriveCodec

--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/CompileStatus.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/CompileStatus.scala
@@ -9,28 +9,39 @@ import io.circe._
 sealed trait CompileStatus {
   def wireValue: String
   def isSuccess: Boolean
+
+  /** The project did not compile and that is a problem to report: `Failed` (compiler diagnostics) or `Error` (the compile task threw). Deliberately NOT the
+    * negation of [[isSuccess]] — `Skipped` and `Cancelled` are also not-success but are not failures, so counting `!isSuccess` would over-report. Every "did
+    * this compile go wrong" check must use this rather than testing for `Failed` alone, which silently drops `Error`.
+    */
+  def isFailure: Boolean
 }
 
 object CompileStatus {
   case object Success extends CompileStatus {
     val wireValue: String = "success"
     val isSuccess: Boolean = true
+    val isFailure: Boolean = false
   }
   case object Failed extends CompileStatus {
     val wireValue: String = "failed"
     val isSuccess: Boolean = false
+    val isFailure: Boolean = true
   }
   case object Error extends CompileStatus {
     val wireValue: String = "error"
     val isSuccess: Boolean = false
+    val isFailure: Boolean = true
   }
   case object Skipped extends CompileStatus {
     val wireValue: String = "skipped"
     val isSuccess: Boolean = false
+    val isFailure: Boolean = false
   }
   case object Cancelled extends CompileStatus {
     val wireValue: String = "cancelled"
     val isSuccess: Boolean = false
+    val isFailure: Boolean = false
   }
 
   def fromString(s: String): CompileStatus = s.toLowerCase match {

--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/SuiteOutcome.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/SuiteOutcome.scala
@@ -66,7 +66,24 @@ object SuiteOutcome {
       case "empty"              => Empty
       case "noFrameworkMatched" => NoFrameworkMatched
       case "errored"            => Errored(message.getOrElse("suite errored"), throwable)
-      case other                => Errored(s"unknown suite outcome '$other'", None)
+      case other                => degrade(Some(other), passed, failed, skipped, ignored)
+    }
+
+  /** The single policy for a message whose `outcome` this version can't read — either absent (written by a bleep predating the ADT) or naming a variant added
+    * by a NEWER bleep. Both wire formats carry the flat counts alongside `outcome`, so those are the fallback: a suite that really ran 5 tests should report 5,
+    * not a fabricated failure.
+    *
+    * With no counts to fall back on, an unrecognized tag becomes [[Errored]] rather than [[Empty]] — an outcome we couldn't interpret must not be able to read
+    * as a quietly-passing or merely-empty suite. An *absent* tag with zero counts is different: that is genuinely how an old runner spelled "empty".
+    *
+    * This is the counterpart of adding a variant: the day one is added, older clients degrade instead of failing to decode the whole event.
+    */
+  def degrade(unknownTag: Option[String], passed: Int, failed: Int, skipped: Int, ignored: Int): SuiteOutcome =
+    unknownTag match {
+      case None      => fromCounts(passed, failed, skipped, ignored)
+      case Some(tag) =>
+        if (passed + failed + skipped + ignored > 0) fromCounts(passed, failed, skipped, ignored)
+        else Errored(s"unrecognized suite outcome '$tag' — produced by a newer bleep than this one, and no counts were sent to fall back on", None)
     }
 
   implicit val encoder: Encoder[SuiteOutcome] = Encoder.instance {

--- a/bleep-bsp-tests/src/scala/bleep/analysis/JvmTestRunnerIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/JvmTestRunnerIntegrationTest.scala
@@ -122,6 +122,23 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
     }
   }
 
+  test("TestProtocol: SuiteDone decodes a legacy (pre-outcome) forked-runner message via counts") {
+    failAfter(quickTimeout) {
+      // Exactly what an older bleep-test-runner jar (version-skewed test classpath) emits: flat
+      // counts, no `outcome` field. Must decode (reconstructing outcome) instead of failing.
+      val legacyPassing = """{"type":"SuiteDone","data":{"suite":"com.example.MySuite","passed":3,"failed":1,"skipped":0,"ignored":0,"durationMs":5}}"""
+      TestProtocol.decodeResponse(legacyPassing) match {
+        case Right(sd: TestProtocol.TestResponse.SuiteDone) => sd.outcome shouldBe SuiteOutcome.Executed(3, 1, 0, 0)
+        case other                                          => fail(s"expected SuiteDone, got $other")
+      }
+      val legacyZero = """{"type":"SuiteDone","data":{"suite":"com.example.MySuite","passed":0,"failed":0,"skipped":0,"ignored":0,"durationMs":5}}"""
+      TestProtocol.decodeResponse(legacyZero) match {
+        case Right(sd: TestProtocol.TestResponse.SuiteDone) => sd.outcome shouldBe SuiteOutcome.Empty
+        case other                                          => fail(s"expected SuiteDone, got $other")
+      }
+    }
+  }
+
   test("TestProtocol: encodes and decodes Log response") {
     failAfter(quickTimeout) {
       val response = TestProtocol.TestResponse.Log(

--- a/bleep-bsp-tests/src/scala/bleep/analysis/SourcegenDagIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/SourcegenDagIntegrationTest.scala
@@ -658,6 +658,107 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
     tags.indexOf("sourcegen:end") should be < tags.indexOf("compile:target")
   }
 
+  test("executor: a THROWN handler exception becomes TaskResult.Error (not Failure) so it is surfaced, not swallowed") {
+    // Regression for the phantom "detailed info was not captured" test failure: when
+    // bleep-test-runner fails to resolve, getTestClasspath THROWS before any suite runs. That
+    // exception must be reported as infrastructure Error (→ SuiteError with the message), not a
+    // logical Failure — a TestSuiteTask Failure is assumed to have already emitted SuiteFinished
+    // and gets no event, collapsing into an uncategorized problem count. withRecovery's catch is
+    // reached ONLY by thrown exceptions (handlers return Failure explicitly for logical failures),
+    // so every caught throwable is definitionally an Error.
+    val p = projectName("p")
+    val dag = TaskDag.buildCompileDag(
+      Set(p),
+      BuildContext(
+        allProjectDeps = Map.empty,
+        platforms = Map.empty,
+        sourcegen = SourcegenPlan.empty,
+        apPlan = AnnotationProcessorPlan.empty,
+        kspPlan = SymbolProcessorPlan.empty
+      )
+    )
+
+    val executor = TaskDag.executor(
+      Handlers(
+        compile = (_, _) => IO.raiseError(new RuntimeException("bleep-test-runner resolution returned no jars")),
+        link = (_, _) => sys.error("LinkTask should not appear here"),
+        discover = (_, _) => sys.error("DiscoverTask should not appear here"),
+        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        sourcegen = (_, _) => sys.error("SourcegenTask should not appear here"),
+        annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
+        symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
+      )
+    )
+
+    val (finalDag, events) = (for {
+      eventQueue <- Queue.unbounded[IO, Option[DagEvent]]
+      killSignal <- Outcome.neverKillSignal
+      d <- executor.execute(dag, 4, eventQueue, killSignal)
+      _ <- eventQueue.offer(None)
+      drained <- drainQueue(eventQueue)
+    } yield (d, drained)).unsafeRunSync()
+
+    finalDag.errored should contain(TaskId.Compile(p))
+    finalDag.failed should not contain TaskId.Compile(p)
+
+    val finished = events.collect { case e: DagEvent.TaskFinished => e.result }
+    finished should have size 1
+    finished.head match {
+      case TaskResult.Error(msg, _) => msg should include("bleep-test-runner resolution returned no jars")
+      case other                    => fail(s"expected TaskResult.Error carrying the message, got $other")
+    }
+  }
+
+  test("executor: a THROWN sourcegen handler still emits SourcegenFinished carrying the error") {
+    // Companion to the TaskResult.Error regression above. These tasks report themselves via their
+    // own Started/Finished pair (the TaskFinished mapping deliberately emits no protocol event for
+    // them), so if recovery wrapped the whole for-comprehension a throw would skip the Finished
+    // emit entirely and the exception would reach the client as absolutely nothing.
+    val target = projectName("target")
+    val scriptsProject = projectName("scripts")
+    val s = script(scriptsProject, "gen.Tool")
+
+    val plan = SourcegenPlan(perProject = Map(target -> Set(s)), scriptProjectDeps = Map(s -> Set(scriptsProject)))
+    val dag = TaskDag.buildCompileDag(
+      Set(target),
+      BuildContext(
+        allProjectDeps = Map.empty,
+        platforms = Map.empty,
+        sourcegen = plan,
+        apPlan = AnnotationProcessorPlan.empty,
+        kspPlan = SymbolProcessorPlan.empty
+      )
+    )
+
+    val executor = TaskDag.executor(
+      Handlers(
+        compile = (_, _) => IO.pure(TaskResult.Success),
+        link = (_, _) => sys.error("LinkTask should not appear here"),
+        discover = (_, _) => sys.error("DiscoverTask should not appear here"),
+        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        sourcegen = (_, _) => IO.raiseError(new RuntimeException("generator blew up")),
+        annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
+        symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
+      )
+    )
+
+    val (finalDag, events) = (for {
+      eventQueue <- Queue.unbounded[IO, Option[DagEvent]]
+      killSignal <- Outcome.neverKillSignal
+      d <- executor.execute(dag, 4, eventQueue, killSignal)
+      _ <- eventQueue.offer(None)
+      drained <- drainQueue(eventQueue)
+    } yield (d, drained)).unsafeRunSync()
+
+    val finished = events.collect { case e: DagEvent.SourcegenFinished => e }
+    finished should have size 1
+    finished.head.success shouldBe false
+    finished.head.error.getOrElse("") should include("generator blew up")
+
+    finalDag.errored should contain(TaskId.Sourcegen(s))
+    finalDag.skipped should contain(TaskId.Compile(target))
+  }
+
   // ==========================================================================
   // SourcegenPlan tests
   // ==========================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/SuiteFinishedCodecTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/SuiteFinishedCodecTest.scala
@@ -1,0 +1,92 @@
+package bleep.analysis
+
+import bleep.bsp.protocol.{BleepBspProtocol, SuiteOutcome}
+import bleep.model.{CrossProjectName, ProjectName, SuiteName}
+import io.circe.parser.decode
+import io.circe.syntax._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** The `SuiteFinished` wire format must survive version skew across the addition of `outcome`: a long-lived server and a newer client (or vice versa) have to
+  * keep talking. Regression for the `DecodingFailure at .data.outcome` a new client hit against an older server.
+  */
+class SuiteFinishedCodecTest extends AnyFunSuite with Matchers {
+  private val proj = CrossProjectName(ProjectName("dquery"), None)
+  private val suite = SuiteName("ai.datoria.dquery.test.IdentityTestsDoris")
+
+  private def sf(outcome: SuiteOutcome): BleepBspProtocol.Event.SuiteFinished =
+    BleepBspProtocol.Event.SuiteFinished(proj, suite, outcome, durationMs = 42, timestamp = 100)
+
+  test("round-trips every outcome variant through the full Event codec") {
+    val outcomes = List(
+      SuiteOutcome.Executed(3, 1, 2, 0),
+      SuiteOutcome.Empty,
+      SuiteOutcome.NoFrameworkMatched,
+      SuiteOutcome.Errored("boom", Some("stack"))
+    )
+    outcomes.foreach { o =>
+      val event: BleepBspProtocol.Event = sf(o)
+      BleepBspProtocol.decode(BleepBspProtocol.encode(event)) shouldBe Right(event)
+    }
+  }
+
+  test("encodes flat counts alongside outcome (so a client predating `outcome` still reads them)") {
+    val json = (sf(SuiteOutcome.Executed(3, 1, 2, 4)): BleepBspProtocol.Event).asJson.hcursor.downField("data")
+    json.get[Int]("passed") shouldBe Right(3)
+    json.get[Int]("failed") shouldBe Right(1)
+    json.get[Int]("skipped") shouldBe Right(2)
+    json.get[Int]("ignored") shouldBe Right(4)
+  }
+
+  /** The JSON a pre-`outcome` server emits: same shape, but with the `outcome` field removed from `data` (leaving the flat counts). Built by stripping a real
+    * encode so project/suite shapes are exactly right.
+    */
+  private def legacyJson(counts: SuiteOutcome.Executed): String = {
+    val full = (sf(counts): BleepBspProtocol.Event).asJson
+    full.hcursor.downField("data").withFocus(_.mapObject(_.remove("outcome"))).top.get.noSpaces
+  }
+
+  test("decodes a legacy message with flat counts and NO outcome (older server)") {
+    decode[BleepBspProtocol.Event](legacyJson(SuiteOutcome.Executed(1, 0, 0, 0))) match {
+      case Right(e: BleepBspProtocol.Event.SuiteFinished) => e.outcome shouldBe SuiteOutcome.Executed(1, 0, 0, 0)
+      case other                                          => fail(s"expected SuiteFinished, got $other")
+    }
+  }
+
+  test("decodes a legacy zero-count message as Empty rather than crashing") {
+    decode[BleepBspProtocol.Event](legacyJson(SuiteOutcome.Executed(0, 0, 0, 0))) match {
+      case Right(e: BleepBspProtocol.Event.SuiteFinished) => e.outcome shouldBe SuiteOutcome.Empty
+      case other                                          => fail(s"expected SuiteFinished, got $other")
+    }
+  }
+
+  /** The JSON a FUTURE bleep would emit: an `outcome` naming a variant this version has never heard of. Tolerance has to run in this direction too, or the day
+    * a variant is added every older client hits `DecodingFailure at .data.outcome` all over again.
+    */
+  private def futureVariantJson(counts: SuiteOutcome.Executed): String = {
+    val full = (sf(counts): BleepBspProtocol.Event).asJson
+    full.hcursor
+      .downField("data")
+      .downField("outcome")
+      .withFocus(_.mapObject(_.add("kind", io.circe.Json.fromString("flakyRetried"))))
+      .top
+      .get
+      .noSpaces
+  }
+
+  test("an unknown outcome variant from a NEWER bleep falls back to the flat counts") {
+    decode[BleepBspProtocol.Event](futureVariantJson(SuiteOutcome.Executed(7, 2, 0, 0))) match {
+      case Right(e: BleepBspProtocol.Event.SuiteFinished) => e.outcome shouldBe SuiteOutcome.Executed(7, 2, 0, 0)
+      case other                                          => fail(s"expected SuiteFinished, got $other")
+    }
+  }
+
+  test("an unknown outcome variant with no counts reports Errored, never a silently-empty suite") {
+    decode[BleepBspProtocol.Event](futureVariantJson(SuiteOutcome.Executed(0, 0, 0, 0))) match {
+      case Right(e: BleepBspProtocol.Event.SuiteFinished) =>
+        e.outcome shouldBe a[SuiteOutcome.Errored]
+        e.outcome.asInstanceOf[SuiteOutcome.Errored].message should include("flakyRetried")
+      case other => fail(s"expected SuiteFinished, got $other")
+    }
+  }
+}

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -2683,8 +2683,8 @@ class MultiWorkspaceBspServer(
     *
     * Two parts:
     *
-    *   1. `bleep-test-runner` itself, versioned `${BLEEP_VERSION}`. Goes through `TemplatedVersions` so dev builds short-circuit to BleepDevDeps class dirs.
-    *      Workspace-specific (the buildDir is in the version), so always resolved fresh — but the BleepDevDeps path is in-process and fast.
+    *   1. `bleep-test-runner` itself — see [[fetchBleepTestRunnerOnly]] for how its version is chosen (`${BLEEP_VERSION}` for a `dev` build so it
+    *      short-circuits to BleepDevDeps class dirs, otherwise pinned to this server's version).
     *   2. Four hardcoded external test-framework deps (test-interface, jupiter-interface, junit-platform-launcher, junit-vintage-engine). These are stable
     *      across every workspace and every bleep version, so we cache them in a process-wide atomic — see
     *      `MultiWorkspaceBspServer.cachedExternalTestRunnerJars`. Without this, every inner-bleep `commands.test` re-runs Coursier for the same four deps;
@@ -2698,8 +2698,22 @@ class MultiWorkspaceBspServer(
     testRunnerJars ++ externalJars
   }
 
+  /** The forked runner speaks this server's `TestProtocol` over the fork's stdin/stdout, so it must be built from the same code as the server. Two ways to get
+    * there, and picking the wrong one breaks a different workflow:
+    *
+    *   - `$version: dev` (integration tests, `bleep --dev`): keep the `${BLEEP_VERSION}` template. `TemplatedVersions` rewrites it to `dev:<buildDir>`, which
+    *     `BleepDevDeps` short-circuits to the *live class dirs* — literally the code this server was built from, so the protocol matches by construction.
+    *     Pinning to `BleepVersion.current` here would bypass the short-circuit and resolve a published jar instead: it fails outright when nothing was
+    *     published at that version, and — worse — silently runs stale runner code when a same-versioned jar happens to be in ivy local.
+    *   - anything else: pin to the *server's* `BleepVersion.current`, NOT the build's `$version`. The two diverge exactly when a snapshot server serves a build
+    *     pinning an older release (bleep deliberately ignores the build's `$version` for a snapshot — see Main.scala), and the template would then resolve the
+    *     OLD released runner, whose `SuiteDone` this server can't decode.
+    */
   private def fetchBleepTestRunnerOnly(started: Started): List[Path] = {
-    val testRunnerDep = model.Dep.Java("build.bleep", "bleep-test-runner", model.Replacements.known.BleepVersion)
+    val version =
+      if (started.build.$version == model.BleepVersion.dev) model.Replacements.known.BleepVersion
+      else model.BleepVersion.current.value
+    val testRunnerDep = model.Dep.Java("build.bleep", "bleep-test-runner", version)
     val result = started.resolver.force(
       Set(testRunnerDep),
       model.VersionCombo.Jvm(model.VersionScala.Scala3),

--- a/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
@@ -846,43 +846,54 @@ object TaskDag {
           } yield taskKill
         }
 
-        // Helper to convert ALL outcomes (success, error, killed) to TaskResult
-        // Uses fiber.join to get Outcome, then embed to convert back to IO with kill fallback
-        def withRecovery(taskName: String, taskKill: Deferred[IO, KillReason])(io: IO[TaskResult]): IO[TaskResult] =
+        /** Render a thrown exception as the TaskResult it semantically is.
+          *
+          * A THROWN exception is infrastructure failure, not a logical one: `TaskResult.Error`, not `Failure`. Handlers return `Failure` explicitly for logical
+          * failures they already reported (compile diagnostics, `N test(s) failed` after a SuiteFinished). What reaches here is only exceptions nothing
+          * reported — e.g. bleep-test-runner failing to resolve throws out of getTestClasspath BEFORE any suite runs. Mapping that to `Failure` made a
+          * TestSuiteTask swallow it (its event mapping assumes a preceding SuiteFinished conveyed it), so it surfaced only as an uncategorized "detailed info
+          * was not captured" count. As `Error` it becomes a SuiteError / CompileFinished(Error) carrying the actual message.
+          */
+        def errorResult(taskName: String, error: Throwable): TaskResult = {
+          val lines = new scala.collection.mutable.ArrayBuffer[String]()
+          lines += s"$taskName failed: ${error.getClass.getName}: ${error.getMessage}"
+          var cause = error.getCause
+          while (cause != null) {
+            lines += s"  Caused by: ${cause.getClass.getName}: ${cause.getMessage}"
+            cause = cause.getCause
+          }
+          val frames = error.getStackTrace.take(10)
+          if (frames.nonEmpty) {
+            lines += "  Stack trace:"
+            frames.foreach(f => lines += s"    at $f")
+          }
+          TaskResult.Error(error = lines.mkString("\n"), processExit = ProcessExit.Unknown)
+        }
+
+        /** Convert ALL outcomes (success, thrown error, cancellation) into a value, via `fiber.join` + `embed` with a kill fallback.
+          *
+          * Generic in the payload so tasks whose handler returns more than a TaskResult (annotation processors and KSP also return a discovered-jar count) get
+          * the same recovery instead of hand-rolling their own — `inject` says how to represent a recovered TaskResult in that payload.
+          */
+        def withRecoveryOf[A](taskName: String, taskKill: Deferred[IO, KillReason], inject: TaskResult => A)(io: IO[A]): IO[A] =
           io.start
             .flatMap(_.join)
             .flatMap { outcome =>
               outcome.embed(
                 onCancel = taskKill.tryGet.map {
-                  case Some(reason) => TaskResult.Killed(reason)
-                  case None         => TaskResult.Killed(KillReason.UserRequest) // Fallback
+                  case Some(reason) => inject(TaskResult.Killed(reason))
+                  case None         => inject(TaskResult.Killed(KillReason.UserRequest)) // Fallback
                 }
               )
             }
-            .handleErrorWith { error =>
-              val errorMsg = s"$taskName failed: ${error.getClass.getName}: ${error.getMessage}"
-              // Build a detailed diagnostic with cause chain and brief stack trace
-              val lines = new scala.collection.mutable.ArrayBuffer[String]()
-              lines += errorMsg
-              var cause = error.getCause
-              while (cause != null) {
-                lines += s"  Caused by: ${cause.getClass.getName}: ${cause.getMessage}"
-                cause = cause.getCause
-              }
-              // Include first few relevant stack frames (skip internal framework frames)
-              val frames = error.getStackTrace.take(10)
-              if (frames.nonEmpty) {
-                lines += "  Stack trace:"
-                frames.foreach(f => lines += s"    at $f")
-              }
-              val diagMessage = lines.mkString("\n")
-              IO.pure(
-                TaskResult.Failure(
-                  error = errorMsg,
-                  diagnostics = List(BleepBspProtocol.Diagnostic.error(diagMessage))
-                )
-              )
-            }
+            .handleErrorWith(error => IO.pure(inject(errorResult(taskName, error))))
+
+        def withRecovery(taskName: String, taskKill: Deferred[IO, KillReason])(io: IO[TaskResult]): IO[TaskResult] =
+          withRecoveryOf[TaskResult](taskName, taskKill, identity)(io)
+
+        /** For handlers returning `(TaskResult, Int)`: a recovered failure discovered nothing. */
+        def withRecoveryCounted(taskName: String, taskKill: Deferred[IO, KillReason])(io: IO[(TaskResult, Int)]): IO[(TaskResult, Int)] =
+          withRecoveryOf[(TaskResult, Int)](taskName, taskKill, r => (r, 0))(io)
 
         for {
           maybeKilled <- isKilled
@@ -946,46 +957,50 @@ object TaskDag {
                     // could pin the BSP fiber indefinitely and block server shutdown.
                     withRecovery(s"Test ${tt.suiteName.value}", taskKill)(handlers.test(tt, taskKill))
 
+                  // These three emit their own Started/Finished pair, and the Finished carries the
+                  // error message. Recovery therefore wraps ONLY the handler call, with the emit
+                  // driven by the recovered result — if withRecovery wrapped the whole
+                  // for-comprehension instead, a thrown handler would skip straight past the
+                  // Finished emit and the exception would reach the client as nothing at all (the
+                  // TaskFinished mapping deliberately emits no protocol event for these tasks).
                   case sgt: SourcegenTask =>
-                    withRecovery(s"Sourcegen ${sgt.script.main}", taskKill) {
-                      for {
-                        sourcegenStartTs <- now
-                        forProjectsList = sgt.forProjects.toList.sortBy(_.value)
-                        _ <- emit(DagEvent.SourcegenStarted(sgt.script.project, sgt.script.main, forProjectsList, sourcegenStartTs))
-                        result <- handlers.sourcegen(sgt, taskKill)
-                        sourcegenEndTs <- now
-                        (success, errorMsg) = resultSummary(result)
-                        _ <- emit(
-                          DagEvent.SourcegenFinished(sgt.script.project, sgt.script.main, success, sourcegenEndTs - sourcegenStartTs, errorMsg, sourcegenEndTs)
-                        )
-                      } yield result
-                    }
+                    for {
+                      sourcegenStartTs <- now
+                      forProjectsList = sgt.forProjects.toList.sortBy(_.value)
+                      _ <- emit(DagEvent.SourcegenStarted(sgt.script.project, sgt.script.main, forProjectsList, sourcegenStartTs))
+                      result <- withRecovery(s"Sourcegen ${sgt.script.main}", taskKill)(handlers.sourcegen(sgt, taskKill))
+                      sourcegenEndTs <- now
+                      (success, errorMsg) = resultSummary(result)
+                      _ <- emit(
+                        DagEvent.SourcegenFinished(sgt.script.project, sgt.script.main, success, sourcegenEndTs - sourcegenStartTs, errorMsg, sourcegenEndTs)
+                      )
+                    } yield result
 
                   case apt: ResolveAnnotationProcessorsTask =>
-                    withRecovery(s"ResolveAnnotationProcessors ${apt.project.value}", taskKill) {
-                      for {
-                        apStartTs <- now
-                        _ <- emit(DagEvent.ResolveAnnotationProcessorsStarted(apt.project, apStartTs))
-                        (result, discoveredJarCount) <- handlers.annotationProcessor(apt, taskKill)
-                        apEndTs <- now
-                        (success, errorMsg) = resultSummary(result)
-                        _ <- emit(
-                          DagEvent.ResolveAnnotationProcessorsFinished(apt.project, success, apEndTs - apStartTs, errorMsg, discoveredJarCount, apEndTs)
-                        )
-                      } yield result
-                    }
+                    for {
+                      apStartTs <- now
+                      _ <- emit(DagEvent.ResolveAnnotationProcessorsStarted(apt.project, apStartTs))
+                      resultAndCount <- withRecoveryCounted(s"ResolveAnnotationProcessors ${apt.project.value}", taskKill)(
+                        handlers.annotationProcessor(apt, taskKill)
+                      )
+                      (result, discoveredJarCount) = resultAndCount
+                      apEndTs <- now
+                      (success, errorMsg) = resultSummary(result)
+                      _ <- emit(
+                        DagEvent.ResolveAnnotationProcessorsFinished(apt.project, success, apEndTs - apStartTs, errorMsg, discoveredJarCount, apEndTs)
+                      )
+                    } yield result
 
                   case kspt: RunSymbolProcessorsTask =>
-                    withRecovery(s"RunSymbolProcessors ${kspt.project.value}", taskKill) {
-                      for {
-                        kspStartTs <- now
-                        _ <- emit(DagEvent.RunSymbolProcessorsStarted(kspt.project, kspStartTs))
-                        (result, discoveredJarCount) <- handlers.symbolProcessor(kspt, taskKill)
-                        kspEndTs <- now
-                        (success, errorMsg) = resultSummary(result)
-                        _ <- emit(DagEvent.RunSymbolProcessorsFinished(kspt.project, success, kspEndTs - kspStartTs, errorMsg, discoveredJarCount, kspEndTs))
-                      } yield result
-                    }
+                    for {
+                      kspStartTs <- now
+                      _ <- emit(DagEvent.RunSymbolProcessorsStarted(kspt.project, kspStartTs))
+                      resultAndCount <- withRecoveryCounted(s"RunSymbolProcessors ${kspt.project.value}", taskKill)(handlers.symbolProcessor(kspt, taskKill))
+                      (result, discoveredJarCount) = resultAndCount
+                      kspEndTs <- now
+                      (success, errorMsg) = resultSummary(result)
+                      _ <- emit(DagEvent.RunSymbolProcessorsFinished(kspt.project, success, kspEndTs - kspStartTs, errorMsg, discoveredJarCount, kspEndTs))
+                    } yield result
                 }
               }
           }

--- a/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
@@ -3,7 +3,7 @@ package bleep.mcp
 import bleep._
 import bleep.bsp.{BspRequestHelper, BspRifle, BspRifleConfig, BspServerBuilder, SetupBleepBsp}
 import bleep.bsp.protocol.BleepBspProtocol
-import bleep.bsp.protocol.{CompileStatus, DiagnosticSeverity, TestStatus}
+import bleep.bsp.protocol.{DiagnosticSeverity, TestStatus}
 import bleep.internal.BspClientDisplayProgress
 import bleep.testing.{BuildDiff, PreviousRunState, TestKey}
 import cats.effect._
@@ -1167,7 +1167,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
               val startedEvents = events.collect { case e: E.CompileStarted => e }
               val finishedProjects = finished.map(_.project).toSet
               val inProgressEvents = startedEvents.filterNot(e => finishedProjects.contains(e.project))
-              val failed = finished.count(_.status == CompileStatus.Failed)
+              val failed = finished.count(_.status.isFailure)
               val suites = events.collect { case e: E.SuiteFinished => e }
 
               val parts = List.newBuilder[String]
@@ -1204,7 +1204,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
           val previousDiags = previousState.compileDiagnostics.getOrElse(e.project, Nil)
           val hasPrevious = previousState.compileDiagnostics.contains(e.project)
 
-          if (e.status == CompileStatus.Failed) {
+          if (e.status.isFailure) {
             // Stream failures immediately — agent needs to know ASAP
             if (hasPrevious) {
               val diff = BuildDiff.diffCompile(e.project, e.status, e.diagnostics, previousDiags, e.durationMs)
@@ -1336,7 +1336,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
       import BleepBspProtocol.{Event => E}
 
       val compileEvents = events.collect { case e: E.CompileFinished => e }
-      val failedProjects = compileEvents.filter(_.status == CompileStatus.Failed)
+      val failedProjects = compileEvents.filter(_.status.isFailure)
       val allDiagnostics = compileEvents.flatMap(_.diagnostics)
       val errorCount = allDiagnostics.count(_.severity == DiagnosticSeverity.Error)
       val warningCount = allDiagnostics.count(_.severity == DiagnosticSeverity.Warning)

--- a/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
@@ -1045,8 +1045,10 @@ object BuildDisplay {
         val previousDiags = previousRun.compileDiagnostics.getOrElse(cf.project, Nil)
         val diff = BuildDiff.diffCompile(cf.project, cf.status, cf.diagnostics, previousDiags, cf.durationMs)
         val line = BuildDiff.formatCompileDiff(diff)
-        // For failed compiles, also show the actual errors
-        if (cf.status == bleep.bsp.protocol.CompileStatus.Failed && cf.diagnostics.nonEmpty) {
+        // For failed compiles, also show the actual errors. `isFailure`, not `== Failed`: a compile
+        // that threw arrives as Error carrying the exception as its single diagnostic, and printing
+        // a bare ❌ with the cause withheld is precisely the "detail not captured" hole.
+        if (cf.status.isFailure && cf.diagnostics.nonEmpty) {
           val errors = cf.diagnostics.filter(_.severity == DiagnosticSeverity.Error)
           val errorLines = errors.take(10).flatMap { d =>
             val text = d.rendered.getOrElse(d.message)

--- a/bleep-core/src/scala/bleep/testing/TestProtocol.scala
+++ b/bleep-core/src/scala/bleep/testing/TestProtocol.scala
@@ -143,15 +143,27 @@ object TestProtocol {
     implicit val suiteDoneDecoder: Decoder[SuiteDone] = Decoder.instance { c =>
       for {
         suite <- c.downField("suite").as[String]
-        kind <- c.downField("outcome").as[String]
-        passed <- c.downField("passed").as[Int]
-        failed <- c.downField("failed").as[Int]
-        skipped <- c.downField("skipped").as[Int]
-        ignored <- c.downField("ignored").as[Int]
+        // `outcome` is optional: a forked test-runner jar that predates the SuiteOutcome ADT (a
+        // version-skewed test classpath — e.g. an older bleep-test-runner resolved from the build)
+        // emits only the flat counts. Reconstruct the outcome from them rather than failing to
+        // decode. This is the forked-runner analog of the version-tolerant BSP SuiteFinished codec.
+        kind <- c.downField("outcome").as[Option[String]]
+        passed <- c.getOrElse("passed")(0)
+        failed <- c.getOrElse("failed")(0)
+        skipped <- c.getOrElse("skipped")(0)
+        ignored <- c.getOrElse("ignored")(0)
         durationMs <- c.downField("durationMs").as[Long]
         message <- c.downField("message").as[Option[String]]
         throwable <- c.downField("throwable").as[Option[String]]
-      } yield SuiteDone(suite, SuiteOutcome.fromWire(kind, passed, failed, skipped, ignored, message, throwable), durationMs)
+      } yield {
+        // `fromWire` already routes a tag it doesn't recognise through the same `degrade` policy the
+        // BSP SuiteFinished codec uses, so both boundaries treat version skew identically.
+        val outcome = kind match {
+          case Some(k) => SuiteOutcome.fromWire(k, passed, failed, skipped, ignored, message, throwable)
+          case None    => SuiteOutcome.degrade(None, passed, failed, skipped, ignored)
+        }
+        SuiteDone(suite, outcome, durationMs)
+      }
     }
 
     implicit val logEncoder: Encoder[Log] = deriveEncoder


### PR DESCRIPTION
Split out of #603, which has become two unrelated things. This half is the protocol and error-reporting work: verified, deployed against a large downstream build, and with no connection to resource scheduling. #603 keeps the machine-governor work, which is being reworked and shouldn't hold these up.

Zero lines of governor code are in this branch (`MachineResources`, reservations, fork budgets — none of it).

## Version skew, tolerated in both directions

#602 made `outcome` a **required** field of the `SuiteFinished` BSP event — a breaking wire change. A newer client hit `DecodingFailure at .data.outcome` against an older, still-running server.

Both boundaries that carry an outcome (the BSP event, and the forked runner's `TestProtocol.SuiteDone`) now put `outcome` **and** the flat counts on the wire, and share a single `SuiteOutcome.degrade` policy for anything they can't read:

| what arrived | why | result |
|---|---|---|
| no `outcome` field | older peer, predates the ADT | reconstruct from the flat counts |
| unknown `outcome` variant | **newer** peer | fall back to the flat counts |
| unknown variant, no counts | newer peer, nothing to fall back on | `Errored`, naming the tag |

That second row is the point. Handling only the missing-field case would have reproduced this exact bug the day someone adds a variant. The third row matters too: an outcome we couldn't interpret must never be able to read as a quietly-passing or merely-empty suite.

## The forked runner now matches the server it talks to

`fetchBleepTestRunnerOnly` resolved `bleep-test-runner` at the **build's** `$version`, but the runner speaks the **server's** `TestProtocol` over the fork's pipe. Those diverge precisely when a snapshot server serves a build pinning an older release — bleep deliberately ignores the build's `$version` for a snapshot — so an old runner emitted `SuiteDone` with no `outcome` and the new server rejected it. One phantom failure per suite, on every module.

Now pinned to `BleepVersion.current`, **except** for a `dev` build, which keeps the `${BLEEP_VERSION}` template so `BleepDevDeps` still short-circuits to the live class dirs. Those dirs are literally this server's own code, so the protocol matches by construction, and `IntegrationTestHarness` depends on it — pinning unconditionally would fail outright without a matching publish-local, and (worse) silently run stale runner code when a same-versioned jar sits in ivy local.

## A thrown task is infrastructure failure

`withRecovery` mapped every caught exception to `TaskResult.Failure`. But for a `TestSuiteTask`, `Failure` means "the suite already reported itself via `SuiteFinished`" and emits no event — so a test-runner resolution failure, which throws *before any suite runs*, reached the user as:

```
Problems (1)
  1 test(s) had issues but detailed info was not captured.
```

attributed to whatever suite happened to be requested. Handlers return `Failure` explicitly for logical failures they have already reported, so the catch only ever sees genuine exceptions — which are `TaskResult.Error`, and now surface with their message.

Sourcegen / annotation-processor / KSP tasks had the same hole one level deeper: recovery wrapped their entire for-comprehension, so a throw skipped straight past the `Finished` emit that carries the error, and since their `TaskFinished` mapping emits no protocol event by design, the exception reached the client as *nothing at all*.

## `CompileStatus.isFailure`

Deliberately **not** `!isSuccess` — `Skipped` and `Cancelled` are not-success but are not failures. Every "did this compile go wrong" check routes through it now, fixing a diff display that printed a bare ❌ with the cause withheld, and an MCP server that told an agent "0 failed" for a compile that errored.

## Testing

566 tests green (57 suites), plus regressions for each fix: the exact legacy no-`outcome` message, an unknown variant both with and without counts, a thrown handler becoming `Error`, and a thrown sourcegen still emitting `SourcegenFinished` carrying its message. `TestFilterIT` covers the `dev` short-circuit end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)