### PR TITLE
bsp: detect server readiness by connecting, not by grepping the log

### DIFF
--- a/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
@@ -226,10 +226,17 @@ object BspServerOperations {
   // Retry Logic
   // ==========================================================================
 
-  /** Wait for server to become ready with polling.
+  /** Wait for the server to become ready by connecting to its socket.
     *
-    * Polls by checking if the socket file exists and the server output contains "listening". We don't try to connect because that causes the server to wait for
-    * JSON-RPC messages, which blocks if the checking client just connects and disconnects.
+    * Readiness is a successful connect (opened, then immediately closed), NOT a substring in the `output` log. The previous log-grep approach — wait until
+    * `output` contains "listening" — bricked healthy daemons: [[startServer]] rotates `output` to `output.prev` on every start attempt, so when a second
+    * client's daemon-start attempt loses the lock race and exits, it has already moved the live daemon's "listening" line out of `output`. From then on the
+    * grep never matched and every client timed out with "failed to start" against a daemon that was in fact accepting connections. A connect probe reflects
+    * what the client actually needs — can I reach the server — and cannot be fooled by log rotation.
+    *
+    * The old comment warned that connecting "causes the server to wait for JSON-RPC messages". It does not: the daemon handles a connect-then-close as an
+    * immediate EOF on a short-lived per-connection thread (bounded further by its read timeout). Polling stops on the first success, so this is at most a
+    * couple of throwaway connects during startup.
     */
   def waitForServer(config: BspRifleConfig): IO[Unit] = {
     val socketFile = config.address match {
@@ -238,14 +245,11 @@ object BspServerOperations {
     }
     val outputFile = config.address.socketDir.resolve("output")
 
-    def isReady: IO[Boolean] = IO.blocking {
-      // Check both socket file exists AND server has logged "listening"
-      Files.exists(socketFile) && {
-        if (Files.exists(outputFile)) {
-          Files.readString(outputFile).contains("listening")
-        } else false
+    def isReady: IO[Boolean] =
+      openConnection(config.address).attempt.flatMap {
+        case Right(conn) => IO.blocking(conn.close()).attempt.as(true)
+        case Left(_)     => IO.pure(false)
       }
-    }
 
     def poll(deadline: Long): IO[Unit] =
       isReady.flatMap {


### PR DESCRIPTION
## The incident

Three agent sessions across different worktrees were all blocked, each `bleep` command failing with:

```
📗 BSP server already running (pid=76399), reusing
📕 Build failed: BSP server failed to start within 1 minute
```

The daemon was **not** wedged. I connected to its socket directly and it answered `build/initialize` in ~50ms, reporting itself fully capable. Thread dump confirmed it: `main` sitting in `accept()`, every cats-effect worker parked idle, no deadlock, no stuck operation, no OOM.

## Root cause

`waitForServer` (the client's readiness check) decided the server was ready by reading the shared `output` log and checking for the substring `"listening"` — it deliberately avoided connecting. But `startServer` rotates `output` → `output.prev` on **every** start attempt. So the sequence that bricks a socket is:

1. Client A starts daemon D1; D1 binds the socket and logs `"BSP server listening on …"`. A connects fine.
2. Client B (another worktree, same bleep-version+JVM → same socket dir) races to start a daemon. `startServer` first rotates D1's `output` (with its `listening` line) into `output.prev`, then launches D2.
3. D2 loses the lock to D1, logs `"BSP server already running"`, exits.
4. Now `output` contains only D2's exit log — no `"listening"`. D1 is healthy and accepting, but every client's grep of `output` fails and times out after a minute. **Bricked until D1 is killed** — and a restart can re-trigger the same race.

Under multi-agent load these start races are common, which is why three sessions bricked at once: they shared one socket dir (`99ade…`), and its `listening` marker had been rotated into `output.prev`.

## Fix

Readiness is now a successful **connect** to the socket (opened, immediately closed) rather than a substring in a log file. This is exactly what the client ultimately needs — can I reach the server — and it cannot be fooled by log rotation.

The old code's stated reason for not connecting ("causes the server to wait for JSON-RPC messages, which blocks if the checking client just connects and disconnects") does not hold: the daemon handles a connect-then-close as an immediate EOF on a short-lived per-connection thread, bounded further by its read timeout. Polling stops on the first success, so it's at most a couple of throwaway connects during startup.

## Verification

- The new `isReady` is precisely the probe I used to disprove the "wedged daemon" theory during diagnosis — it got a clean `build/initialize` response from the daemon the old check had declared dead.
- `bleep-tests` 265/265 (no regression). The forked-daemon lifecycle has no automated coverage (ITs use in-process BSP — noted in CLAUDE.md), so this is validated against the live daemon rather than a new test.

## Follow-up (not in this PR)

`startServer` should not rotate `output` on a start attempt that loses the lock race, so a losing starter stops destroying the winning daemon's diagnostic log. Not needed for correctness once readiness is connect-based — it only costs log history — and cleanly separable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)