### PR TITLE
Stop one client's disconnect from SIGKILLing every other client's forks

### DIFF
--- a/bleep-bsp-tests/src/scala/bleep/bsp/SignalAttributionTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/bsp/SignalAttributionTest.scala
@@ -1,0 +1,34 @@
+package bleep.bsp
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** A SIGKILL description must not name a culprit it cannot know.
+  *
+  * Regression for a message that asserted "sent by the OS, not by the script or by bleep — almost always the kernel reclaiming memory under pressure". The
+  * actual killer was bleep's own daemon-wide child reaping, and a user measured the victim at a flat 160MB RSS with 8GB of RAM free while the message insisted
+  * it was memory pressure. `destroyForcibly` and the kernel's OOM killer both deliver signal 9; the signal alone attributes nothing.
+  */
+class SignalAttributionTest extends AnyFunSuite with Matchers {
+
+  test("SIGKILL is not blamed on the OS or on memory pressure") {
+    val msg = SourceGenRunner.describeSignal(9)
+    msg should include("SIGKILL")
+    // The specific false claims that cost a day of debugging.
+    msg should not include "not by bleep"
+    msg should not include "not by the script"
+    msg.toLowerCase should not include "almost always"
+    // It must offer candidates to check rather than a verdict.
+    msg.toLowerCase should include("candidates")
+    msg.toLowerCase should include("bleep itself")
+  }
+
+  test("a small fork on a machine with free memory is explicitly told it was not an OOM") {
+    SourceGenRunner.describeSignal(9).toLowerCase should include("it was not an oom")
+  }
+
+  test("other signals still say what they know") {
+    SourceGenRunner.describeSignal(11) should include("SIGSEGV")
+    SourceGenRunner.describeSignal(15) should include("signal 15")
+  }
+}

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -700,29 +700,28 @@ class MultiWorkspaceBspServer(
     myOperationIds.remove(operationId): Unit
   }
 
-  /** Cancel all in-flight requests and kill child processes. */
+  /** Cancel this connection's in-flight requests.
+    *
+    * Scope is the point. `activeRequests` is per-connection, and cancelling those tokens propagates into the running IOs, whose `Resource` releases then
+    * `destroyForcibly` the processes THOSE requests started. That is precise and sufficient.
+    *
+    * There used to be a `killAllChildProcesses()` here as "belt and suspenders", walking `ProcessHandle.current().children()`. But `current()` is the DAEMON,
+    * which is shared by every workspace connected to it — so a cleanup path scoped to one connection reached across all of them and SIGKILLed other clients'
+    * perfectly healthy forks. One client disconnecting or sending `build/shutdown` killed another client's in-flight sourcegen and test JVMs.
+    *
+    * It was invisible because `destroyForcibly` here bypassed the kill-reason tracking, so the victim reported "killed by SIGKILL, not by bleep" and looked
+    * exactly like an OS memory kill. Measured on a fork that died this way: RSS flat at 160MB, 8GB free, memory pressure reporting 67% free — nothing to do
+    * with memory. Only forks living longer than a few seconds died, because that is how long another client needs to disconnect.
+    */
   private def cancelAllActiveRequests(): Unit = {
     val activeCount = activeRequests.size()
     if (activeCount > 0) {
       logger.withContext("count", activeCount).withContext("requests", activeRequests.keySet().asScala.mkString(", ")).warn("Cancelling all active requests")
     }
-    // Cancel all active request tokens (triggers cancellation flow in running IOs)
+    // Cancel this connection's request tokens (triggers cancellation flow in running IOs, which
+    // release their Resources and kill the processes they own).
     activeRequests.values().forEach(_.cancel())
-
-    // Kill any child processes of this JVM (belt and suspenders)
-    killAllChildProcesses()
   }
