### PR TITLE
Fix Windows startup crash (#601), and unhide the 42 Windows test failures CI was swallowing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,15 @@
-# Windows checkouts default to core.autocrlf=true, which rewrites LF to CRLF for anything git considers text. Fixtures whose *bytes* are the thing under test
-# must be exempt, or they hash differently on Windows than everywhere else.
+# Windows checkouts default to core.autocrlf=true, which rewrites LF to CRLF in the working tree. Bleep is a cross-platform build tool whose tests compare
+# generated text against literals and hash fixtures byte-for-byte, so a CRLF working tree silently changes results on Windows only. Normalize everything to LF
+# on every platform instead.
 #
-# ChecksumTests reads the .pom and compares its sha1/md5 against the checked-in .sha1/.md5 files. With CRLF conversion the pom hashes to
-# 14b5269f59a923be0cd8d0feb71d3b5fb6b4de43 instead of c47391f7adba596ba1600da80685d5bc9e63390b, and the expectation files themselves gain trailing \r.
+# Two concrete failures this fixes, both invisible until the Windows CI job stopped swallowing test failures:
+#   * BuildRewriteTest compared `yaml.encodeShortened` output (correctly LF) against `stripMargin` literals in a .scala source that git had given CRLF.
+#   * ChecksumTests hashes a .pom and compares against checked-in .sha1/.md5; with CRLF the pom hashed to 14b5269f… instead of c47391f7…
+* text=auto eol=lf
+
+# Fixtures whose bytes are the thing under test — never touch them at all.
 bleep-tests/src/resources/** -text
+
+# Batch files are the one place CRLF genuinely matters to the interpreter.
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Windows checkouts default to core.autocrlf=true, which rewrites LF to CRLF for anything git considers text. Fixtures whose *bytes* are the thing under test
+# must be exempt, or they hash differently on Windows than everywhere else.
+#
+# ChecksumTests reads the .pom and compares its sha1/md5 against the checked-in .sha1/.md5 files. With CRLF conversion the pom hashes to
+# 14b5269f59a923be0cd8d0feb71d3b5fb6b4de43 instead of c47391f7adba596ba1600da80685d5bc9e63390b, and the expectation files themselves gain trailing \r.
+bleep-tests/src/resources/** -text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,10 +267,16 @@ jobs:
         env:
           CI: true
         # Slow ITs run in the `build` job — see the non-windows test step for rationale.
+        #
+        # `shell: pwsh` with an explicit $LASTEXITCODE check after every command. This used to be `shell: cmd`, where a multi-line `run:` reports only the LAST
+        # command's exit code — so `bleep test` failing was silently discarded and only `selftest` decided the step. That hid 42 real Windows test failures
+        # across every green run of this job.
+        shell: pwsh
         run: |
-          ${{ matrix.file_name }} --dev test --no-color bleep-tests --exclude-tag slow
-          ${{ matrix.file_name }} selftest
-        shell: cmd
+          .\${{ matrix.file_name }} --dev test --no-color bleep-tests --exclude-tag slow
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::bleep test failed with exit code $LASTEXITCODE"; exit $LASTEXITCODE }
+          .\${{ matrix.file_name }} selftest
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::bleep selftest failed with exit code $LASTEXITCODE"; exit $LASTEXITCODE }
         if: runner.os == 'Windows'
 
       - name: Temporarily save package

--- a/bleep-cli/src/resources/META-INF/native-image/io.github.alexarchambault.native-terminal/native-terminal/reachability-metadata.json
+++ b/bleep-cli/src/resources/META-INF/native-image/io.github.alexarchambault.native-terminal/native-terminal/reachability-metadata.json
@@ -40,6 +40,42 @@
           "void*",
           "jlong"
         ]
+      },
+      {
+        "returnType": "void*",
+        "parameterTypes": [
+          "jint"
+        ]
+      },
+      {
+        "returnType": "jint",
+        "parameterTypes": [
+          "void*",
+          "jint"
+        ]
+      },
+      {
+        "returnType": "jint",
+        "parameterTypes": [
+          "void*",
+          "void*"
+        ]
+      },
+      {
+        "returnType": "jint",
+        "parameterTypes": []
+      },
+      {
+        "returnType": "jint",
+        "parameterTypes": [
+          "jint",
+          "void*",
+          "jint",
+          "jint",
+          "void*",
+          "jint",
+          "void*"
+        ]
       }
     ]
   }

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -908,16 +908,18 @@ object Main {
 
   /** `NativeTerminal.setupAnsi()` in [[_main]] only reaches kernel32 when stdout is a real console, and no CI runner is one — GitHub Actions redirects stdout
     * to a pipe. So the whole FFM path went untested on Windows, and we shipped native images with no `foreign` downcall metadata for kernel32: every Windows
-    * user crashed on their first command with MissingForeignRegistrationError (#601) while CI stayed green. Call the console path unconditionally from
-    * `selftest`, which the Windows CI job does run, so the downcalls have to link.
+    * user crashed on their first command with MissingForeignRegistrationError (#601) while CI stayed green. Reach kernel32 unconditionally from `selftest`,
+    * which the Windows CI job does run, so the downcalls have to link.
     *
-    * Off a pipe `GetConsoleMode` fails — that is the expected outcome here, and the IOException it raises drags `GetLastError` + `FormatMessageW` in too, so
-    * one call exercises four of the six kernel32 downcalls. Only that specific failure is tolerated; an unregistered downcall is an Error and propagates.
+    * `getSize` rather than `setupAnsi` because it has no error path: it calls `GetStdHandle` (the exact downcall that crashed in #601) and
+    * `GetConsoleScreenBufferInfo`, discards the return code, and reads whatever the struct holds — off a pipe that is a harmless 0x0. `setupAnsi` would be the
+    * more faithful reproduction, but off a pipe `GetConsoleMode` fails and the error path runs into a bug in native-terminal 0.0.9.1: `FormatMessageW`'s
+    * descriptor is built with `FunctionDescriptor.of(C_INT, ...)` yet invoked as `invokeExact(...)V`, so `getLastErrorMessage` throws WrongMethodTypeException
+    * on any JVM. Real users have a real console, `GetConsoleMode` succeeds, and that path never runs — so it does not affect #601.
     */
-  private def selftestWindowsAnsi(): Unit =
+  private def selftestWindowsKernel32(): Unit =
     if (Properties.isWin)
-      try println(s"kernel32 ANSI setup: ${io.github.alexarchambault.nativeterm.internal.WindowsTerm.setupAnsi()}")
-      catch { case e: java.io.IOException => println(s"kernel32 ANSI setup: linked, not a console ($e)") }
+      println(s"kernel32 console size: ${io.github.alexarchambault.nativeterm.internal.WindowsTerm.getSize()}")
 
   def _main(_args: Array[String]): ExitCode = {
     val userPaths = UserPaths.fromAppDirs
@@ -957,7 +959,7 @@ object Main {
         FileWatching(logger, Map(FileUtils.cwd -> List(())))(println(_)).run(FileWatching.StopWhen.Immediately)
         // verify TerminalSizeCache initialization works (SIGWINCH doesn't exist on Windows)
         BspClientDisplayProgress(logger).discard()
-        selftestWindowsAnsi()
+        selftestWindowsKernel32()
         println("OK")
         ExitCode.Success
 

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -906,6 +906,19 @@ object Main {
         }
     }
 
+  /** `NativeTerminal.setupAnsi()` in [[_main]] only reaches kernel32 when stdout is a real console, and no CI runner is one — GitHub Actions redirects stdout
+    * to a pipe. So the whole FFM path went untested on Windows, and we shipped native images with no `foreign` downcall metadata for kernel32: every Windows
+    * user crashed on their first command with MissingForeignRegistrationError (#601) while CI stayed green. Call the console path unconditionally from
+    * `selftest`, which the Windows CI job does run, so the downcalls have to link.
+    *
+    * Off a pipe `GetConsoleMode` fails — that is the expected outcome here, and the IOException it raises drags `GetLastError` + `FormatMessageW` in too, so
+    * one call exercises four of the six kernel32 downcalls. Only that specific failure is tolerated; an unregistered downcall is an Error and propagates.
+    */
+  private def selftestWindowsAnsi(): Unit =
+    if (Properties.isWin)
+      try println(s"kernel32 ANSI setup: ${io.github.alexarchambault.nativeterm.internal.WindowsTerm.setupAnsi()}")
+      catch { case e: java.io.IOException => println(s"kernel32 ANSI setup: linked, not a console ($e)") }
+
   def _main(_args: Array[String]): ExitCode = {
     val userPaths = UserPaths.fromAppDirs
 
@@ -944,6 +957,7 @@ object Main {
         FileWatching(logger, Map(FileUtils.cwd -> List(())))(println(_)).run(FileWatching.StopWhen.Immediately)
         // verify TerminalSizeCache initialization works (SIGWINCH doesn't exist on Windows)
         BspClientDisplayProgress(logger).discard()
+        selftestWindowsAnsi()
         println("OK")
         ExitCode.Success
 

--- a/bleep-cli/src/scala/bleep/sbtimport/runSbt.scala
+++ b/bleep-cli/src/scala/bleep/sbtimport/runSbt.scala
@@ -184,6 +184,17 @@ object runSbt {
     val b = Map.newBuilder[Path, List[String]]
     var i = 0
 
+    /** sbt writes the build's location as a `file:` URL, and inconsistently: `In file:/x/y/` for the root build but `In file:///x/y/` for sub-builds. This used
+      * to be `line.split(":").last`, which handed `///x/y/` straight to `Path.of`. Unix collapses the leading slashes, Windows reads `//` as the start of a UNC
+      * path and produced `\\x\y` (server `x`, share `y`) — a different key than the same build reached via the other spelling. Take everything after the marker
+      * (so a `C:` drive letter survives too) and collapse the leading slash run to one.
+      */
+    def parseInFilePath(line: String): String = {
+      val marker = "In file:"
+      val rest = line.substring(line.indexOf(marker) + marker.length).trim
+      if (rest.startsWith("/")) "/" + rest.dropWhile(_ == '/') else rest
+    }
+
     def commit() = {
       currentPath match {
         case Some(currentPath) => b += ((currentPath, projectNames.result()))
@@ -198,7 +209,7 @@ object runSbt {
       if (line.contains("In file:")) {
         commit()
         // store next build file found
-        currentPath = Some(Path.of(line.split(":").last.trim))
+        currentPath = Some(Path.of(parseInFilePath(line)))
       } else if (currentPath.isDefined) {
         line.split("\\s+") match {
           case Array(_, name) if !name.contains("**") => projectNames += name

--- a/bleep-core/src/scala/bleep/ProjectDigest.scala
+++ b/bleep-core/src/scala/bleep/ProjectDigest.scala
@@ -181,13 +181,18 @@ object ProjectDigest {
   private def hashFilesystem(md: MessageDigest, dir: Path): Unit = {
     val files = scala.util
       .Using(Files.walk(dir)) { stream =>
-        stream.toScala(List).filter(Files.isRegularFile(_)).sorted
+        stream.toScala(List).filter(Files.isRegularFile(_))
       }
       .getOrElse(Nil)
+      // Normalize to '/' so the digest matches git ls-tree's representation across OSes, and sort by that normalized string rather than by `Path`.
+      // `Path.compareTo` is case-insensitive on Windows and byte-wise on Unix, so sorting Paths fed the digest in a different order per OS — and in a
+      // different order than [[gitLsTree]], which sorts these very same strings. A digest that depends on the OS is not portable across machines, which is the
+      // whole point of it. Unix ordering is unchanged (comparing full paths that share a prefix is equivalent to comparing the relative parts), so only the
+      // previously-wrong Windows digests move.
+      .map(file => (dir.relativize(file).toString.replace('\\', '/'), file))
+      .sortBy { case (relPath, _) => relPath }
 
-    files.foreach { file =>
-      // Normalize to '/' so the digest matches git ls-tree's representation across OSes.
-      val relPath = dir.relativize(file).toString.replace('\\', '/')
+    files.foreach { case (relPath, file) =>
       val content = Files.readAllBytes(file)
       val blobHash = gitBlobHash(content)
       md.update(relPath.getBytes("UTF-8"))

--- a/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
@@ -15,15 +15,26 @@ class IntegrationSnapshotTests extends SnapshotTest {
   absolutePaths.sortedValues.foreach(println)
   val userPaths = UserPaths.fromAppDirs
 
+  /** [[absolutePaths]] with the machine-specific side normalized to `/`, so filling a placeholder never introduces a backslash.
+    *
+    * `bloopFileStrings` holds whole bloop JSON documents as JSON strings, so a filled value is spliced into text that is itself parsed as JSON later. On
+    * Windows the raw `D:\a\bleep\bleep` turned `"directory": "<BLEEP_GIT>/..."` into `"directory": "D:\a\bleep\bleep/..."`, where `\a` and `\b` are not valid
+    * JSON escapes — jsoniter then failed with `expected '}' or ','`. Forward slashes are accepted everywhere: `Path.of("D:/a/b")` is a normal Windows path.
+    *
+    * No-op on Unix, where these values contain no backslashes to begin with. Only `fill` is affected; `templatize` still needs the platform's real spelling to
+    * match, though regenerating snapshots on Windows has a separate unfixed problem (`Replacements.Replacer.path` calls `Path.of` on a templated string).
+    */
+  private val fillPaths: model.Replacements =
+    model.Replacements.ofReplacements(absolutePaths.sortedValues.map { case (abs, placeholder) => (abs.replace('\\', '/'), placeholder) })
+
   /** Substitute `<BLEEP_GIT>`-style placeholders into the parsed snapshot JSON, before it is decoded into [[sbtimport.ImportInputData]].
     *
     * `ImportInputData` decodes many fields to `java.nio.file.Path`, so decoding first and substituting afterwards only ever worked by accident: `<` is a legal
     * filename character on Unix, so the intermediate `Path.of("<BLEEP_GIT>/...")` was nonsense but legal. Windows rejects `<` outright, so decoding threw
     * InvalidPathException and every snapshot test failed before it could read its input at all.
     *
-    * Done on the parsed AST rather than the raw text on purpose: filled Windows paths contain `\`, which would corrupt JSON string escapes if spliced into the
-    * text. `contents` of a `GeneratedFile` is skipped to preserve the previous `replace(fill, rewriteGeneratedFiles = false)` semantics — those stay
-    * templatized on read.
+    * Done on the parsed AST rather than the raw text on purpose: splicing into the text would corrupt JSON string escapes. `contents` of a `GeneratedFile` is
+    * skipped to preserve the previous `replace(fill, rewriteGeneratedFiles = false)` semantics — those stay templatized on read.
     */
   private def fillPlaceholders(json: io.circe.Json): io.circe.Json = {
     import io.circe.Json
@@ -32,9 +43,9 @@ class IntegrationSnapshotTests extends SnapshotTest {
         Json.Null,
         Json.fromBoolean,
         Json.fromJsonNumber,
-        str => if (fillStrings) Json.fromString(absolutePaths.fill.string(str)) else json,
+        str => if (fillStrings) Json.fromString(fillPaths.fill.string(str)) else json,
         arr => Json.fromValues(arr.map(go(_, fillStrings))),
-        obj => Json.fromFields(obj.toIterable.map { case (k, v) => (absolutePaths.fill.string(k), go(v, fillStrings && k != "contents")) })
+        obj => Json.fromFields(obj.toIterable.map { case (k, v) => (fillPaths.fill.string(k), go(v, fillStrings && k != "contents")) })
       )
     go(json, fillStrings = true)
   }

--- a/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationSnapshotTests.scala
@@ -3,7 +3,6 @@ package bleep
 import bleep.internal.FileUtils
 import bleep.testing.{BloopConversions, GenBloopFiles, SnapshotTest}
 import bloop.config.Config
-import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
 import org.scalatest.Assertion
 
@@ -15,6 +14,30 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 class IntegrationSnapshotTests extends SnapshotTest {
   absolutePaths.sortedValues.foreach(println)
   val userPaths = UserPaths.fromAppDirs
+
+  /** Substitute `<BLEEP_GIT>`-style placeholders into the parsed snapshot JSON, before it is decoded into [[sbtimport.ImportInputData]].
+    *
+    * `ImportInputData` decodes many fields to `java.nio.file.Path`, so decoding first and substituting afterwards only ever worked by accident: `<` is a legal
+    * filename character on Unix, so the intermediate `Path.of("<BLEEP_GIT>/...")` was nonsense but legal. Windows rejects `<` outright, so decoding threw
+    * InvalidPathException and every snapshot test failed before it could read its input at all.
+    *
+    * Done on the parsed AST rather than the raw text on purpose: filled Windows paths contain `\`, which would corrupt JSON string escapes if spliced into the
+    * text. `contents` of a `GeneratedFile` is skipped to preserve the previous `replace(fill, rewriteGeneratedFiles = false)` semantics — those stay
+    * templatized on read.
+    */
+  private def fillPlaceholders(json: io.circe.Json): io.circe.Json = {
+    import io.circe.Json
+    def go(json: Json, fillStrings: Boolean): Json =
+      json.fold(
+        Json.Null,
+        Json.fromBoolean,
+        Json.fromJsonNumber,
+        str => if (fillStrings) Json.fromString(absolutePaths.fill.string(str)) else json,
+        arr => Json.fromValues(arr.map(go(_, fillStrings))),
+        obj => Json.fromFields(obj.toIterable.map { case (k, v) => (absolutePaths.fill.string(k), go(v, fillStrings && k != "contents")) })
+      )
+    go(json, fillStrings = true)
+  }
 
   // picked because it exists for apple arm64, and is old
   private val jvm8: model.Jvm = model.Jvm("liberica:8.0.452", None)
@@ -143,9 +166,10 @@ class IntegrationSnapshotTests extends SnapshotTest {
         )
         inputData
       } else {
-        decode[sbtimport.ImportInputData](new String(FileUtils.readGzippedBytes(inputDataPath), StandardCharsets.UTF_8)) match {
+        val jsonText = new String(FileUtils.readGzippedBytes(inputDataPath), StandardCharsets.UTF_8)
+        io.circe.parser.parse(jsonText).flatMap(json => fillPlaceholders(json).as[sbtimport.ImportInputData]) match {
           case Left(circeError) => throw new BleepException.InvalidJson(inputDataPath, circeError)
-          case Right(inputData) => inputData.replace(absolutePaths.fill, rewriteGeneratedFiles = false)
+          case Right(inputData) => inputData
         }
       }
 

--- a/bleep-tests/src/scala/bleep/ProjectDigestTest.scala
+++ b/bleep-tests/src/scala/bleep/ProjectDigestTest.scala
@@ -33,10 +33,15 @@ class ProjectDigestTest extends AnyFunSuite with Matchers {
     dir
   }
 
+  /** `Files.list` is wrapped in `Using` because the stream holds an open directory handle, and Windows refuses to delete a directory that anyone still has
+    * open. The read-only clear is for git: `git init` + `git commit` writes loose objects under `.git/objects` with the read-only attribute set, and on Windows
+    * `Files.delete` honours that and throws AccessDeniedException. POSIX only consults the parent directory's permissions, so this went unnoticed.
+    */
   private def deleteRecursively(path: Path): Unit =
     if (Files.exists(path)) {
       if (Files.isDirectory(path))
-        Files.list(path).toScala(List).foreach(deleteRecursively)
+        scala.util.Using(Files.list(path))(_.toScala(List)).get.foreach(deleteRecursively)
+      else path.toFile.setWritable(true).discard()
       Files.delete(path)
     }
 

--- a/bleep-tests/src/scala/bleep/mavenimport/MavenImportTest.scala
+++ b/bleep-tests/src/scala/bleep/mavenimport/MavenImportTest.scala
@@ -4,9 +4,17 @@ import bleep.model
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.funsuite.AnyFunSuite
 
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 
 class MavenImportTest extends AnyFunSuite with TripleEqualsSupport {
+
+  /** The POMs below hardcode a POSIX `/tmp/test-maven` build directory, but the tests that go on to call `buildFromMavenPom` relativize it against a real
+    * `Files.createTempDirectory` build dir. On Windows `Path.of("/tmp/test-maven").toAbsolutePath` is drive-relative and binds to the current drive (`D:` on
+    * CI) while the temp dir lives on `C:`, so `WindowsPath.relativize` rejects the pair with `'other' has different root`. Point the POM at the actual temp dir
+    * so both sides share a root on every OS. Forward slashes throughout — `Path.of("C:/x/y")` is fine on Windows, and it keeps the XML free of escapes.
+    */
+  private def pomIn(xml: String, tempDir: Path): String =
+    xml.replace("/tmp/test-maven", tempDir.toString.replace('\\', '/'))
 
   test("parse single-module effective POM") {
     val xml = """<?xml version="1.0" encoding="UTF-8"?>
@@ -195,7 +203,7 @@ class MavenImportTest extends AnyFunSuite with TripleEqualsSupport {
     val tempFile = Files.createTempFile("effective-pom", ".xml")
     val tempDir = Files.createTempDirectory("test-maven")
     try {
-      Files.writeString(tempFile, xml)
+      Files.writeString(tempFile, pomIn(xml, tempDir))
       val mavenProjects = parsePom(tempFile)
 
       val build = buildFromMavenPom(
@@ -253,7 +261,7 @@ class MavenImportTest extends AnyFunSuite with TripleEqualsSupport {
     val tempFile = Files.createTempFile("effective-pom", ".xml")
     val tempDir = Files.createTempDirectory("test-maven")
     try {
-      Files.writeString(tempFile, xml)
+      Files.writeString(tempFile, pomIn(xml, tempDir))
       val mavenProjects = parsePom(tempFile)
 
       val build = buildFromMavenPom(
@@ -317,7 +325,7 @@ class MavenImportTest extends AnyFunSuite with TripleEqualsSupport {
     val tempFile = Files.createTempFile("effective-pom", ".xml")
     val tempDir = Files.createTempDirectory("test-maven")
     try {
-      Files.writeString(tempFile, xml)
+      Files.writeString(tempFile, pomIn(xml, tempDir))
       val mavenProjects = parsePom(tempFile)
 
       val build = buildFromMavenPom(
@@ -372,7 +380,7 @@ class MavenImportTest extends AnyFunSuite with TripleEqualsSupport {
     val tempFile = Files.createTempFile("effective-pom", ".xml")
     val tempDir = Files.createTempDirectory("test-maven")
     try {
-      Files.writeString(tempFile, xml)
+      Files.writeString(tempFile, pomIn(xml, tempDir))
       val mavenProjects = parsePom(tempFile)
 
       val build = buildFromMavenPom(

--- a/bleep-tests/src/scala/bleep/testing/SnapshotTest.scala
+++ b/bleep-tests/src/scala/bleep/testing/SnapshotTest.scala
@@ -45,11 +45,13 @@ trait SnapshotTest extends AnyFunSuite with TripleEqualsSupport {
     while (!Files.isDirectory(from))
       from = from.getParent
 
-    gitWithRetry("git add", from, List("/usr/bin/env", "git", "add", in.toString), logger)
+    // plain `git`, not `/usr/bin/env git` — ProcessBuilder resolves it via PATH on every platform, whereas /usr/bin/env does not exist on Windows and made
+    // every snapshot test fail there with `CreateProcess error=2`.
+    gitWithRetry("git add", from, List("git", "add", in.toString), logger)
 
     if (Properties.isWin) succeed // let's deal with this later
     else if (isCi) {
-      gitWithRetry("git diff", from, List("/usr/bin/env", "git", "diff", "--exit-code", "HEAD", in.toString), logger)
+      gitWithRetry("git diff", from, List("git", "diff", "--exit-code", "HEAD", in.toString), logger)
       succeed
     } else succeed
   }


### PR DESCRIPTION
Fixes #601.

## 1. The crash

Every Windows user was dead on their first command, on 1.0.0-M9 and 1.0.0-M10:

```
MissingForeignRegistrationError: Cannot perform downcall with leaf type (long,int)long
  at ...nativeterm.internal.Kernel32.<clinit>(Kernel32.java:128)
  at ...nativeterm.NativeTerminal.setupAnsi(NativeTerminal.java:51)
  at bleep.Main$._main(Main.scala:890)
```

`reachability-metadata.json` for native-terminal has existed since 6a3176e5, but it only declared the **Unix** downcalls (the `CLibrary` ioctl/tcgetattr shapes). native-terminal is a multi-release jar; the kernel32 bindings live in `META-INF/versions/22/` and not one of their six `FunctionDescriptor`s was registered.

`(long,int)long` is `GetStdHandle(jint) -> void*` — GraalVM prepends the function-pointer argument to the leaf type. It is the first handle built in `Kernel32.<clinit>`, so the process aborted before bleep did anything.

All six are now registered, read off the `<clinit>` bytecode of native-terminal 0.0.9.1: `GetStdHandle`, `SetConsoleMode`, `GetConsoleMode`, `GetConsoleScreenBufferInfo` (same shape as `GetConsoleMode`), `GetLastError`, `FormatMessageW`.

## 2. Why CI never caught it

The Windows binary **was** built and tested — and passed, through two releases. The crashing path is unreachable in CI:

```java
public static boolean setupAnsi() throws IOException {
    if (isWindows && IsTerminal.isTerminal())
        return WindowsTerm.setupAnsi();   // only here does Kernel32.<clinit> run
    return true;
}
```

GitHub Actions redirects stdout to a pipe, so `isTerminal()` is false and kernel32 is never touched. No runner is a console, so no amount of running the binary reaches it.

`selftest` — which the Windows job already runs, and which exists as the native-image-config canary — now reaches kernel32 unconditionally via `WindowsTerm.getSize()`. It is proven to work in this PR's CI run:

```
kernel32 console size: TerminalSize{width=1, height=1}
OK
```

(`getSize` rather than the more faithful `setupAnsi` because off a pipe `GetConsoleMode` fails and the error path hits a bug in native-terminal 0.0.9.1: `FormatMessageW`'s descriptor is `FunctionDescriptor.of(C_INT, ...)` but it is invoked as `invokeExact(...)V`, so `getLastErrorMessage` throws `WrongMethodTypeException` on any JVM. Real users have a real console, `GetConsoleMode` succeeds, and that path never runs — it does not affect #601. Not yet reported upstream.)

## 3. The Windows job was swallowing test failures

Fixing the above turned the job red and revealed why it had been green: the step was a `shell: cmd` multi-line `run:`, and cmd propagates only the **last** command's exit code. `bleep test`'s result was discarded; only the trailing `selftest` decided the step.

`bleep test` had been failing **42 tests** on every "green" run of this job.

Now `shell: pwsh` with an explicit `$LASTEXITCODE` check after each command. And then all 42 fixed, in two rounds (42 -> 14 -> 0):

| root cause | count | kind |
|---|---|---|
| `SnapshotTest` ran git as `/usr/bin/env git`, which does not exist on Windows | ~19 | test |
| Snapshot `<BLEEP_GIT>` placeholders substituted *after* decoding to `Path`; `<` is legal on Unix, rejected by Windows | 7 | test |
| ...then the filled Windows path spliced raw `\` into embedded bloop JSON (`\a`, `\b` are not JSON escapes) | 7 | test |
| `.scala` sources checked out with CRLF, so `stripMargin` literals did not match LF output | 7 | repo config |
| `ProjectDigest.hashFilesystem` sorted `Path` (case-insensitive on Windows) while `gitLsTree` sorted strings | 2 | **production** |
| `runSbt` fed sbt's `In file:///x/y/` to `Path.of` as `///x/y/`, read as UNC `\\x\y` | 1 | **production** |
| `MavenImportTest` POMs hardcoded `/tmp/test-maven`, relativized against a `C:` temp dir | 4 | test |
| `ChecksumTests` hashes a `.pom` byte-for-byte; CRLF checkout changed the hash | 1 | repo config |
| `ProjectDigestTest` teardown could not delete git's read-only loose objects; also leaked a `Files.list` handle | 1 | test |

### The two production bugs

**`ProjectDigest` digests were not portable across machines.** `hashFilesystem` sorted `Path` objects; `gitLsTree` sorted strings. `Path.compareTo` is case-insensitive on Windows and byte-wise on Unix, so the two hashing paths disagreed *with each other* on Windows and with every other OS — defeating the entire point of the digest. Now both sort the normalized relative path string actually fed to the digest. Unix ordering is provably unchanged (comparing full paths that share a prefix is equivalent to comparing the relative parts), so **no cache invalidation outside Windows**.

**`runSbt.parseProjectsOutput` mis-parsed sbt's `file:` URLs.** It took `line.split(":").last`, so sbt's `In file:///x/y/` spelling became `///x/y/`. Unix collapses the slashes; Windows reads `//` as a UNC prefix and produced `\\x\y` — a *different map key* than the same build reached via sbt's other spelling `In file:/x/y/`. Now parsed from the marker with the leading slash run collapsed, which also keeps a `C:` drive letter intact.

### Line endings

`* text=auto eol=lf` for the tree, `-text` for byte-exact fixtures, `eol=crlf` for `.bat`/`.cmd`. `git add --renormalize .` is a no-op, so nothing in the repo changes — this only affects what a Windows checkout produces.

Worth noting the YAML printer is **innocent**: circe-yaml already defaults to `LineBreak.Unix`. The CRLF was on the expected side, in the test sources themselves.

## Verification

- **`windows-latest`: `Tests: 177 passed, 0 failed`** across 30 suites, with the exit code now actually propagating — plus the `kernel32 console size` line proving the downcalls link.
- **`build` (full Linux suite, including slow ITs and the `git diff --exit-code` snapshot comparison): green.** This independently confirms the risky changes — the placeholder rework produced byte-identical snapshot output, Unix digests are unchanged, and the sbt parsing change still works against real sbt output.
- Both Linux arches green. Full `bleep-tests` suite passes locally on macOS with no snapshot churn.

## Unrelated, seen in passing

`PlatformCancellationTest` (bleep-bsp-tests) flaked once on macOS arm with `DirectoryNotEmptyException` in teardown — the assertion passed, then the Kotlin/JS compiler kept flushing files into the temp dir while `deleteRecursively` walked it. Pre-existing race, green on other runs, left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
