### PR TITLE
bsp: diagnose compile-server OOM deaths instead of littering heap dumps

### DIFF
--- a/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
@@ -77,7 +77,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
           jobs.values.toList.traverse_(_.cancel)
         }
       )
-    } yield new BleepMcpSession(client, lifecycle.server, lifecycle.listening, eventRoutes, diagnosticRoutes, watchJobs, watchResults, buildHistory)
+    } yield new BleepMcpSession(client, bspConfig, lifecycle.server, lifecycle.listening, eventRoutes, diagnosticRoutes, watchJobs, watchResults, buildHistory)
 
   private def setupBspConfig(): Either[BleepException, BspRifleConfig] =
     started.bspServerClasspathSource match {
@@ -133,6 +133,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
 
   private class BleepMcpSession(
       _client: McpServer.Client[IO],
+      bspConfig: BspRifleConfig,
       bspServer: bleep.bsp.BuildServer,
       bspListening: java.util.concurrent.Future[Void],
       eventRoutes: ConcurrentHashMap[String, Queue[IO, Option[BleepBspProtocol.Event]]],
@@ -590,6 +591,17 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
         }.toArray
       }
 
+    /** The session holds one BSP connection for its whole lifetime, so a failed tool call is the only place the agent ever sees why the server died. If the
+      * server log records an OutOfMemoryError death, append that explanation (with the fix) to the failure.
+      */
+    private def diagnoseOomOnFailure[A](io: IO[A]): IO[A] =
+      io.handleErrorWith { e =>
+        BspRifle.oomCrashExplanation(bspConfig).flatMap {
+          case Some(oom) => IO.raiseError(new BleepException.Cause(e, s"${e.getMessage}. $oom"))
+          case None      => IO.raiseError(e)
+        }
+      }
+
     /** Execute a compile via BSP on the persistent connection. Reports progress heartbeat every 30s, returns compact summary. */
     private def executeBspOperation(
         projectNames: List[String],
@@ -620,7 +632,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
         // Heartbeat fiber: report progress every 30s
         heartbeatFiber <- heartbeat(collectedEvents, done, "compile", context).start
 
-        _ <- {
+        _ <- diagnoseOomOnFailure {
           val targets = BspQuery.buildTargets(started.buildPaths, targetProjects)
           BspRequestHelper
             .callCancellable(
@@ -677,7 +689,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
         consumerFiber <- consumeAndLogEvents(eventQueue, collectedEvents, previousState, context).start
         heartbeatFiber <- heartbeat(collectedEvents, done, "test", context).start
 
-        _ <- {
+        _ <- diagnoseOomOnFailure {
           val targets = BspQuery.buildTargets(started.buildPaths, targetProjects)
           BspRequestHelper
             .callCancellable(
@@ -773,7 +785,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
           _ <- IO.delay(diagnosticRoutes.put(originId, diagnosticCallback()))
           consumerFiber <- consumeAndLogEvents(eventQueue, collectedEvents, previousState, context).start
 
-          _ <- {
+          _ <- diagnoseOomOnFailure {
             val targets = BspQuery.buildTargets(started.buildPaths, targetProjects)
             mode match {
               case BleepBspProtocol.BuildMode.Test =>
@@ -951,7 +963,7 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
       }
 
       for {
-        result <- {
+        result <- diagnoseOomOnFailure {
           val targets = BspQuery.buildTargets(started.buildPaths, targetProjects)
           BspRequestHelper.callCancellable(
             bspServer.buildTargetScalaTestClasses(new bsp4j.ScalaTestClassesParams(targets)),
@@ -1073,14 +1085,16 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
         targetProjects: Array[model.CrossProjectName]
     ): IO[Unit] = {
       val targets = BspQuery.buildTargets(started.buildPaths, targetProjects)
-      BspRequestHelper
-        .callCancellable(
-          {
-            val params = new bsp4j.CompileParams(targets)
-            bspServer.buildTargetCompile(params)
-          },
-          bspListening
-        )
+      diagnoseOomOnFailure(
+        BspRequestHelper
+          .callCancellable(
+            {
+              val params = new bsp4j.CompileParams(targets)
+              bspServer.buildTargetCompile(params)
+            },
+            bspListening
+          )
+      )
         .flatMap { result =>
           IO.raiseWhen(result.getStatusCode != bsp4j.StatusCode.OK)(
             new BleepException.Text(s"Compilation failed with status ${result.getStatusCode}")

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -717,7 +717,10 @@ object Main {
                 BleepConfigOps.rewritePersisted(logger, userPaths)(updateBspServerConfig(_.copy(compileServerMaxMemory = Some(size)))).map(_ => ())
               }
             ),
-            Opts.subcommand[BleepCommand]("max-memory-clear", "remove compile server max heap setting (use JVM default)")(
+            Opts.subcommand[BleepCommand](
+              "max-memory-clear",
+              "remove compile server max heap setting (back to default: 1/4 of physical RAM, clamped to 4g..16g)"
+            )(
               Opts(() => BleepConfigOps.rewritePersisted(logger, userPaths)(updateBspServerConfig(_.copy(compileServerMaxMemory = None))).map(_ => ()))
             ),
             Opts.subcommand[BleepCommand](

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -86,7 +86,8 @@ object BspRifle {
                     BspServerOperations.waitForServer(config)
                 case false =>
                   // Zombie: PID file exists but process is dead
-                  IO(logger.info(s"BSP server pid=$pid is dead, cleaning up and starting fresh")) >>
+                  warnIfDiedOfOom(config, pid, logger) >>
+                    IO(logger.info(s"BSP server pid=$pid is dead, cleaning up and starting fresh")) >>
                     BspServerOperations.cleanup(socketDir) >>
                     startAndWait(config, logger)
               }
@@ -106,11 +107,40 @@ object BspRifle {
     } yield ()
   }
 
+  /** If the server's `output` log records the VM's OOM termination line, it died (or is right now dying) of OutOfMemoryError. -XX:+DisplayVMOutputToStderr
+    * routes that line into the log the moment the VM starts terminating, so the client connected when it happened can diagnose it — in CI there is no next run
+    * to notice. The `output` file always belongs to the server generation the caller was dealing with; it must be read before cleanup/forceStop/startServer,
+    * which delete or rotate it.
+    */
+  def oomCrashExplanation(config: BspRifleConfig): IO[Option[String]] = IO.blocking {
+    val log = config.address.socketDir.resolve("output")
+    if (BspServerOperations.containsOomMarker(log)) {
+      val cap = config.javaOpts.filter(_.startsWith("-Xmx")).lastOption.getOrElse("<unset>")
+      val suggestion = bleep.MachineResources.parseMemoryMb(cap) match {
+        case Some(mb) =>
+          val doubled = mb * 2
+          if (doubled % 1024 == 0) s"${doubled / 1024}g" else s"${doubled}m"
+        case None => "8g"
+      }
+      Some(
+        s"BSP server died of OutOfMemoryError with heap capped at $cap (see $log)." +
+          s" If this recurs, raise the cap with: bleep config compile-server max-memory $suggestion"
+      )
+    } else None
+  }
+
+  /** A dead server whose log records the OOM termination line died of OutOfMemoryError — say so, with the fix, instead of a bare "dead, restarting". */
+  private def warnIfDiedOfOom(config: BspRifleConfig, pid: Long, logger: Logger): IO[Unit] =
+    oomCrashExplanation(config).flatMap {
+      case Some(msg) => IO(logger.warn(s"$msg (dead server pid=$pid)"))
+      case None      => IO.unit
+    }
+
   /** Start a new server and wait for it to be ready. */
   def startAndWait(config: BspRifleConfig, logger: Logger): IO[Unit] =
     for {
       _ <- IO(logger.info("Waiting for BSP server to be ready"))
-      process <- startServer(config)
+      process <- startServer(config, logger)
       // Check if process exited immediately (e.g., exit code 222 = already running)
       exitedImmediately <- IO.blocking(process.isAlive).map(!_)
       _ <-
@@ -143,8 +173,8 @@ object BspRifle {
     * @return
     *   The server process (for monitoring, not for direct interaction)
     */
-  def startServer(config: BspRifleConfig): IO[Process] =
-    BspServerOperations.startServer(config)
+  def startServer(config: BspRifleConfig, logger: Logger): IO[Process] =
+    BspServerOperations.startServer(config, logger)
 
   /** Connect to a running server with retry on transient failures.
     *

--- a/bleep-core/src/scala/bleep/bsp/BspRifleConfig.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifleConfig.scala
@@ -65,17 +65,36 @@ object BspRifleConfig {
     case class Tcp(host: String, port: Int, socketDir: Path) extends Address
   }
 
-  /** Default JVM options for BSP server */
+  /** Default max heap for the BSP server: a quarter of physical RAM, clamped to [4g, 16g].
+    *
+    * The old fixed 4g cap OOM-killed the server repeatedly on large builds under concurrent clients, even on machines with plenty of RAM. Machine-dependent but
+    * deterministic per machine, so it is safe to include in the JvmKey hash. Overridable via `bleep config compile-server max-memory`.
+    */
+  val defaultMaxHeapMb: Long = {
+    val physicalMb = bleep.MachineResources.physicalMemoryMb(fallbackMb = 16 * 1024L)
+    math.min(16 * 1024L, math.max(4 * 1024L, physicalMb / 4))
+  }
+
+  def defaultMaxHeapOpt: String = s"-Xmx${defaultMaxHeapMb}m"
+
+  /** Default JVM options for BSP server. Does NOT include -Xmx: the heap cap comes from user config or [[defaultMaxHeapOpt]] (see SetupBleepBsp). */
   val defaultJavaOpts: Seq[String] = Seq(
     "-Xss4m",
-    "-Xmx4g",
     "-XX:ReservedCodeCacheSize=512m",
     "-XX:+UseZGC",
     "-XX:+ZGenerational",
     "-XX:ZUncommitDelay=30",
     "-XX:ZCollectionInterval=5",
     "-XX:+UseStringDeduplication",
-    "-XX:+HeapDumpOnOutOfMemoryError",
+    // No OS core file on a hard VM crash: multi-GB, one per crash, and nothing ever reads them.
+    "-XX:-CreateCoredumpOnCrash",
+    // Route VM tty output to stderr, which startServer captures into the socket dir's `output`
+    // log (stdout is discarded). Notably this captures "Terminating due to
+    // java.lang.OutOfMemoryError" from ExitOnOutOfMemoryError below — the marker clients use to
+    // diagnose OOM death (BspServerOperations.OomMarker). We deliberately do NOT
+    // -XX:+HeapDumpOnOutOfMemoryError: dumps are ~heap-sized, accumulate one per crash, and
+    // freeze the JVM for minutes mid-write, during which clients hang on a dead-but-alive server.
+    "-XX:+DisplayVMOutputToStderr",
     // Die immediately on OOM instead of limping on. A worker-thread OOM otherwise poisons
     // static initializers (e.g. sbt.nio.file.FileTreeView$ fails init once, then throws
     // NoClassDefFoundError forever), silently bricking all further compiles for the server's
@@ -120,7 +139,7 @@ object BspRifleConfig {
       address = Address.DomainSocket(socketPath),
       jvmKey = jvmKey,
       javaPath = javaPath,
-      javaOpts = defaultJavaOpts,
+      javaOpts = defaultJavaOpts :+ defaultMaxHeapOpt,
       serverMainClass = serverMainClass,
       serverClasspath = serverClasspath,
       workingDir = workingDir,

--- a/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
@@ -1,6 +1,7 @@
 package bleep.bsp
 
 import cats.effect.IO
+import ryddig.Logger
 
 import java.net.{ConnectException, InetSocketAddress, Socket, StandardProtocolFamily}
 import java.nio.channels.SocketChannel
@@ -19,6 +20,46 @@ object BspServerOperations {
   /** Exit code indicating server is already running */
   val ServerAlreadyRunningExitCode: Int = 222
 
+  /** The line HotSpot prints (via VM tty output) right before -XX:+ExitOnOutOfMemoryError kills the VM. -XX:+DisplayVMOutputToStderr routes it into the socket
+    * dir's `output` log, making it the durable evidence that a server died of OOM — no heap dump required.
+    */
+  val OomMarker = "Terminating due to java.lang.OutOfMemoryError"
+
+  def containsOomMarker(log: Path): Boolean =
+    // lossy decode: the log interleaves subprocess output that need not be valid UTF-8, and a diagnosis helper must not throw over it
+    Files.exists(log) && new String(Files.readAllBytes(log), java.nio.charset.StandardCharsets.UTF_8).contains(OomMarker)
+
+  /** Heap dumps written by older bleep versions, which ran the server with -XX:+HeapDumpOnOutOfMemoryError. They land in the server's working directory (the
+    * socket dir) as `java_pid<pid>.hprof`. Current servers don't write dumps; these are legacy litter to clean up.
+    */
+  def listHeapDumps(socketDir: Path): List[Path] =
+    if (Files.isDirectory(socketDir)) {
+      val stream = Files.list(socketDir)
+      try
+        stream
+          .iterator()
+          .asScala
+          .filter { p =>
+            val name = p.getFileName.toString
+            name.startsWith("java_pid") && name.endsWith(".hprof")
+          }
+          .toList
+      finally stream.close()
+    } else Nil
+
+  /** A hint to append to connect/startup failure messages when the server log shows an OutOfMemoryError death.
+    *
+    * By the time these failures surface, startServer has rotated `output` to `output.prev`, so the crashed generation's log may be under either name — check
+    * both and say which one carried the evidence.
+    */
+  def oomHint(socketDir: Path): String =
+    List("output", "output.prev").map(socketDir.resolve).find(containsOomMarker) match {
+      case None      => ""
+      case Some(log) =>
+        s"""\nNote: $log contains "$OomMarker" — the server ran out of heap.""" +
+          " Raise the cap with: bleep config compile-server max-memory <size>"
+    }
+
   // ==========================================================================
   // Process Management
   // ==========================================================================
@@ -27,10 +68,20 @@ object BspServerOperations {
     *
     * The server is started as a daemon process with stdout/stderr redirected to an output file for later inspection.
     */
-  def startServer(config: BspRifleConfig): IO[Process] = IO
+  def startServer(config: BspRifleConfig, logger: Logger): IO[Process] = IO
     .blocking {
       val socketDir = config.address.socketDir
       ensureDirectoryExists(socketDir)
+
+      // Multi-GB heap dumps left behind by older bleep versions (whose servers ran with
+      // -XX:+HeapDumpOnOutOfMemoryError) accumulate one per crash until the disk fills.
+      // Current servers don't write dumps — OOM death is diagnosed from the output log
+      // (OomMarker) — so anything found here is litter.
+      listHeapDumps(socketDir).foreach { dump =>
+        val sizeMb = Files.size(dump) / (1024L * 1024L)
+        Files.delete(dump)
+        logger.warn(s"Deleted legacy OutOfMemoryError heap dump $dump (${sizeMb}MB)")
+      }
 
       val outputFile = socketDir.resolve("output")
       // Preserve previous server's output for debugging, then start fresh
@@ -219,7 +270,7 @@ object BspServerOperations {
                   s"server output:\n$outputContent"
                 ).mkString("\n  ")
                 new RuntimeException(
-                  s"BSP server failed to start within ${config.startCheckTimeout}\n  $details"
+                  s"BSP server failed to start within ${config.startCheckTimeout}\n  $details${oomHint(config.address.socketDir)}"
                 )
               }.flatMap(IO.raiseError)
             } else {
@@ -253,7 +304,7 @@ object BspServerOperations {
             if (now.toMillis >= deadline) {
               IO.raiseError(
                 new RuntimeException(
-                  s"Failed to connect to BSP server within ${config.connectionTimeout}: ${ex.getClass.getSimpleName}: ${ex.getMessage}"
+                  s"Failed to connect to BSP server within ${config.connectionTimeout}: ${ex.getClass.getSimpleName}: ${ex.getMessage}${oomHint(config.address.socketDir)}"
                 )
               )
             } else {

--- a/bleep-core/src/scala/bleep/bsp/SetupBleepBsp.scala
+++ b/bleep-core/src/scala/bleep/bsp/SetupBleepBsp.scala
@@ -38,14 +38,17 @@ object SetupBleepBsp {
       logger: Logger,
       extraServerClasspath: Seq[Path]
   ): Either[BleepException, BspRifleConfig] = {
-    val extraJavaOpts = config.bspServerConfigOrDefault.compileServerMaxMemory.map(m => s"-Xmx$m").toList
+    val maxHeapOpt = config.bspServerConfigOrDefault.compileServerMaxMemory match {
+      case Some(m) => s"-Xmx$m"
+      case None    => BspRifleConfig.defaultMaxHeapOpt
+    }
     val majorVersion = BspRifleConfig.jvmMajorVersion(resolvedJvm.jvm.name)
     val versionOpts = BspRifleConfig.jdkVersionOpts(majorVersion)
-    val javaOpts = BspRifleConfig.defaultJavaOpts ++ versionOpts ++ extraJavaOpts
+    val javaOpts = BspRifleConfig.defaultJavaOpts ++ Seq(maxHeapOpt) ++ versionOpts
     // Include extra classpath JAR filenames in the JVM key so the hash differs
     // when semanticdb-javac is present, giving a dedicated server instance
     val extraCpOpts = extraServerClasspath.map(p => s"--extra-cp=${p.getFileName}").toList
-    val jvmKey = createJvmKey(resolvedJvm.jvm, compileServerMode, versionOpts.toList ++ extraJavaOpts ++ extraCpOpts)
+    val jvmKey = createJvmKey(resolvedJvm.jvm, compileServerMode, maxHeapOpt :: versionOpts.toList ++ extraCpOpts)
 
     for {
       serverClasspath <- resolveServerClasspath(resolver, userPaths, logger)

--- a/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
+++ b/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
@@ -376,16 +376,35 @@ case class ReactiveBsp(
         }
 
       // Retry once if the server crashed (e.g. after `bleep clean` deleted class files).
-      // Kill the dead server, start a fresh one, and reconnect.
+      // Kill the dead server, start a fresh one, and reconnect. Diagnose OOM death from the
+      // server log BEFORE forceStop deletes it — in CI there is no next run to notice, so
+      // this run must be the one that says why the server died.
       bspOperation = attemptBspOperation.flatMap {
         case ReactiveBsp.BspAttemptResult.Success       => IO.unit
         case ReactiveBsp.BspAttemptResult.ServerCrashed =>
-          IO(bspLogger.warn("BSP server crashed, restarting and retrying...")) >>
-            IO(diagLog("[RETRY] Server crashed, killing stale server and retrying")) >>
-            display.reset >> // Reset display state to avoid double-counting events from crashed attempt
-            BspRifle.forceStop(config) >>
-            BspRifle.ensureRunning(config, bspLogger) >>
-            attemptBspOperation.void
+          BspRifle.oomCrashExplanation(config).flatMap { oomFirst =>
+            (oomFirst match {
+              case Some(msg) => IO(bspLogger.warn(msg)) >> IO(bspLogger.warn("Restarting BSP server and retrying..."))
+              case None      => IO(bspLogger.warn("BSP server crashed, restarting and retrying..."))
+            }) >>
+              IO(diagLog("[RETRY] Server crashed, killing stale server and retrying")) >>
+              display.reset >> // Reset display state to avoid double-counting events from crashed attempt
+              BspRifle.forceStop(config) >>
+              BspRifle.ensureRunning(config, bspLogger) >>
+              attemptBspOperation.flatMap {
+                case ReactiveBsp.BspAttemptResult.Success       => IO.unit
+                case ReactiveBsp.BspAttemptResult.ServerCrashed =>
+                  // Two crashes in a row is systematic, not transient — fail the command instead
+                  // of looping (or worse, reporting a summary from a half-run build).
+                  BspRifle.oomCrashExplanation(config).flatMap { oomSecond =>
+                    val msg = oomSecond.orElse(oomFirst) match {
+                      case Some(oom) => s"BSP server crashed twice. $oom"
+                      case None      => s"BSP server crashed twice (no OutOfMemoryError recorded; see server log: ${BspRifle.getOutputFile(config)})"
+                    }
+                    IO.raiseError(new BleepException.Text(msg))
+                  }
+              }
+          }
       }
 
       // Race BSP operation with user quit - pressing 'q' cancels BSP immediately
@@ -393,7 +412,14 @@ case class ReactiveBsp(
       bspError <- raceResult match {
         case Left(err) =>
           IO(diagLog(s"[ERROR] BSP operation failed: ${err.getClass.getName}: ${err.getMessage}")) >>
-            IO(started.logger.error(s"BSP operation failed: ${err.getMessage}")).as(Some(err))
+            IO(started.logger.error(s"BSP operation failed: ${err.getMessage}")) >>
+            // e.g. an error racing the server's OOM death: the connection may not have closed
+            // yet so ServerCrashed never fired, but the server log already names the cause
+            BspRifle.oomCrashExplanation(config).flatMap {
+              case Some(oom) => IO(started.logger.error(oom))
+              case None      => IO.unit
+            } >>
+            IO.pure(Some(err))
         case Right(_) => IO.pure(None)
       }
 

--- a/docs/guides/compile-servers.mdx
+++ b/docs/guides/compile-servers.mdx
@@ -71,13 +71,21 @@ or generated-code-heavy builds may need more.
 ```bash
 bleep config compile-server max-memory 4g
 bleep config compile-server max-memory 2048m
-bleep config compile-server max-memory-clear   # back to JVM default
+bleep config compile-server max-memory-clear   # back to bleep's default
 ```
 
-Sets the `-Xmx` for the compile server JVM(s) bleep starts. Reach
-for this when you're hitting `OutOfMemoryError` during compile, or
-when you have plenty of RAM and want to give the compiler room to
-breathe.
+Sets the `-Xmx` for the compile server JVM(s) bleep starts. The
+default is a quarter of physical RAM, clamped to between 4g and
+16g. Reach for this when you're hitting `OutOfMemoryError` during
+compile, or when you have plenty of RAM and want to give the
+compiler room to breathe.
+
+When the server does die of `OutOfMemoryError`, it exits
+immediately — no heap dump or core file is written. The client
+that was connected (or the next bleep invocation) detects the OOM
+from the server log and reports it together with the configured
+cap and the command to raise it. Heap dumps left behind by older
+bleep versions are deleted automatically at server start.
 
 [Reference &rarr;](/docs/reference/cli/config/compile-server/)
 

--- a/docs/reference/cli/config/compile-server.mdx
+++ b/docs/reference/cli/config/compile-server.mdx
@@ -18,7 +18,7 @@ bleep config compile-server <subcommand>
 
 ## `bleep config compile-server auto-shutdown-disable`
 
-<p>leave compile servers running between bleep invocations. This gets much better performance at the cost of memory</p>
+<p>leave compile servers running between bleep invocations. this gets much better performance at the cost of memory</p>
 
 ## `bleep config compile-server auto-shutdown-enable`
 
@@ -46,7 +46,7 @@ bleep config compile-server max-memory <size>
 
 ## `bleep config compile-server max-memory-clear`
 
-<p>remove compile server max heap setting (use JVM default)</p>
+<p>remove compile server max heap setting (back to default: 1/4 of physical RAM, clamped to 4g..16g)</p>
 
 ## `bleep config compile-server heap-pressure-threshold`
 
@@ -67,4 +67,24 @@ bleep config compile-server heap-pressure-threshold <threshold>
 ## `bleep config compile-server heap-pressure-threshold-clear`
 
 <p>remove heap pressure threshold setting (use default: 0.80)</p>
+
+## `bleep config compile-server read-timeout`
+
+<p>set minutes the server waits for a client's next message before dropping the connection, 0 to wait forever (default: 30)</p>
+
+### Synopsis
+
+```bash
+bleep config compile-server read-timeout <minutes>
+```
+
+### Arguments
+
+| Argument | Type |
+|----------|------|
+| `minutes` | one |
+
+## `bleep config compile-server read-timeout-clear`
+
+<p>remove read timeout setting (use default: 30 minutes)</p>
 

--- a/docs/reference/cli/dist.mdx
+++ b/docs/reference/cli/dist.mdx
@@ -27,7 +27,7 @@ bleep dist <project name exact> <path> [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--class <string>` | explicitly override main class. If not set. Bleep will first look in the build file, then fall back to looking into compiled class files |
+| `--class <string>` | explicitly override main class. If not set, bleep will first look in the build file, then fall back to looking into compiled class files |
 | `--watch, -w` | start in watch mode |
 | `--no-tui` | disable TUI, show summary only (for CI/agents) |
 | `--quiet, -q` | alias for --no-tui |

--- a/docs/reference/cli/fmt.mdx
+++ b/docs/reference/cli/fmt.mdx
@@ -8,7 +8,7 @@ title: bleep fmt
 
 # `bleep fmt`
 
-<p>format Scala and Java source files</p>
+<p>format Scala, Java, and Kotlin source files</p>
 
 ## Synopsis
 

--- a/docs/reference/cli/publish-local.mdx
+++ b/docs/reference/cli/publish-local.mdx
@@ -8,7 +8,7 @@ title: bleep publish-local
 
 # `bleep publish-local`
 
-<p>publishes your project locally (deprecated: use 'publish local')</p>
+<p>publishes your project locally (deprecated: use 'publish local-ivy')</p>
 
 ## Synopsis
 

--- a/docs/reference/cli/run.mdx
+++ b/docs/reference/cli/run.mdx
@@ -27,7 +27,7 @@ bleep run <project or script name> <arguments...> [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--class <string>` | explicitly override main class. If not set. Bleep will first look in the build file, then fall back to looking into compiled class files |
+| `--class <string>` | explicitly override main class. If not set, bleep will first look in the build file, then fall back to looking into compiled class files |
 | `--watch, -w` | start in watch mode |
 | `--no-tui` | disable TUI, show summary only (for CI/agents) |
 | `--quiet, -q` | alias for --no-tui |

--- a/docs/reference/cli/test.mdx
+++ b/docs/reference/cli/test.mdx
@@ -35,6 +35,8 @@ bleep test <project name...> [flags]
 | `--test-arg <string>` (repeatable) | arguments passed to test framework |
 | `--only, -o <string>` (repeatable) | Test only a subset of test suite class names. Class name can be fully qualified to disambiguate |
 | `--exclude, -x <string>` (repeatable) | Exclude specific test suite class names. Class name can be fully qualified to disambiguate. Takes precedence over --only |
+| `--only-tag <tag>` (repeatable) | Run only tests tagged with these names (declared in `testTags` per project). Multiple are OR-combined. |
+| `--exclude-tag <tag>` (repeatable) | Exclude tests tagged with these names. Takes precedence over --only-tag. |
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
 | `--junit-report <string>` | write JUnit XML reports to this directory |


### PR DESCRIPTION
## Problem

The shared compile server ran with a fixed `-Xmx4g` and `-XX:+HeapDumpOnOutOfMemoryError`. Under concurrent clients on a large build it OOM-died repeatedly, and each death:

- froze the JVM for **minutes** writing a ~5.7 GB `java_pid<pid>.hprof` into the socket dir, during which clients hung on a dead-but-alive server and timed out with a bare "failed to start"
- left the dump behind forever — observed in the wild: **22 dumps, 116 GB**, nothing ever deleted them
- was reported to nobody: the next client just said the server was dead and restarted it

## Fixes

**Sizing**
- Default max heap: ¼ of physical RAM clamped to [4g, 16g] (was: fixed 4g). Deterministic per machine, so safe in the JvmKey hash.
- `bleep config compile-server max-memory` now *replaces* the default `-Xmx` instead of appending a duplicate flag.

**No files on death**
- Dropped `-XX:+HeapDumpOnOutOfMemoryError`, added `-XX:-CreateCoredumpOnCrash`. OOM death is instant now — the mid-dump freeze window no longer exists.
- `startServer` deletes legacy `java_pid*.hprof` litter from older versions (logged per file).

**The replacement signal**
- `-XX:+DisplayVMOutputToStderr` routes HotSpot's `Terminating due to java.lang.OutOfMemoryError` line into the socket dir's `output` log (stdout is discarded). Verified empirically on GraalVM CE 25: exit code 3, marker on stderr, no hprof.
- The log rotates per server generation (`output` → `output.prev`), so evidence is naturally scoped to the server a client was talking to — no pid matching needed.

**Client-side diagnosis — including the run that was connected when it happened (CI has no next run)**
- Next-run startup path (dead pid / zombie cleanup) warns with the cap and a concrete doubled `max-memory` suggestion.
- `ReactiveBsp`: mid-operation crash logs the explanation before restart-and-retry; a **second** crash now fails the command loudly (previously swallowed by `.void`, which could report a summary from a half-run build); generic operation errors racing the death (e.g. read timeout) also check the log.
- Connect/start timeout messages append a hint when `output`/`output.prev` carry the marker.
- MCP sessions: `bspConfig` is threaded into the session and all five BSP request sites (compile, test, watch cycle, suite discovery, run's silent compile) append the explanation to the failed tool call — the only place an agent would ever see the cause.

Caveat: the marker is HotSpot wording — correct for the coursier-managed GraalVM/Temurin JVMs bleep uses; OpenJ9 would fall back to the undiagnosed "server crashed" messages.

Docs updated (`compile-servers.mdx` guide + regenerated CLI reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)