-
-  /** Kill all child processes of this JVM using ProcessHandle API */
-  private def killAllChildProcesses(): Unit =
-    try
-      ProcessHandle.current().children().forEach { child =>
-        try {
-          debugLog(s"Killing child process: ${child.pid()}")
-          child.destroyForcibly(): Unit
-        } catch { case _: Exception => }
-      }
-    catch { case _: Exception => }
 
   private def handleExit(): Unit = {
     // Don't exit the daemon - just close this connection

--- a/bleep-bsp/src/scala/bleep/bsp/SourceGenRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/SourceGenRunner.scala
@@ -35,13 +35,21 @@ object SourceGenRunner {
     if (kept.isEmpty) None else Some(kept.mkString("\n"))
   }
 
-  /** On Unix a signal death is the whole story, and for a sourcegen fork it is usually the same story as everywhere else in this build: the OS reclaiming
-    * memory.
+  /** Describe a signal death WITHOUT claiming to know who sent it.
+    *
+    * This used to assert "sent by the OS, not by the script or by bleep ... almost always the kernel reclaiming memory under pressure". That was wrong, and
+    * confidently wrong: the actual killer was bleep's own daemon-wide `killAllChildProcesses`, reaping other clients' forks on any disconnect. A user measured
+    * the victim at a flat 160MB RSS with 8GB free while the message insisted it was memory pressure.
+    *
+    * SIGKILL is not attributable from the signal alone — bleep's own `destroyForcibly` and the kernel's OOM killer are indistinguishable at this level. So
+    * state what is known, list the candidates, and let the reader check rather than sending them somewhere specific on our guess.
     */
   private[bsp] def describeSignal(signal: Int): String =
     signal match {
       case 9 =>
-        "killed by SIGKILL — sent by the OS, not by the script or by bleep; on a forked JVM this is almost always the kernel reclaiming memory under pressure"
+        "killed by SIGKILL — something outside the script terminated it. SIGKILL carries no attribution, so the candidates are: the OS reclaiming memory " +
+          "(check the system log for a memory-pressure kill), another process killing it, or bleep itself. If the fork was small and the machine had memory " +
+          "free, it was not an OOM"
       case 11    => "killed by SIGSEGV — the JVM crashed; look for an hs_err_pid*.log"
       case other => s"killed by signal $other"
     }

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -173,10 +173,11 @@ object JvmPool {
               ExitDescription("EOF on stdout, exited 0", Some("The JVM exited cleanly without sending a suite result — it likely called System.exit()."))
             case 137 =>
               ExitDescription(
-                "killed by SIGKILL (exit 137), not by bleep",
+                "killed by SIGKILL (exit 137)",
                 Some(
-                  "Nothing in bleep terminated this process, so it was killed from outside — most likely the OS reclaiming memory. " +
-                    "Check the system log for memory-pressure kills before assuming so; if there are none, look for another external killer."
+                  "Nothing that records a reason terminated this process. SIGKILL carries no attribution, so this is not proof the OS did it — bleep's own " +
+                    "untracked kill paths look identical. Candidates: the OS reclaiming memory (check the system log for a memory-pressure kill), another " +
+                    "process, or bleep. If this JVM was small and the machine had memory free, it was not an OOM."
                 )
               )
             case 139 => ExitDescription("killed by SIGSEGV (exit 139)", Some("The JVM crashed; look for an hs_err_pid*.log next to the working directory."))


### PR DESCRIPTION
One client disconnecting SIGKILLed every other client's in-flight forks.

## The bug

`cancelAllActiveRequests()` — which runs when a connection's server loop exits, and on `build/shutdown` — ended with:

```scala
private def killAllChildProcesses(): Unit =
  ProcessHandle.current().children().forEach(_.destroyForcibly())
```

`current()` is the **daemon**, and the daemon is shared by every workspace connected to it. So a cleanup path scoped to *one* connection reached across *all* of them: any client disconnecting or shutting down killed other clients' perfectly healthy sourcegen and test JVMs, mid-run.

`activeRequests` was already correctly per-connection. Cancelling those tokens propagates into the running IOs, whose `Resource` releases `destroyForcibly` the processes **those** requests own — precise and sufficient. The extra sweep was "belt and suspenders" that was safe in a single-client daemon and destructive in a shared one. Removed.

## Why it took so long to find

The kill bypassed the kill-reason tracking, so the victim reported `killed by SIGKILL … not by bleep` — indistinguishable from an OS memory kill, and the message actively asserted that's what it was.

It isn't. Measured on a killed fork:

| observation | |
| --- | --- |
| fork RSS | **flat ~160MB** its whole life, never grew |
| machine | 48GB, 3.7–8.8GB free pages, `memory_pressure` reporting **67% free** |
| kill times | 3364, 3516, 3929, 4437, 4569, 4674, 5109, 5209 ms — a tight window |
| forks finishing in ~0.6s | **never** died |
| same script run in-process (`bleep sourcegen ddbt`) | succeeded every time, ~7.7s |
| ruled out | not an output-inactivity watchdog — it died mid-stream with continuous logging |

Every one of those follows from the real cause: the 3–5s window is how long another client needs to disconnect; short forks finish before it opens; in-process runs have no fork to reap; and other worktrees were building concurrently against the same daemon.

Same root cause as the earlier cross-client-shutdown report — that caught the request-cancellation half of this function, this is the process-killing half.

## The messages stop guessing

`destroyForcibly` and the kernel's OOM killer both deliver signal 9. The signal attributes nothing, so claiming *"sent by the OS, not by the script or by bleep … almost always the kernel reclaiming memory under pressure"* was not just wrong — it pointed the investigation away from bleep for a long time.

Both SIGKILL messages (sourcegen and test-fork) now state what's known, list the candidates **including bleep itself**, and say outright that a small fork on a machine with free memory was not an OOM. Three regression tests pin that the false phrases cannot return.

## Testing

601 tests green. Verified against the original reproducer while deliberately churning a second client against the same daemon every 2s — precisely the condition that used to kill it: **2 passed, 0 failed**, no SIGKILL, no skipped downstream projects. Previously this failed reproducibly, 10+ times over ~2 hours.

Reported in ~/bleep: `bug-report-sourcegen-fork-sigkill.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
