### PR TITLE
cli: forward --flags to scripts (decline rejected them as unknown options)

### DIFF
--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -1129,6 +1129,32 @@ object Main {
         }
     }
 
+  /** Scripts receive their trailing arguments verbatim, including tokens that start with `--`.
+    *
+    * decline's `Opts.arguments` rejects anything that looks like an option (`--clients` becomes "Unexpected option: --clients"), so before parsing we insert
+    * decline's `--` end-of-options separator right after the script name. decline then treats every following token as a positional argument and hands the raw
+    * list to the script's `run(started, commands, args)`.
+    *
+    * Only applied when the invocation actually targets a script (`bleep <script> ...` or `bleep run <script> ...`), so every built-in subcommand keeps its
+    * normal flag parsing. A `--` the user typed themselves is left untouched (`PreBootstrapOpts` already forwards it), so there is never a double insertion.
+    * The script's own `--watch`/`-w` flag, when present, must come immediately after the script name; it is kept in front of the inserted separator so watch
+    * mode still works, while everything after it is forwarded to the script raw.
+    */
+  private[bleep] def insertScriptArgSeparator(restArgs: List[String], scriptNames: Set[String]): List[String] = {
+    def withSeparator(scriptName: String, rest: List[String]): List[String] = {
+      val (leadingWatchFlags, scriptArgs) = rest.span(arg => arg == "--watch" || arg == "-w")
+      (scriptName :: leadingWatchFlags) ::: ("--" :: scriptArgs)
+    }
+
+    if (restArgs.contains("--")) restArgs
+    else
+      restArgs match {
+        case scriptName :: rest if scriptNames.contains(scriptName)          => withSeparator(scriptName, rest)
+        case "run" :: scriptName :: rest if scriptNames.contains(scriptName) => "run" :: withSeparator(scriptName, rest)
+        case other                                                           => other
+      }
+  }
+
   /** Parse a build command with decline, create the real logger from LoggingOpts, replay stored bootstrap messages, then run. */
   private def runBuildCommand(
       opts: Opts[BleepBuildCommand],
@@ -1138,8 +1164,9 @@ object Main {
       config: model.BleepConfig,
       buildPaths: BuildPaths,
       started: Started
-  ): ExitCode =
-    Command("bleep", s"Bleeping fast build! (version ${model.BleepVersion.current.value})")(opts).parse(restArgs, sys.env) match {
+  ): ExitCode = {
+    val parseArgs = insertScriptArgSeparator(restArgs, started.build.scripts.keys.map(_.value).toSet)
+    Command("bleep", s"Bleeping fast build! (version ${model.BleepVersion.current.value})")(opts).parse(parseArgs, sys.env) match {
       case Left(help) =>
         help.errors match {
           case List() =>
@@ -1175,6 +1202,7 @@ object Main {
           }
         }
     }
+  }
 
   /** Check if restArgs request machine-readable output (json or raw), logs should go to stderr. */
   private def hasMachineOutput(restArgs: List[String]): Boolean =

--- a/bleep-tests/src/scala/bleep/CliInvocationTest.scala
+++ b/bleep-tests/src/scala/bleep/CliInvocationTest.scala
@@ -40,6 +40,34 @@ class CliInvocationTest extends AnyFunSuite {
     )
   }
 
+  private val scriptNames = Set("myscript", "native-image")
+
+  test("script invocation forwards plain trailing args unchanged") {
+    assert(Main.insertScriptArgSeparator(List("myscript", "foo", "bar"), scriptNames) == List("myscript", "--", "foo", "bar"))
+  }
+
+  test("script invocation forwards `--`-prefixed args verbatim") {
+    assert(Main.insertScriptArgSeparator(List("myscript", "--clients", "20"), scriptNames) == List("myscript", "--", "--clients", "20"))
+  }
+
+  test("a leading `--watch`/`-w` stays a bleep flag, the rest is forwarded raw") {
+    assert(Main.insertScriptArgSeparator(List("myscript", "--watch", "--clients", "20"), scriptNames) == List("myscript", "--watch", "--", "--clients", "20"))
+    assert(Main.insertScriptArgSeparator(List("myscript", "-w"), scriptNames) == List("myscript", "-w", "--"))
+  }
+
+  test("a user-supplied `--` separator is left untouched (no double insertion)") {
+    assert(Main.insertScriptArgSeparator(List("myscript", "--", "--watch"), scriptNames) == List("myscript", "--", "--watch"))
+  }
+
+  test("`run <script>` also forwards `--`-prefixed args verbatim") {
+    assert(Main.insertScriptArgSeparator(List("run", "myscript", "--clients", "20"), scriptNames) == List("run", "myscript", "--", "--clients", "20"))
+  }
+
+  test("built-in subcommands are not rewritten") {
+    assert(Main.insertScriptArgSeparator(List("compile", "--watch", "myproject"), scriptNames) == List("compile", "--watch", "myproject"))
+    assert(Main.insertScriptArgSeparator(List("run", "myproject", "--foo"), scriptNames) == List("run", "myproject", "--foo"))
+  }
+
   def callMainSlurpingStdIo(arguments: Array[String]): IoBuffer = {
     val systemOut = System.out
     val systemErr = System.err


### PR DESCRIPTION
`bleep <script> --foo bar` failed with "Unexpected option: --foo" because script trailing args are parsed by decline's `Opts.arguments[String]`, which treats any `--`-prefixed token as an unknown flag. Scripts had to work around it with env vars (native-image) or positional args (bsp-stress).

Fix: insert decline's `--` end-of-options separator right after the script name in `runBuildCommand`, the single point where every build-context invocation reaches `.parse`. `PreBootstrapOpts` already strips bleep's own global flags (`--dev`, `--no-color`, …) beforehand, so `restArgs.head` is reliably the subcommand name — a head-match against the known script names is safe, no reimplementation of decline's parsing. Everything after the script name (including `--flags`) is then captured verbatim into the `args` handed to `BleepScript.run`.

Guarded three ways: only fires when the target is actually a script (built-ins like `compile`/`test`/`run <project>` pass through unchanged); a user-typed `--` is left alone (no double insertion); a leading `--watch`/`-w` stays in front of the separator so script watch mode still works.

One behavior note: a non-leading `--watch` for a script (`bleep myscript foo --watch`) now forwards `--watch` to the script rather than enabling bleep watch mode — watch must come immediately after the script name. Any real flag-forwarding case is incompatible with interspersed watch anyway.

6 new unit tests in CliInvocationTest cover normal args, `--`-flags, watch preservation, explicit `--`, the `run` form, and built-in pass-through. CliInvocationTest 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)