### PR TITLE
ci: run jvm3 on Windows, like every other arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,12 +268,16 @@ jobs:
           CI: true
         # Slow ITs run in the `build` job — see the non-windows test step for rationale.
         #
+        # Tests `jvm3`, same as every other arch in this matrix. This used to test only `bleep-tests`, so `bleep-bsp-tests` — the compiler, BSP, process and
+        # linker machinery, i.e. the most platform-sensitive half of the suite — had never once run on Windows. That is 177 tests here against 742 everywhere
+        # else. Windows is not a second-class arch; see the banner at the top of this job.
+        #
         # `shell: pwsh` with an explicit $LASTEXITCODE check after every command. This used to be `shell: cmd`, where a multi-line `run:` reports only the LAST
         # command's exit code — so `bleep test` failing was silently discarded and only `selftest` decided the step. That hid 42 real Windows test failures
         # across every green run of this job.
         shell: pwsh
         run: |
-          .\${{ matrix.file_name }} --dev test --no-color bleep-tests --exclude-tag slow
+          .\${{ matrix.file_name }} --dev test --no-color jvm3 --exclude-tag slow
           if ($LASTEXITCODE -ne 0) { Write-Host "::error::bleep test failed with exit code $LASTEXITCODE"; exit $LASTEXITCODE }
           .\${{ matrix.file_name }} selftest
           if ($LASTEXITCODE -ne 0) { Write-Host "::error::bleep selftest failed with exit code $LASTEXITCODE"; exit $LASTEXITCODE }

--- a/bleep-bsp-tests/src/scala/bleep/analysis/EdgeCaseIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/EdgeCaseIntegrationTest.scala
@@ -28,8 +28,13 @@ import scala.concurrent.duration._
   */
 class EdgeCaseIntegrationTest extends AnyFunSuite with Matchers with TimeLimits {
 
-  // Timeouts for different test categories
-  val quickTimeout = Span(5, Seconds) // Tests that should complete almost instantly
+  // Timeouts for different test categories.
+  //
+  // `quickTimeout` was 5s, which was never true to its name: most of these tests spawn `node` or a native binary, and process startup on a loaded CI runner is
+  // not instant. "Scala.js: handles uncaught exception in test" flaked on both macos-15-intel and windows-latest at 5s while passing everywhere else — a
+  // timeout tuned on a developer machine, failing whichever runner happened to be busiest. These are guards against a genuine hang, so they only need to be far
+  // below the suite-level idle timeout, not tight.
+  val quickTimeout = Span(30, Seconds) // Tests that should complete without hanging
   val mediumTimeout = Span(10, Seconds) // Tests with moderate work
   val cancellationTimeout = Span(5, Seconds) // Tests that rely on cancellation (should be fast)
 
@@ -477,8 +482,10 @@ class EdgeCaseIntegrationTest extends AnyFunSuite with Matchers with TimeLimits 
           )
         } yield res).attempt.unsafeRunSync()
 
-        // Should handle (either by auto-setting exec or failing gracefully)
-        result.isRight shouldBe true
+        // The contract is that the problem is reported rather than swallowed into a pass — same formulation as the missing-binary test above. Unix reaches
+        // that via Right(unsuccessful): the runner sets the exec bit, runs the file, and it fails. Windows has no exec bit, so the file is executable by
+        // permission but is not a valid executable image, CreateProcess rejects it, and the failure arrives as Left. Both report; neither passes.
+        result.isLeft || result.exists(r => !r.isSuccess) shouldBe true
       } finally deleteRecursively(tempDir)
     }
   }

--- a/bleep-bsp-tests/src/scala/bleep/analysis/PlatformTestHelper.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/PlatformTestHelper.scala
@@ -42,14 +42,25 @@ trait PlatformTestHelper {
   /** Managed Node.js binary path, fetched via Coursier. */
   def nodeBinary: String = PlatformTestHelper.nodeBinary
 
-  /** Cancel the surrounding test when Kotlin Native cannot run on this host. JetBrains does not publish a `kotlin-native-prebuilt-linux-aarch64-*` artifact
-    * (verified up to 2.3.21 / 2.4.0-RC). `KotlinNativeCompiler.scala` falls back to the `linux-x86_64` distribution, which the JVM then fails to load on
-    * aarch64 with `UnsatisfiedLinkError` inside `kotlinx.cinterop.JvmCallbacksKt.<clinit>`. Until upstream publishes a linux-aarch64 host, tests that drive the
-    * Konan compiler must be cancelled (not silently skipped) on that arch. Uses `assume` so ScalaTest reports the test as canceled rather than passed.
+  /** Cancel the surrounding test when Kotlin Native cannot run on this host. Uses `assume` so ScalaTest reports the test as canceled rather than passed — the
+    * coverage loss stays visible in the run summary instead of masquerading as a green test.
+    *
+    * Two hosts are excluded, both because the Konan toolchain itself does not work there, never because a test is inconvenient:
+    *
+    *   - **linux-aarch64**: JetBrains does not publish a `kotlin-native-prebuilt-linux-aarch64-*` artifact (verified up to 2.3.21 / 2.4.0-RC).
+    *     `KotlinNativeCompiler.scala` falls back to the `linux-x86_64` distribution, which the JVM then fails to load with `UnsatisfiedLinkError` inside
+    *     `kotlinx.cinterop.JvmCallbacksKt.<clinit>`.
+    *   - **Windows**: the Konan driver dies during its own static initialization — `error: compilation failed: null` followed by `ExceptionInInitializerError`
+    *     at `org.jetbrains.kotlin.backend.konan.driver.NativeCompilerDriver.run`. It does not throw something catchable; it takes the whole forked test JVM
+    *     down with exit code 2, which is why `KotlinNativeAdvancedIntegrationTest` and `LinkExecutorIntegrationTest` reported as "did not finish" rather than
+    *     as failures. Note this cancels only the Konan-driving tests: Scala Native linking works on Windows and keeps running.
     */
-  def assumeKotlinNativeAvailable(): Unit =
+  def assumeKotlinNativeAvailable(): Unit = {
     org.scalatest.Assertions
       .assume(bleep.OsArch.current != bleep.OsArch.LinuxArm64, "Kotlin Native does not publish a linux-aarch64 prebuilt; test cannot run on this host")
+    org.scalatest.Assertions
+      .assume(!scala.util.Properties.isWin, "Kotlin Native's compiler driver crashes in its static initializer on Windows and kills the test JVM")
+  }
 
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)

--- a/bleep-bsp-tests/src/scala/bleep/analysis/PortableAnalysisMappersTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/PortableAnalysisMappersTest.scala
@@ -77,8 +77,9 @@ class PortableAnalysisMappersTest extends AnyFunSuite with Matchers {
       buildDir =>
         val randomPath = Path.of("/some/random/path/foo.jar")
       val vf = PlainVirtualFile(randomPath, buildDir)
-      // Should be absolute, no marker prefix
-      vf.id() should startWith("/")
+      // Should be absolute, no marker prefix. Asked of the path rather than of the string: a Windows absolute path starts with a drive letter, so the id is
+      // `D:/some/random/path/foo.jar` and a literal startsWith("/") only ever described Unix.
+      Path.of(vf.id()).isAbsolute shouldBe true
       vf.id() should not contain "${BASE}"
       vf.id() should not contain "${LIB}"
     }

--- a/bleep-bsp-tests/src/scala/bleep/testing/ExitAttributionTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/testing/ExitAttributionTest.scala
@@ -12,8 +12,12 @@ import org.scalatest.matchers.should.Matchers
   */
 class ExitAttributionTest extends AnyFunSuite with Matchers {
 
+  /** Any already-exited process will do — these tests are about how a death is *described*, not about what died. `/bin/sh` does not exist on Windows, so
+    * hardcoding it made the whole suite fail there with `CreateProcess error=2`.
+    */
   private def deadProcess(): Process = {
-    val p = new ProcessBuilder("/bin/sh", "-c", "exit 0").start()
+    val cmd = if (scala.util.Properties.isWin) List("cmd", "/c", "exit 0") else List("/bin/sh", "-c", "exit 0")
+    val p = new ProcessBuilder(cmd*).start()
     p.waitFor()
     p
   }


### PR DESCRIPTION
Follow-up to #607.

## The gap

The Windows native-image job tested only `bleep-tests`. All four other arches test `jvm3`, which also covers **`bleep-bsp-tests`** — the compiler, BSP, process-spawning and linker machinery, i.e. the most platform-sensitive half of the suite.

| job | command | tests |
|---|---|---|
| macOS / Linux native-image | `jvm3 --exclude-tag slow` | **742** |
| windows-latest | `bleep-tests --exclude-tag slow` | **177** |

So `bleep-bsp-tests` had never executed on Windows, once, ever.

## This PR

One word: `bleep-tests` → `jvm3`. Windows now runs the same set as everyone else.

**Draft on purpose** — this newly runs ~565 tests across 44 suites on a platform they have never seen, and only 7 of those suites carry any OS guard today. I expect a substantial batch of failures, of the same character as the 42 in #607. Working through them is the point of the PR; this first push is to measure the damage.

Ground rule carried over from the banner in `build.yml`: "doesn't work on Windows" is never a reason to skip a test. A guard is only legitimate when the *feature* genuinely isn't supported on the platform, and each one will say so explicitly.

Timing note: the Windows job runs 12 min against a 40-min timeout, and Linux runs the same `jvm3` set in 13 min, so there should be headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)