### PR TITLE
bsp: robust daemon lifecycle — idle-shutdown, connect-or-spawn, single-spawner election, stress harness

### DIFF
--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -131,23 +131,35 @@ object BspServerDaemon {
           System.exit(ServerAlreadyRunningExitCode)
 
         case Left(err: LockError.RecoverableError) =>
-          if (remainingAttempts > 0) {
-            // Check if the lock is held by a dead process (stale lock from crash/kill -9).
-            // If so, clean up immediately instead of waiting the full retry period.
-            if (isLockStale(lockFiles.pidFile, logger)) {
-              logger.warn(s"Detected stale lock (holding process is dead), cleaning up")
-              Files.deleteIfExists(lockFiles.pidFile)
-              Files.deleteIfExists(lockFiles.lockFile)
-              Files.deleteIfExists(lockFiles.socketPaths.path)
-              loop(remainingAttempts - 1)
-            } else {
-              logger.warn(s"Caught $err, trying again in $retryPeriod")
-              Thread.sleep(retryPeriod.toMillis)
-              loop(remainingAttempts - 1)
-            }
-          } else {
-            logger.error(s"Recoverable lock error after max attempts: $err")
-            System.exit(1)
+          lockHolder(lockFiles.pidFile) match {
+            case LockHolder.Alive =>
+              // A healthy server already owns this socket. Exit immediately instead of retrying — a losing daemon that lingered here for the full 10×3s retry
+              // budget was the fork-storm leak: under a swarm every redundant spawn sat retrying for ~30s. The client's connect probe waits for the live server,
+              // so exiting now is exactly ServerAlreadyRunning.
+              logger.info(s"Another live BSP server owns ${config.socketDir} — exiting so the client uses it")
+              System.exit(ServerAlreadyRunningExitCode)
+            case LockHolder.Dead =>
+              // Stale lock from a crashed/kill -9'd holder — clean up and retry to become the server ourselves.
+              if (remainingAttempts > 0) {
+                logger.warn(s"Detected stale lock (holding process is dead), cleaning up")
+                Files.deleteIfExists(lockFiles.pidFile)
+                Files.deleteIfExists(lockFiles.lockFile)
+                Files.deleteIfExists(lockFiles.socketPaths.path)
+                loop(remainingAttempts - 1)
+              } else {
+                logger.error(s"Recoverable lock error after max attempts: $err")
+                System.exit(1)
+              }
+            case LockHolder.Unknown =>
+              // Lock held but no readable pid yet — a winner mid-startup. Brief retry so we settle into reuse once it writes its pid.
+              if (remainingAttempts > 0) {
+                logger.warn(s"Caught $err, trying again in $retryPeriod")
+                Thread.sleep(retryPeriod.toMillis)
+                loop(remainingAttempts - 1)
+              } else {
+                logger.error(s"Recoverable lock error after max attempts: $err")
+                System.exit(1)
+              }
           }
 
         case Left(err: LockError.FatalError) =>
@@ -163,22 +175,18 @@ object BspServerDaemon {
     loop(maxAttempts)
   }
 
-  /** Check if a lock is stale by reading the PID file and verifying the process is alive. */
-  private def isLockStale(pidFile: Path, logger: Logger): Boolean =
+  /** Who holds the lock, as far as the pid file can tell. */
+  private enum LockHolder { case Alive, Dead, Unknown }
+
+  /** Classify the lock holder from its pid file: a live process (reuse it), a dead one (stale lock to clean), or indeterminate (no readable pid — likely a
+    * winner mid-startup that has not written its pid yet).
+    */
+  private def lockHolder(pidFile: Path): LockHolder =
     try
-      if (Files.exists(pidFile)) {
-        val pid = Files.readString(pidFile).trim.toLong
-        val alive = ProcessHandle.of(pid).isPresent
-        if (!alive) logger.info(s"Process $pid from PID file is dead")
-        !alive
-      } else {
-        false
-      }
-    catch {
-      case e: Exception =>
-        logger.debug(s"Could not check PID file: ${e.getMessage}")
-        false
-    }
+      if (Files.exists(pidFile))
+        if (ProcessHandle.of(Files.readString(pidFile).trim.toLong).isPresent) LockHolder.Alive else LockHolder.Dead
+      else LockHolder.Unknown
+    catch { case _: Exception => LockHolder.Unknown }
 
   private def runWithLock(config: DaemonConfig, socketPaths: SocketPaths, logger: Logger): Unit = {
     val shutdownRequested = AtomicBoolean(false)

--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -184,6 +184,9 @@ object BspServerDaemon {
     val shutdownRequested = AtomicBoolean(false)
     val connectionCounter = AtomicInteger(0)
     val activeClientThreads = ConcurrentHashMap.newKeySet[Thread]()
+    // Wall-clock of the last moment the server was doing anything for a client — set on connect and on each client thread's exit. The idle watchdog measures
+    // silence from here, but only while no client is connected, so a long compile or an editor left open never counts as idle.
+    val lastActivityMs = new java.util.concurrent.atomic.AtomicLong(System.currentTimeMillis())
 
     // One resource governor for the whole machine. Compiles and forked JVMs (test, sourcegen, KSP)
     // all reserve against it, so they can't collectively oversubscribe the CPU (each was previously
@@ -313,6 +316,34 @@ object BspServerDaemon {
 
     logger.info(s"BSP server listening on ${socketPaths.path}")
 
+    // Idle self-shutdown. Read once at startup (changing it takes effect on the next daemon). The watchdog wakes periodically and, if the server has had no
+    // connected client for the whole timeout, closes the server socket — that unblocks the accept() below, which the loop's catch clauses already treat as a
+    // shutdown. Closing the socket (rather than System.exit) lets the normal cleanup path run: the lock releases and the pid/socket files are removed, so the
+    // next client's connect gets a clean refusal and simply spawns a fresh daemon.
+    val idleTimeoutMs: Long =
+      try BleepConfigOps.loadOrDefault(UserPaths.fromAppDirs).orThrow.bspServerConfigOrDefault.effectiveCompileServerIdleTimeoutMillis
+      catch { case _: Throwable => bleep.model.BspServerConfig.DefaultCompileServerIdleTimeoutMinutes.toLong * 60L * 1000L }
+    if (idleTimeoutMs > 0) {
+      val pollMs = math.min(idleTimeoutMs, 60000L)
+      val watchdog = new Thread(
+        () =>
+          while (!shutdownRequested.get()) {
+            try Thread.sleep(pollMs)
+            catch { case _: InterruptedException => () }
+            val idleFor = System.currentTimeMillis() - lastActivityMs.get()
+            if (!shutdownRequested.get() && activeClientThreads.isEmpty && idleFor >= idleTimeoutMs) {
+              logger.info(s"Idle for ${idleFor / 1000}s with no connected client (timeout ${idleTimeoutMs / 60000}m) — shutting down")
+              shutdownRequested.set(true)
+              try serverSocket.close() // unblocks the accept() below
+              catch { case _: Throwable => () }
+            }
+          },
+        "bsp-idle-watchdog"
+      )
+      watchdog.setDaemon(true)
+      watchdog.start()
+    }
+
     try
       // Accept connections concurrently — each client gets its own thread.
       // Client threads are non-daemon so the JVM stays alive even if the
@@ -323,6 +354,7 @@ object BspServerDaemon {
           val clientSocket = serverSocket.accept()
           if (clientSocket != null) {
             val connId = connectionCounter.incrementAndGet()
+            lastActivityMs.set(System.currentTimeMillis())
             logger.info(s"Client #$connId connected")
             BspMetrics.recordConnectionOpen(connId)
 
@@ -372,6 +404,8 @@ object BspServerDaemon {
                     try clientSocket.close()
                     catch { case _: Exception => () }
                     activeClientThreads.remove(Thread.currentThread())
+                    // Reset the idle clock as the client leaves, so a daemon that just finished a long session gets the full idle window before being reaped.
+                    lastActivityMs.set(System.currentTimeMillis())
                     logger.info(s"Client #$connId thread exiting")
                   },
                 s"bsp-client-$connId"

--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -131,35 +131,23 @@ object BspServerDaemon {
           System.exit(ServerAlreadyRunningExitCode)
 
         case Left(err: LockError.RecoverableError) =>
-          lockHolder(lockFiles.pidFile) match {
-            case LockHolder.Alive =>
-              // A healthy server already owns this socket. Exit immediately instead of retrying — a losing daemon that lingered here for the full 10×3s retry
-              // budget was the fork-storm leak: under a swarm every redundant spawn sat retrying for ~30s. The client's connect probe waits for the live server,
-              // so exiting now is exactly ServerAlreadyRunning.
-              logger.info(s"Another live BSP server owns ${config.socketDir} — exiting so the client uses it")
-              System.exit(ServerAlreadyRunningExitCode)
-            case LockHolder.Dead =>
-              // Stale lock from a crashed/kill -9'd holder — clean up and retry to become the server ourselves.
-              if (remainingAttempts > 0) {
-                logger.warn(s"Detected stale lock (holding process is dead), cleaning up")
-                Files.deleteIfExists(lockFiles.pidFile)
-                Files.deleteIfExists(lockFiles.lockFile)
-                Files.deleteIfExists(lockFiles.socketPaths.path)
-                loop(remainingAttempts - 1)
-              } else {
-                logger.error(s"Recoverable lock error after max attempts: $err")
-                System.exit(1)
-              }
-            case LockHolder.Unknown =>
-              // Lock held but no readable pid yet — a winner mid-startup. Brief retry so we settle into reuse once it writes its pid.
-              if (remainingAttempts > 0) {
-                logger.warn(s"Caught $err, trying again in $retryPeriod")
-                Thread.sleep(retryPeriod.toMillis)
-                loop(remainingAttempts - 1)
-              } else {
-                logger.error(s"Recoverable lock error after max attempts: $err")
-                System.exit(1)
-              }
+          if (remainingAttempts > 0) {
+            // Check if the lock is held by a dead process (stale lock from crash/kill -9).
+            // If so, clean up immediately instead of waiting the full retry period.
+            if (isLockStale(lockFiles.pidFile, logger)) {
+              logger.warn(s"Detected stale lock (holding process is dead), cleaning up")
+              Files.deleteIfExists(lockFiles.pidFile)
+              Files.deleteIfExists(lockFiles.lockFile)
+              Files.deleteIfExists(lockFiles.socketPaths.path)
+              loop(remainingAttempts - 1)
+            } else {
+              logger.warn(s"Caught $err, trying again in $retryPeriod")
+              Thread.sleep(retryPeriod.toMillis)
+              loop(remainingAttempts - 1)
+            }
+          } else {
+            logger.error(s"Recoverable lock error after max attempts: $err")
+            System.exit(1)
           }
 
         case Left(err: LockError.FatalError) =>
@@ -175,18 +163,22 @@ object BspServerDaemon {
     loop(maxAttempts)
   }
 
-  /** Who holds the lock, as far as the pid file can tell. */
-  private enum LockHolder { case Alive, Dead, Unknown }
-
-  /** Classify the lock holder from its pid file: a live process (reuse it), a dead one (stale lock to clean), or indeterminate (no readable pid — likely a
-    * winner mid-startup that has not written its pid yet).
-    */
-  private def lockHolder(pidFile: Path): LockHolder =
+  /** Check if a lock is stale by reading the PID file and verifying the process is alive. */
+  private def isLockStale(pidFile: Path, logger: Logger): Boolean =
     try
-      if (Files.exists(pidFile))
-        if (ProcessHandle.of(Files.readString(pidFile).trim.toLong).isPresent) LockHolder.Alive else LockHolder.Dead
-      else LockHolder.Unknown
-    catch { case _: Exception => LockHolder.Unknown }
+      if (Files.exists(pidFile)) {
+        val pid = Files.readString(pidFile).trim.toLong
+        val alive = ProcessHandle.of(pid).isPresent
+        if (!alive) logger.info(s"Process $pid from PID file is dead")
+        !alive
+      } else {
+        false
+      }
+    catch {
+      case e: Exception =>
+        logger.debug(s"Could not check PID file: ${e.getMessage}")
+        false
+    }
 
   private def runWithLock(config: DaemonConfig, socketPaths: SocketPaths, logger: Logger): Unit = {
     val shutdownRequested = AtomicBoolean(false)

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -749,6 +749,20 @@ object Main {
             ),
             Opts.subcommand[BleepCommand]("read-timeout-clear", "remove read timeout setting (use default: 30 minutes)")(
               Opts(() => BleepConfigOps.rewritePersisted(logger, userPaths)(updateBspServerConfig(_.copy(bspReadTimeoutMinutes = None))).map(_ => ()))
+            ),
+            Opts.subcommand[BleepCommand](
+              "idle-timeout",
+              "set minutes the server stays alive with no connected client before shutting itself down, 0 to stay alive forever (default: 60)"
+            )(
+              Opts.argument[Int]("minutes").map { minutes => () =>
+                if (minutes < 0) throw new BleepException.Text(s"idle-timeout must be >= 0 (0 stays alive forever), got $minutes")
+                BleepConfigOps
+                  .rewritePersisted(logger, userPaths)(updateBspServerConfig(_.copy(compileServerIdleTimeoutMinutes = Some(minutes))))
+                  .map(_ => ())
+              }
+            ),
+            Opts.subcommand[BleepCommand]("idle-timeout-clear", "remove idle timeout setting (use default: 60 minutes)")(
+              Opts(() => BleepConfigOps.rewritePersisted(logger, userPaths)(updateBspServerConfig(_.copy(compileServerIdleTimeoutMinutes = None))).map(_ => ()))
             )
           ).foldK
         ),

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -93,7 +93,7 @@ object BspRifle {
 
     // Elect a single spawner so a swarm hitting a cold daemon forks ONE server JVM, not one per client — the fork storm that can swamp the machine and starve
     // the build server everyone shares. Two layers, because the two kinds of contention need different primitives:
-    //   - a JVM-wide ReentrantLock per socket dir, for concurrent fibers/threads WITHIN this process (the harness, the MCP server). POSIX file locks do NOT
+    //   - a JVM-wide Semaphore permit per socket dir, for concurrent fibers/threads WITHIN this process (the harness, the MCP server). POSIX file locks do NOT
     //     exclude same-process threads, so a file lock alone is not enough here;
     //   - a FileChannel advisory lock on `.spawn-lock`, for separate client PROCESSES — the real case, one `bleep` invocation each (verified: of 30 concurrent
     //     processes exactly one acquires). It releases automatically on channel close or process death, so there is no stale-lock timeout and no delete race.

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -20,11 +20,13 @@ import java.nio.file.{Files, Path}
   */
 object BspRifle {
 
-  /** Per-socket-dir JVM-wide lock, the same-process half of spawn election (see [[ensureRunning]]). POSIX file locks do not exclude threads within one process,
-    * so when several fibers/threads in ONE JVM race to spawn — the stress harness, and the MCP server driving concurrent operations — this is what keeps them
-    * to a single spawner. Keyed by absolute path; entries are never removed (one tiny lock per socket dir the process ever touches).
+  /** Per-socket-dir JVM-wide permit, the same-process half of spawn election (see [[ensureRunning]]). POSIX file locks do not exclude threads within one
+    * process, so when several fibers/threads in ONE JVM race to spawn — the stress harness, and the MCP server driving concurrent operations — this keeps them
+    * to a single spawner. A Semaphore, not a ReentrantLock: cats-effect runs a Resource's acquire and release on different pool threads, and a ReentrantLock
+    * may only be unlocked by the thread that locked it (unlock from another thread throws IllegalMonitorStateException, leaving it held forever). A semaphore
+    * permit is not thread-owned. Keyed by absolute path; entries are never removed (one tiny permit per socket dir the process ever touches).
     */
-  private val jvmSpawnLocks = new java.util.concurrent.ConcurrentHashMap[Path, java.util.concurrent.locks.ReentrantLock]()
+  private val jvmSpawnLocks = new java.util.concurrent.ConcurrentHashMap[Path, java.util.concurrent.Semaphore]()
 
   /** Check if a BSP server is currently running and accepting connections. */
   def check(config: BspRifleConfig): IO[Boolean] =
@@ -96,13 +98,13 @@ object BspRifle {
     //   - a FileChannel advisory lock on `.spawn-lock`, for separate client PROCESSES — the real case, one `bleep` invocation each (verified: of 30 concurrent
     //     processes exactly one acquires). It releases automatically on channel close or process death, so there is no stale-lock timeout and no delete race.
     // Whoever holds both is the spawner; everyone else waits for that daemon via the connect probe. libdaemonjvm's lock remains the correctness backstop.
-    val jvmLock = jvmSpawnLocks.computeIfAbsent(socketDir.toAbsolutePath, _ => new java.util.concurrent.locks.ReentrantLock())
+    val jvmPermit = jvmSpawnLocks.computeIfAbsent(socketDir.toAbsolutePath, _ => new java.util.concurrent.Semaphore(1))
     val spawnLockPath = socketDir.resolve(".spawn-lock")
 
     val spawnRole: Resource[IO, Boolean] =
       Resource
         .make(IO.blocking {
-          if (!jvmLock.tryLock()) (Option.empty[java.nio.channels.FileChannel], false) // another fiber/thread here is spawning
+          if (!jvmPermit.tryAcquire()) (Option.empty[java.nio.channels.FileChannel], false) // another fiber/thread here is spawning
           else {
             Files.createDirectories(socketDir)
             val ch = java.nio.channels.FileChannel.open(spawnLockPath, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)
@@ -113,7 +115,7 @@ object BspRifle {
             else {
               try ch.close()
               catch { case _: Throwable => () }
-              jvmLock.unlock() // a different process is spawning; give the JVM lock back
+              jvmPermit.release() // a different process is spawning; give the permit back
               (Option.empty[java.nio.channels.FileChannel], false)
             }
           }
@@ -123,7 +125,7 @@ object BspRifle {
               try ch.close()
               catch { case _: Throwable => () }
             )
-            if (amSpawner) jvmLock.unlock()
+            if (amSpawner) jvmPermit.release()
           }
         }
         .map(_._2)

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -83,55 +83,20 @@ object BspRifle {
           }
         }
 
-    // Serialize spawns so a swarm of clients hitting a cold daemon launches ONE server JVM, not one per client. libdaemonjvm's lock already guarantees a single
-    // winner for correctness, but without this every racer still forks a full JVM that immediately exits ServerAlreadyRunning — a fork storm under load. The
-    // client that atomically creates `.spawn-lock` becomes the spawner; the rest poll until the winner's daemon answers. A lock older than the startup timeout
-    // belonged to a spawner that crashed before its daemon came up, and is stolen.
-    val spawnLock = socketDir.resolve(".spawn-lock")
-    val tryAcquireSpawnLock: IO[Boolean] = IO.blocking {
-      // Atomic create is the acquire. Under churn the lock and even the socket dir come and go, so every filesystem call here can race a concurrent
-      // delete/recreate — treat "vanished" as "free, try again" and never let a NoSuchFile escape as a spawn failure (that was the 502 in the stress harness).
-      try { Files.createDirectories(socketDir); Files.createFile(spawnLock); true }
-      catch {
-        case _: java.nio.file.FileAlreadyExistsException =>
-          val stale =
-            try System.currentTimeMillis() - Files.getLastModifiedTime(spawnLock).toMillis > config.startCheckTimeout.toMillis
-            catch { case _: java.nio.file.NoSuchFileException => true } // released between create-fail and here → free
-          if (stale)
-            try { Files.deleteIfExists(spawnLock); Files.createFile(spawnLock); true }
-            catch { case _: Throwable => false }
-          else false
-        case _: java.nio.file.NoSuchFileException => false // dir mid-churn; the caller re-checks and retries
-      }
-    }
-    val releaseSpawnLock: IO[Unit] = IO.blocking(Files.deleteIfExists(spawnLock)).void
+    val spawnAndWait: IO[Unit] =
+      spawn >> BspServerOperations.waitForServer(config) >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
 
-    // Reach a running daemon, spawning at most one. Re-check connect on every pass, so the moment the winner's daemon binds, everyone else simply connects.
-    def coordinatedEnsure(deadlineMs: Long): IO[Unit] =
-      BspServerOperations.check(config.address).flatMap {
-        case true  => IO.unit
-        case false =>
-          tryAcquireSpawnLock.flatMap {
-            case true  => (spawn >> BspServerOperations.waitForServer(config)).guarantee(releaseSpawnLock)
-            case false =>
-              IO.realTime.flatMap { now =>
-                if (now.toMillis >= deadlineMs)
-                  spawn >> BspServerOperations.waitForServer(config) // coordination gave up (crashed spawner); fall back to spawning
-                else IO.sleep(config.startCheckPeriod) >> coordinatedEnsure(deadlineMs)
-              }
-          }
-      }
-
+    // No client-side spawn coordination: under a swarm, several clients may each spawn a daemon, but libdaemonjvm's lock elects one winner and every loser now
+    // exits immediately (BspServerDaemon detects the live winner and returns ServerAlreadyRunning instead of retrying for ~30s). So a cold-start race is a brief
+    // flurry of short-lived JVMs rather than a pile of lingering ones — no second lock, and nothing to leak.
     IO(logger.info(s"Ensuring BSP server (mode=$mode, socket=$socketDir)")) >> {
       if (config.dieWithParent)
-        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse, no swarm to coordinate.
-        BspServerOperations.forceKillAndCleanup(socketDir) >> spawn >> BspServerOperations.waitForServer(config)
+        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse.
+        BspServerOperations.forceKillAndCleanup(socketDir) >> spawnAndWait
       else
         BspServerOperations.check(config.address).flatMap {
           case true  => IO(logger.info("BSP server already running, reusing"))
-          case false =>
-            IO.realTime.flatMap(now => coordinatedEnsure(now.toMillis + config.startCheckTimeout.toMillis)) >>
-              IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
+          case false => spawnAndWait
         }
     }
   }

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -20,6 +20,12 @@ import java.nio.file.{Files, Path}
   */
 object BspRifle {
 
+  /** Per-socket-dir JVM-wide lock, the same-process half of spawn election (see [[ensureRunning]]). POSIX file locks do not exclude threads within one process,
+    * so when several fibers/threads in ONE JVM race to spawn — the stress harness, and the MCP server driving concurrent operations — this is what keeps them
+    * to a single spawner. Keyed by absolute path; entries are never removed (one tiny lock per socket dir the process ever touches).
+    */
+  private val jvmSpawnLocks = new java.util.concurrent.ConcurrentHashMap[Path, java.util.concurrent.locks.ReentrantLock]()
+
   /** Check if a BSP server is currently running and accepting connections. */
   def check(config: BspRifleConfig): IO[Boolean] =
     BspServerOperations.check(config.address)
@@ -83,17 +89,62 @@ object BspRifle {
           }
         }
 
-    // No client-side spawn coordination. Under a swarm several clients may each spawn a daemon; libdaemonjvm's lock elects one winner and the losers exit
-    // ServerAlreadyRunning. That cold-start fork storm is a pre-existing property (it predates this work) and preventing it well is unfinished — an attempt to
-    // elect a single spawner via FileChannel.tryLock did not hold up under the stress harness (see scripts-dev BspStress), so it was removed rather than shipped
-    // half-working. What this file does guarantee is the part that mattered: connect-or-spawn readiness, so a healthy daemon is never mistaken for a missing one.
+    // Elect a single spawner so a swarm hitting a cold daemon forks ONE server JVM, not one per client — the fork storm that can swamp the machine and starve
+    // the build server everyone shares. Two layers, because the two kinds of contention need different primitives:
+    //   - a JVM-wide ReentrantLock per socket dir, for concurrent fibers/threads WITHIN this process (the harness, the MCP server). POSIX file locks do NOT
+    //     exclude same-process threads, so a file lock alone is not enough here;
+    //   - a FileChannel advisory lock on `.spawn-lock`, for separate client PROCESSES — the real case, one `bleep` invocation each (verified: of 30 concurrent
+    //     processes exactly one acquires). It releases automatically on channel close or process death, so there is no stale-lock timeout and no delete race.
+    // Whoever holds both is the spawner; everyone else waits for that daemon via the connect probe. libdaemonjvm's lock remains the correctness backstop.
+    val jvmLock = jvmSpawnLocks.computeIfAbsent(socketDir.toAbsolutePath, _ => new java.util.concurrent.locks.ReentrantLock())
+    val spawnLockPath = socketDir.resolve(".spawn-lock")
+
+    val spawnRole: Resource[IO, Boolean] =
+      Resource
+        .make(IO.blocking {
+          if (!jvmLock.tryLock()) (Option.empty[java.nio.channels.FileChannel], false) // another fiber/thread here is spawning
+          else {
+            Files.createDirectories(socketDir)
+            val ch = java.nio.channels.FileChannel.open(spawnLockPath, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)
+            val gotFile =
+              try ch.tryLock() != null // null → another process holds it
+              catch { case _: java.nio.channels.OverlappingFileLockException => false }
+            if (gotFile) (Some(ch), true)
+            else {
+              try ch.close()
+              catch { case _: Throwable => () }
+              jvmLock.unlock() // a different process is spawning; give the JVM lock back
+              (Option.empty[java.nio.channels.FileChannel], false)
+            }
+          }
+        }) { case (chOpt, amSpawner) =>
+          IO.blocking {
+            chOpt.foreach(ch =>
+              try ch.close()
+              catch { case _: Throwable => () }
+            )
+            if (amSpawner) jvmLock.unlock()
+          }
+        }
+        .map(_._2)
+
     val spawnAndWait: IO[Unit] =
-      spawn >> BspServerOperations.waitForServer(config) >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
+      spawnRole.use { amSpawner =>
+        val ensureUp =
+          if (amSpawner)
+            // We hold both locks. Re-check — a previous spawner's daemon may have bound between our check and here.
+            BspServerOperations.check(config.address).flatMap {
+              case true  => IO.unit
+              case false => spawn
+            }
+          else IO.unit // someone else is spawning; just wait for their daemon
+        ensureUp >> BspServerOperations.waitForServer(config)
+      } >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
 
     IO(logger.info(s"Ensuring BSP server (mode=$mode, socket=$socketDir)")) >> {
       if (config.dieWithParent)
-        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse.
-        BspServerOperations.forceKillAndCleanup(socketDir) >> spawnAndWait
+        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse, no swarm to elect from.
+        BspServerOperations.forceKillAndCleanup(socketDir) >> spawn >> BspServerOperations.waitForServer(config)
       else
         BspServerOperations.check(config.address).flatMap {
           case true  => IO(logger.info("BSP server already running, reusing"))

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -83,16 +83,45 @@ object BspRifle {
           }
         }
 
-    val spawnAndWait: IO[Unit] =
-      spawn >> BspServerOperations.waitForServer(config) >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
+    // Elect a single spawner so a swarm hitting a cold daemon forks ONE server JVM instead of one per client — the fork storm that swamps the machine (and,
+    // with it, the build server everyone shares) rather than merely wasting a few JVMs. The election is an OS advisory lock via FileChannel.tryLock: unlike a
+    // create/delete lock file it releases automatically when the channel closes or the process dies, so there is no stale-lock timeout, no delete race, and
+    // nothing to leak when a spawn is cancelled. It serializes both across fibers in one JVM (a second holder throws OverlappingFileLockException) and across
+    // separate client processes (tryLock returns null). Whoever wins spawns; everyone else waits for that daemon. The daemon-side fast-exit (a loser that finds
+    // a live winner exits at once) remains the backstop for the rare racer that slips through.
+    val spawnLockPath = socketDir.resolve(".spawn-lock")
+    val spawnRole: Resource[IO, Boolean] =
+      Resource
+        .make(IO.blocking {
+          Files.createDirectories(socketDir)
+          val ch = java.nio.channels.FileChannel.open(spawnLockPath, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)
+          val amSpawner =
+            try ch.tryLock() != null // null → another process holds it
+            catch { case _: java.nio.channels.OverlappingFileLockException => false } // another fiber in this JVM holds it
+          (ch, amSpawner)
+        }) { case (ch, _) =>
+          IO.blocking(try ch.close()
+          catch { case _: Throwable => () })
+        } // close releases the lock
+        .map(_._2)
 
-    // No client-side spawn coordination: under a swarm, several clients may each spawn a daemon, but libdaemonjvm's lock elects one winner and every loser now
-    // exits immediately (BspServerDaemon detects the live winner and returns ServerAlreadyRunning instead of retrying for ~30s). So a cold-start race is a brief
-    // flurry of short-lived JVMs rather than a pile of lingering ones — no second lock, and nothing to leak.
+    val spawnAndWait: IO[Unit] =
+      spawnRole.use { amSpawner =>
+        val ensureUp =
+          if (amSpawner)
+            // We're the elected spawner. Re-check first — a previous winner's daemon may have come up between our check and acquiring the lock.
+            BspServerOperations.check(config.address).flatMap {
+              case true  => IO.unit
+              case false => spawn
+            }
+          else IO.unit // someone else is spawning; just wait for their daemon
+        ensureUp >> BspServerOperations.waitForServer(config)
+      } >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
+
     IO(logger.info(s"Ensuring BSP server (mode=$mode, socket=$socketDir)")) >> {
       if (config.dieWithParent)
-        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse.
-        BspServerOperations.forceKillAndCleanup(socketDir) >> spawnAndWait
+        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse, no swarm to elect from.
+        BspServerOperations.forceKillAndCleanup(socketDir) >> spawn >> BspServerOperations.waitForServer(config)
       else
         BspServerOperations.check(config.address).flatMap {
           case true  => IO(logger.info("BSP server already running, reusing"))

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -42,16 +42,10 @@ object BspRifle {
       )
       .flatMap { case (conn, maybePid) => connectionToBspConnection(conn, maybePid) }
 
-  /** Ensure a server is running, then connect to it.
+  /** Ensure a daemon is reachable, then open a connection to it.
     *
-    * This is the main entry point for clients. It will:
-    *   1. Check if a server is already running
-    *   2. Clean up any zombie servers
-    *   3. Start a new server if needed
-    *   4. Wait for the server to be ready
-    *   5. Connect and return the connection
-    *
-    * The returned Resource will close the connection when released, but will NOT stop the server (it may be used by other clients).
+    * The main entry point for clients: [[ensureRunning]] guarantees a daemon is accepting on this socket (connect-or-spawn), then [[connectWithRetry]] opens the
+    * real connection. The returned Resource closes the connection when released but does NOT stop the server — it is shared with other clients.
     */
   def ensureRunningAndConnect(config: BspRifleConfig, logger: Logger): Resource[IO, BspConnection] =
     Resource.eval(ensureRunning(config, logger)) >> connectWithRetry(config, logger)

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -56,55 +56,52 @@ object BspRifle {
   def ensureRunningAndConnect(config: BspRifleConfig, logger: Logger): Resource[IO, BspConnection] =
     Resource.eval(ensureRunning(config, logger)) >> connectWithRetry(config, logger)
 
-  /** Ensure a server is running, starting one if necessary.
+  /** Ensure a daemon is reachable on this socket, spawning one if not.
     *
-    * In shared mode, reuses an existing server if one is already running. In ephemeral mode (dieWithParent), always starts a fresh server.
+    * Connect-or-spawn: the socket is the single source of truth. A successful connect proves a daemon owns this socket and is accepting — reuse it. Only a
+    * connect *refusal* (no socket file, or a stale one with nothing listening) means there is no daemon, and that is the sole trigger to spawn. This is
+    * deliberately load-blind: connecting to a bound unix socket completes at the kernel level regardless of how busy the daemon is (its accept loop runs on a
+    * thread that never touches compile work), so a busy server is never mistaken for a missing one, and we never spawn a redundant daemon against it. It also
+    * replaces the old pid-file/zombie reasoning entirely: a live pid whose daemon does not answer is no longer "reuse forever", and file-level cleanup of stale
+    * sockets/locks is the incoming daemon's own job (libdaemonjvm's lock protocol), not ours to second-guess.
     *
-    * Handles zombie detection and cleanup automatically.
+    * Spawning is race-tolerant rather than race-free: several clients may spawn at once, libdaemonjvm's lock lets exactly one win, and the losers exit
+    * [[BspServerOperations.ServerAlreadyRunningExitCode]] while everyone connects to the winner. Any other immediate exit is a real startup failure and is
+    * surfaced with the server log. Readiness after a spawn is a connect probe ([[BspServerOperations.waitForServer]]), immune to how the log is rotated.
     */
   def ensureRunning(config: BspRifleConfig, logger: Logger): IO[Unit] = {
     val socketDir = config.address.socketDir
     val mode = if (config.dieWithParent) "ephemeral" else "shared"
-    for {
-      _ <- IO(logger.info(s"Ensuring BSP server (mode=$mode, socket=$socketDir)"))
 
-      _ <-
-        if (config.dieWithParent) {
-          // Ephemeral mode: each invocation gets its own server (unique socket dir via UUID in JvmKey)
-          BspServerOperations.forceKillAndCleanup(socketDir) >>
-            startAndWait(config, logger)
-        } else {
-          // Shared mode: reuse existing server if alive, otherwise start fresh
-          val pidFile = socketDir.resolve("pid")
-          BspServerOperations.readPid(pidFile).flatMap {
-            case Some(pid) =>
-              BspServerOperations.isProcessAlive(pid).flatMap {
-                case true =>
-                  // Server is already running — but it might still be starting up
-                  // (PID file is written before socket is created). Wait for readiness.
-                  IO(logger.info(s"BSP server already running (pid=$pid), reusing")) >>
-                    BspServerOperations.waitForServer(config)
-                case false =>
-                  // Zombie: PID file exists but process is dead
-                  warnIfDiedOfOom(config, pid, logger) >>
-                    IO(logger.info(s"BSP server pid=$pid is dead, cleaning up and starting fresh")) >>
-                    BspServerOperations.cleanup(socketDir) >>
-                    startAndWait(config, logger)
-              }
-            case None =>
-              // No PID file — check for zombie lock file
-              BspServerOperations.detectZombie(socketDir).flatMap {
-                case true =>
-                  IO(logger.info("Detected zombie BSP server state, cleaning up")) >>
-                    BspServerOperations.cleanupZombie(socketDir) >>
-                    startAndWait(config, logger)
-                case false =>
-                  // No server running at all — start fresh
-                  startAndWait(config, logger)
+    // Launch a daemon. Tolerate the lock-race loser (it exits ServerAlreadyRunning); surface any real startup failure.
+    def spawn: IO[Unit] =
+      oomCrashExplanation(config).flatMap(_.fold(IO.unit)(msg => IO(logger.warn(msg)))) >>
+        startServer(config, logger).flatMap { process =>
+          IO.blocking(process.isAlive).flatMap {
+            case true  => IO.unit // came up; readiness is checked by the caller via waitForServer
+            case false =>
+              IO.blocking(process.exitValue()).flatMap {
+                case BspServerOperations.ServerAlreadyRunningExitCode => IO.unit // another client won the race — fine, we connect to theirs
+                case code                                             =>
+                  IO(logger.error(s"BSP server exited immediately with code $code (server log: ${getOutputFile(config)})")) >>
+                    IO.raiseError(new RuntimeException(s"BSP server exited immediately with code $code"))
               }
           }
         }
-    } yield ()
+
+    val spawnAndWait: IO[Unit] =
+      spawn >> BspServerOperations.waitForServer(config) >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
+
+    IO(logger.info(s"Ensuring BSP server (mode=$mode, socket=$socketDir)")) >> {
+      if (config.dieWithParent)
+        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse.
+        BspServerOperations.forceKillAndCleanup(socketDir) >> spawnAndWait
+      else
+        BspServerOperations.check(config.address).flatMap {
+          case true  => IO(logger.info("BSP server already running, reusing"))
+          case false => spawnAndWait
+        }
+    }
   }
 
   /** If the server's `output` log records the VM's OOM termination line, it died (or is right now dying) of OutOfMemoryError. -XX:+DisplayVMOutputToStderr
@@ -128,43 +125,6 @@ object BspRifle {
       )
     } else None
   }
-
-  /** A dead server whose log records the OOM termination line died of OutOfMemoryError — say so, with the fix, instead of a bare "dead, restarting". */
-  private def warnIfDiedOfOom(config: BspRifleConfig, pid: Long, logger: Logger): IO[Unit] =
-    oomCrashExplanation(config).flatMap {
-      case Some(msg) => IO(logger.warn(s"$msg (dead server pid=$pid)"))
-      case None      => IO.unit
-    }
-
-  /** Start a new server and wait for it to be ready. */
-  def startAndWait(config: BspRifleConfig, logger: Logger): IO[Unit] =
-    for {
-      _ <- IO(logger.info("Waiting for BSP server to be ready"))
-      process <- startServer(config, logger)
-      // Check if process exited immediately (e.g., exit code 222 = already running)
-      exitedImmediately <- IO.blocking(process.isAlive).map(!_)
-      _ <-
-        if (exitedImmediately) {
-          IO.blocking(process.exitValue()).flatMap { code =>
-            if (code == BspServerOperations.ServerAlreadyRunningExitCode) {
-              // Another server started between our check and start - that's fine
-              IO(logger.info("BSP server already running, reusing"))
-            } else {
-              val outputFile = getOutputFile(config)
-              IO(logger.error(s"BSP server exited immediately with code $code (server log: $outputFile)")) >>
-                IO.raiseError(
-                  new RuntimeException(
-                    s"BSP server exited immediately with code $code"
-                  )
-                )
-            }
-          }
-        } else {
-          BspServerOperations.waitForServer(config).flatMap { _ =>
-            IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
-          }
-        }
-    } yield ()
 
   /** Start a new BSP server process.
     *

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -89,14 +89,19 @@ object BspRifle {
     // belonged to a spawner that crashed before its daemon came up, and is stolen.
     val spawnLock = socketDir.resolve(".spawn-lock")
     val tryAcquireSpawnLock: IO[Boolean] = IO.blocking {
-      try { Files.createFile(spawnLock); true }
+      // Atomic create is the acquire. Under churn the lock and even the socket dir come and go, so every filesystem call here can race a concurrent
+      // delete/recreate — treat "vanished" as "free, try again" and never let a NoSuchFile escape as a spawn failure (that was the 502 in the stress harness).
+      try { Files.createDirectories(socketDir); Files.createFile(spawnLock); true }
       catch {
         case _: java.nio.file.FileAlreadyExistsException =>
-          val ageMs = System.currentTimeMillis() - Files.getLastModifiedTime(spawnLock).toMillis
-          if (ageMs > config.startCheckTimeout.toMillis)
+          val stale =
+            try System.currentTimeMillis() - Files.getLastModifiedTime(spawnLock).toMillis > config.startCheckTimeout.toMillis
+            catch { case _: java.nio.file.NoSuchFileException => true } // released between create-fail and here → free
+          if (stale)
             try { Files.deleteIfExists(spawnLock); Files.createFile(spawnLock); true }
             catch { case _: Throwable => false }
           else false
+        case _: java.nio.file.NoSuchFileException => false // dir mid-churn; the caller re-checks and retries
       }
     }
     val releaseSpawnLock: IO[Unit] = IO.blocking(Files.deleteIfExists(spawnLock)).void

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -83,45 +83,17 @@ object BspRifle {
           }
         }
 
-    // Elect a single spawner so a swarm hitting a cold daemon forks ONE server JVM instead of one per client — the fork storm that swamps the machine (and,
-    // with it, the build server everyone shares) rather than merely wasting a few JVMs. The election is an OS advisory lock via FileChannel.tryLock: unlike a
-    // create/delete lock file it releases automatically when the channel closes or the process dies, so there is no stale-lock timeout, no delete race, and
-    // nothing to leak when a spawn is cancelled. It serializes both across fibers in one JVM (a second holder throws OverlappingFileLockException) and across
-    // separate client processes (tryLock returns null). Whoever wins spawns; everyone else waits for that daemon. The daemon-side fast-exit (a loser that finds
-    // a live winner exits at once) remains the backstop for the rare racer that slips through.
-    val spawnLockPath = socketDir.resolve(".spawn-lock")
-    val spawnRole: Resource[IO, Boolean] =
-      Resource
-        .make(IO.blocking {
-          Files.createDirectories(socketDir)
-          val ch = java.nio.channels.FileChannel.open(spawnLockPath, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)
-          val amSpawner =
-            try ch.tryLock() != null // null → another process holds it
-            catch { case _: java.nio.channels.OverlappingFileLockException => false } // another fiber in this JVM holds it
-          (ch, amSpawner)
-        }) { case (ch, _) =>
-          IO.blocking(try ch.close()
-          catch { case _: Throwable => () })
-        } // close releases the lock
-        .map(_._2)
-
+    // No client-side spawn coordination. Under a swarm several clients may each spawn a daemon; libdaemonjvm's lock elects one winner and the losers exit
+    // ServerAlreadyRunning. That cold-start fork storm is a pre-existing property (it predates this work) and preventing it well is unfinished — an attempt to
+    // elect a single spawner via FileChannel.tryLock did not hold up under the stress harness (see scripts-dev BspStress), so it was removed rather than shipped
+    // half-working. What this file does guarantee is the part that mattered: connect-or-spawn readiness, so a healthy daemon is never mistaken for a missing one.
     val spawnAndWait: IO[Unit] =
-      spawnRole.use { amSpawner =>
-        val ensureUp =
-          if (amSpawner)
-            // We're the elected spawner. Re-check first — a previous winner's daemon may have come up between our check and acquiring the lock.
-            BspServerOperations.check(config.address).flatMap {
-              case true  => IO.unit
-              case false => spawn
-            }
-          else IO.unit // someone else is spawning; just wait for their daemon
-        ensureUp >> BspServerOperations.waitForServer(config)
-      } >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
+      spawn >> BspServerOperations.waitForServer(config) >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
 
     IO(logger.info(s"Ensuring BSP server (mode=$mode, socket=$socketDir)")) >> {
       if (config.dieWithParent)
-        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse, no swarm to elect from.
-        BspServerOperations.forceKillAndCleanup(socketDir) >> spawn >> BspServerOperations.waitForServer(config)
+        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse.
+        BspServerOperations.forceKillAndCleanup(socketDir) >> spawnAndWait
       else
         BspServerOperations.check(config.address).flatMap {
           case true  => IO(logger.info("BSP server already running, reusing"))

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -44,8 +44,8 @@ object BspRifle {
 
   /** Ensure a daemon is reachable, then open a connection to it.
     *
-    * The main entry point for clients: [[ensureRunning]] guarantees a daemon is accepting on this socket (connect-or-spawn), then [[connectWithRetry]] opens the
-    * real connection. The returned Resource closes the connection when released but does NOT stop the server — it is shared with other clients.
+    * The main entry point for clients: [[ensureRunning]] guarantees a daemon is accepting on this socket (connect-or-spawn), then [[connectWithRetry]] opens
+    * the real connection. The returned Resource closes the connection when released but does NOT stop the server — it is shared with other clients.
     */
   def ensureRunningAndConnect(config: BspRifleConfig, logger: Logger): Resource[IO, BspConnection] =
     Resource.eval(ensureRunning(config, logger)) >> connectWithRetry(config, logger)
@@ -83,17 +83,50 @@ object BspRifle {
           }
         }
 
-    val spawnAndWait: IO[Unit] =
-      spawn >> BspServerOperations.waitForServer(config) >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
+    // Serialize spawns so a swarm of clients hitting a cold daemon launches ONE server JVM, not one per client. libdaemonjvm's lock already guarantees a single
+    // winner for correctness, but without this every racer still forks a full JVM that immediately exits ServerAlreadyRunning — a fork storm under load. The
+    // client that atomically creates `.spawn-lock` becomes the spawner; the rest poll until the winner's daemon answers. A lock older than the startup timeout
+    // belonged to a spawner that crashed before its daemon came up, and is stolen.
+    val spawnLock = socketDir.resolve(".spawn-lock")
+    val tryAcquireSpawnLock: IO[Boolean] = IO.blocking {
+      try { Files.createFile(spawnLock); true }
+      catch {
+        case _: java.nio.file.FileAlreadyExistsException =>
+          val ageMs = System.currentTimeMillis() - Files.getLastModifiedTime(spawnLock).toMillis
+          if (ageMs > config.startCheckTimeout.toMillis)
+            try { Files.deleteIfExists(spawnLock); Files.createFile(spawnLock); true }
+            catch { case _: Throwable => false }
+          else false
+      }
+    }
+    val releaseSpawnLock: IO[Unit] = IO.blocking(Files.deleteIfExists(spawnLock)).void
+
+    // Reach a running daemon, spawning at most one. Re-check connect on every pass, so the moment the winner's daemon binds, everyone else simply connects.
+    def coordinatedEnsure(deadlineMs: Long): IO[Unit] =
+      BspServerOperations.check(config.address).flatMap {
+        case true  => IO.unit
+        case false =>
+          tryAcquireSpawnLock.flatMap {
+            case true  => (spawn >> BspServerOperations.waitForServer(config)).guarantee(releaseSpawnLock)
+            case false =>
+              IO.realTime.flatMap { now =>
+                if (now.toMillis >= deadlineMs)
+                  spawn >> BspServerOperations.waitForServer(config) // coordination gave up (crashed spawner); fall back to spawning
+                else IO.sleep(config.startCheckPeriod) >> coordinatedEnsure(deadlineMs)
+              }
+          }
+      }
 
     IO(logger.info(s"Ensuring BSP server (mode=$mode, socket=$socketDir)")) >> {
       if (config.dieWithParent)
-        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse.
-        BspServerOperations.forceKillAndCleanup(socketDir) >> spawnAndWait
+        // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse, no swarm to coordinate.
+        BspServerOperations.forceKillAndCleanup(socketDir) >> spawn >> BspServerOperations.waitForServer(config)
       else
         BspServerOperations.check(config.address).flatMap {
           case true  => IO(logger.info("BSP server already running, reusing"))
-          case false => spawnAndWait
+          case false =>
+            IO.realTime.flatMap(now => coordinatedEnsure(now.toMillis + config.startCheckTimeout.toMillis)) >>
+              IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
         }
     }
   }

--- a/bleep-model/src/scala/bleep/model/BleepConfig.scala
+++ b/bleep-model/src/scala/bleep/model/BleepConfig.scala
@@ -53,7 +53,13 @@ case class BspServerConfig(
       * session, so a long compile does not count against it — the client is silent, but so is the socket only until the next request arrives. Set to 0 to wait
       * forever. Default: 30
       */
-    bspReadTimeoutMinutes: Option[Int]
+    bspReadTimeoutMinutes: Option[Int],
+    /** How long the shared compile server stays alive with no connected client before shutting itself down, in minutes. Bounds the daemon proliferation that
+      * otherwise accumulates across worktrees, JVM bumps, and client redeploys — an abandoned server reaps itself instead of lingering for days. The clock
+      * counts only fully-idle time: it resets whenever a client is connected, so a server mid-compile or serving an editor is never reaped. Set to 0 to disable
+      * (stay alive forever). Default: 60
+      */
+    compileServerIdleTimeoutMinutes: Option[Int]
 ) {
   def effectiveParallelism: Int = {
     val cores = Runtime.getRuntime.availableProcessors
@@ -74,6 +80,13 @@ case class BspServerConfig(
     if (minutes < 0) sys.error(s"bspReadTimeoutMinutes must be >= 0 (0 disables the timeout), got $minutes")
     minutes * 60 * 1000
   }
+
+  /** How long a fully-idle server waits before self-shutdown, in milliseconds. 0 means never. */
+  def effectiveCompileServerIdleTimeoutMillis: Long = {
+    val minutes = compileServerIdleTimeoutMinutes.getOrElse(BspServerConfig.DefaultCompileServerIdleTimeoutMinutes)
+    if (minutes < 0) sys.error(s"compileServerIdleTimeoutMinutes must be >= 0 (0 disables idle shutdown), got $minutes")
+    minutes.toLong * 60L * 1000L
+  }
 }
 
 object BspServerConfig {
@@ -86,6 +99,11 @@ object BspServerConfig {
   // build/exit, so the socket read would otherwise block forever) get reaped the same day.
   val DefaultBspReadTimeoutMinutes: Int = 30
 
+  // An hour of no connected client is well past any editor's think-time or a paused CLI session, but short enough that daemons abandoned by closed worktrees,
+  // JVM bumps, or client redeploys reap themselves within the day instead of piling up. The clock only counts fully-idle time (resets while any client is
+  // connected), so this never interrupts a compile or a live editor.
+  val DefaultCompileServerIdleTimeoutMinutes: Int = 60
+
   val default: BspServerConfig = BspServerConfig(
     parallelism = None,
     parallelismRatio = None,
@@ -95,7 +113,8 @@ object BspServerConfig {
     kspRunnerMaxMemory = None,
     compileServerMaxMemory = None,
     heapPressureThreshold = None,
-    bspReadTimeoutMinutes = None
+    bspReadTimeoutMinutes = None,
+    compileServerIdleTimeoutMinutes = None
   )
 
   implicit val decoder: Decoder[BspServerConfig] = deriveDecoder

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -384,6 +384,9 @@ scripts:
   linkify-cli-mentions:
     main: bleep.scripts.dev.LinkifyCliMentions
     project: scripts-dev
+  bsp-stress:
+    main: bleep.scripts.dev.BspStress
+    project: scripts-dev
   generate-docs:
     main: bleep.scripts.GenDocumentation
     project: scripts

--- a/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
+++ b/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
@@ -129,6 +129,9 @@ object BspStress extends BleepScript("BspStress") {
               conn.output.write(body)
               conn.output.flush()
               readFramedReply(conn.input)
+              // Hold the session briefly, as a real client does actual work between connect and disconnect. Without this the loop degenerates into a reconnect
+              // firehose (thousands/s) that no single daemon's accept backlog survives — which masks, rather than tests, the spawn behaviour.
+              Thread.sleep(75)
             }
           }
           .timeout((a.connectTimeoutSec + 30).seconds)
@@ -143,7 +146,7 @@ object BspStress extends BleepScript("BspStress") {
     def clientLoop(deadlineMs: Long): IO[Unit] =
       IO.realTime.flatMap { now =>
         if (now.toMillis >= deadlineMs) IO.unit
-        else oneAttempt >> IO.sleep(5.millis) >> clientLoop(deadlineMs)
+        else oneAttempt >> IO.sleep(100.millis) >> clientLoop(deadlineMs)
       }
 
     // Track the peak count of simultaneously-alive spawned daemons — the honest fork-storm signal (see Stats.peakConcurrent).

--- a/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
+++ b/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
@@ -26,23 +26,22 @@ import scala.jdk.CollectionConverters.*
   *   - respawn coverage: distinct daemon pids seen > 1, proving the kill/respawn path actually exercised.
   *   - churn failures (broken pipe / stream closed when the daemon is killed mid-use) are expected and only informational.
   *
-  * Run: `bleep publish local-ivy` first (the harness forks the real bleep-bsp at `BleepVersion.current`), then `bleep bsp-stress [--clients N] [--duration-sec
-  * S] [--kill-every-ms K] [--connect-timeout-sec T]`.
+  * Run: `bleep publish local-ivy` first (the harness forks the real bleep-bsp at `BleepVersion.current`), then `bleep bsp-stress [clients] [durationSec]
+  * [killEveryMs] [connectTimeoutSec]` (positional, since bleep's script parser rejects `--`-flags). Defaults: 500 15s(30) 2000 20.
   */
 object BspStress extends BleepScript("BspStress") {
 
   private final case class Args(clients: Int, durationSec: Int, killEveryMs: Int, connectTimeoutSec: Int)
 
+  // Positional, because bleep's script arg parser rejects anything starting with `--`:
+  //   bleep bsp-stress [clients] [durationSec] [killEveryMs] [connectTimeoutSec]
   private def parseArgs(args: List[String]): Args = {
-    val m = args
-      .sliding(2, 2)
-      .collect { case List(k, v) if k.startsWith("--") => k -> v }
-      .toMap
+    def at(i: Int, default: Int): Int = args.lift(i).flatMap(_.toIntOption).getOrElse(default)
     Args(
-      clients = m.get("--clients").map(_.toInt).getOrElse(500),
-      durationSec = m.get("--duration-sec").map(_.toInt).getOrElse(30),
-      killEveryMs = m.get("--kill-every-ms").map(_.toInt).getOrElse(2000),
-      connectTimeoutSec = m.get("--connect-timeout-sec").map(_.toInt).getOrElse(20)
+      clients = at(0, 500),
+      durationSec = at(1, 30),
+      killEveryMs = at(2, 2000),
+      connectTimeoutSec = at(3, 20)
     )
   }
 

--- a/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
+++ b/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
@@ -172,7 +172,7 @@ object BspStress extends BleepScript("BspStress") {
     } yield ()
 
     try program.unsafeRunSync()
-    finally cleanup(stressDir, readPid(), logger)
+    finally cleanup(stressDir, stats.distinctPids.asScala.toSet ++ readPid(), logger)
 
     report(stats, logger)
     if (stats.bricks.get() > 0 || stats.successes.get() == 0) {
@@ -201,11 +201,16 @@ object BspStress extends BleepScript("BspStress") {
     }
   }
 
-  private def cleanup(stressDir: Path, survivingPid: Option[Long], logger: ryddig.Logger): Unit = {
-    survivingPid.foreach { pid =>
+  private def cleanup(stressDir: Path, spawnedPids: Set[Long], logger: ryddig.Logger): Unit = {
+    // Kill EVERY daemon this run ever spawned, not just the last pid file — the herd leaves losers retrying the lock for tens of seconds, and a chaos-killed
+    // generation's replacements pile up. Then a pkill backstop catches any whose cmdline still points at our socket dir.
+    spawnedPids.foreach { pid =>
       try new ProcessBuilder("kill", "-9", pid.toString).start().waitFor()
       catch { case _: Throwable => () }
     }
+    try new ProcessBuilder("pkill", "-9", "-f", stressDir.getFileName.toString).start().waitFor()
+    catch { case _: Throwable => () }
+    logger.info(s"Killed ${spawnedPids.size} spawned daemon(s) + pkill backstop for ${stressDir.getFileName}")
     try Files.walk(stressDir).iterator().asScala.toList.reverse.foreach(p => Files.deleteIfExists(p): Unit)
     catch { case e: Throwable => logger.warn(s"Could not fully delete $stressDir: ${e.getMessage}") }
   }

--- a/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
+++ b/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
@@ -55,6 +55,9 @@ object BspStress extends BleepScript("BspStress") {
     val maxLatencyMs = new AtomicLong(0)
     val failuresByKind = new ConcurrentHashMap[String, AtomicLong]()
     val distinctPids = ConcurrentHashMap.newKeySet[Long]()
+    // Peak number of spawned daemons ALIVE at the same instant. This is the fork-storm signal — distinctPids counts pid-file churn over the whole run (every
+    // spawn attempt, winners and short-lived losers), which vastly overcounts; a healthy run keeps peakConcurrent at 1–2 even while distinctPids climbs.
+    val peakConcurrent = new AtomicLong(0)
 
     def recordSuccess(latencyMs: Long): Unit = {
       successes.incrementAndGet(); sumLatencyMs.addAndGet(latencyMs)
@@ -143,6 +146,13 @@ object BspStress extends BleepScript("BspStress") {
         else oneAttempt >> IO.sleep(5.millis) >> clientLoop(deadlineMs)
       }
 
+    // Track the peak count of simultaneously-alive spawned daemons — the honest fork-storm signal (see Stats.peakConcurrent).
+    def sampler(deadlineMs: Long): IO[Unit] =
+      IO.sleep(250.millis) >> IO {
+        val alive = stats.distinctPids.asScala.count(pid => ProcessHandle.of(pid).isPresent)
+        stats.peakConcurrent.accumulateAndGet(alive.toLong, math.max): Unit
+      } >> IO.realTime.flatMap(now => if (now.toMillis >= deadlineMs) IO.unit else sampler(deadlineMs))
+
     def chaosLoop(deadlineMs: Long): IO[Unit] =
       IO.sleep(a.killEveryMs.millis) >> IO.realTime.flatMap { now =>
         if (now.toMillis >= deadlineMs) IO.unit
@@ -167,8 +177,10 @@ object BspStress extends BleepScript("BspStress") {
       deadlineMs = startMs + a.durationSec * 1000L
       clients = List.fill(a.clients)(clientLoop(deadlineMs))
       chaosFiber <- chaosLoop(deadlineMs).start
+      samplerFiber <- sampler(deadlineMs).start
       _ <- clients.parSequence_
       _ <- chaosFiber.join.attempt
+      _ <- samplerFiber.join.attempt
     } yield ()
 
     try program.unsafeRunSync()
@@ -221,7 +233,10 @@ object BspStress extends BleepScript("BspStress") {
     val meanMs = if (ok == 0) 0 else stats.sumLatencyMs.get() / ok
     logger.info("──────── BSP stress report ────────")
     logger.info(s"attempts=$att  successes=$ok (${if (att == 0) 0 else ok * 100 / att}%)  mean=${meanMs}ms  max=${stats.maxLatencyMs.get()}ms")
-    logger.info(s"daemon kills=${stats.kills.get()}  distinct daemon pids seen=${stats.distinctPids.size()} (want > 1: proves respawn was exercised)")
+    logger.info(
+      s"daemon kills=${stats.kills.get()}  PEAK concurrent daemons=${stats.peakConcurrent.get()} (want ~1-2: proves NO fork storm)  distinct pids seen=${stats.distinctPids
+          .size()} (cumulative pid-file churn, not live count)"
+    )
     if (stats.failuresByKind.isEmpty) logger.info("failures: none")
     else {
       logger.info("failures by kind:")

--- a/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
+++ b/scripts-dev/src/scala/bleep/scripts/dev/BspStress.scala
@@ -1,0 +1,230 @@
+package bleep.scripts.dev
+
+import bleep.bsp.{BspRifle, BspRifleConfig, SetupBleepBsp}
+import bleep.{BleepScript, Commands, Started}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import ryddig.LogLevel
+
+import java.nio.file.{Files, Path}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+/** Adversarial stress harness for the BSP daemon lifecycle. NOT a test — a runnable main you drive by hand and tune against.
+  *
+  * It fans out N concurrent "clients", each looping `ensureRunningAndConnect` → `build/initialize` → read reply → disconnect against ONE shared throwaway
+  * socket dir, while a chaos fiber `kill -9`s the daemon on an interval. That reproduces exactly the conditions that brick things in the field: a swarm of
+  * clients racing to spawn the daemon, plus the daemon dying under live clients so the survivors must detect it and respawn — all without touching any real
+  * daemon (its own temp socket dir).
+  *
+  * What it watches for:
+  *   - BRICK: a client reports "failed to start within …" against a daemon that is actually up. This is the readiness bug
+  *     ([[BspServerOperations.waitForServer]]) and must never happen — any occurrence fails the run.
+  *   - respawn coverage: distinct daemon pids seen > 1, proving the kill/respawn path actually exercised.
+  *   - churn failures (broken pipe / stream closed when the daemon is killed mid-use) are expected and only informational.
+  *
+  * Run: `bleep publish local-ivy` first (the harness forks the real bleep-bsp at `BleepVersion.current`), then `bleep bsp-stress [--clients N] [--duration-sec
+  * S] [--kill-every-ms K] [--connect-timeout-sec T]`.
+  */
+object BspStress extends BleepScript("BspStress") {
+
+  private final case class Args(clients: Int, durationSec: Int, killEveryMs: Int, connectTimeoutSec: Int)
+
+  private def parseArgs(args: List[String]): Args = {
+    val m = args
+      .sliding(2, 2)
+      .collect { case List(k, v) if k.startsWith("--") => k -> v }
+      .toMap
+    Args(
+      clients = m.get("--clients").map(_.toInt).getOrElse(500),
+      durationSec = m.get("--duration-sec").map(_.toInt).getOrElse(30),
+      killEveryMs = m.get("--kill-every-ms").map(_.toInt).getOrElse(2000),
+      connectTimeoutSec = m.get("--connect-timeout-sec").map(_.toInt).getOrElse(20)
+    )
+  }
+
+  /** Lock-free tallies shared across all client fibers. */
+  private final class Stats {
+    val attempts = new AtomicLong(0)
+    val successes = new AtomicLong(0)
+    val bricks = new AtomicLong(0) // "failed to start within" against a live daemon — THE bug
+    val kills = new AtomicLong(0)
+    val sumLatencyMs = new AtomicLong(0)
+    val maxLatencyMs = new AtomicLong(0)
+    val failuresByKind = new ConcurrentHashMap[String, AtomicLong]()
+    val distinctPids = ConcurrentHashMap.newKeySet[Long]()
+
+    def recordSuccess(latencyMs: Long): Unit = {
+      successes.incrementAndGet(); sumLatencyMs.addAndGet(latencyMs)
+      maxLatencyMs.accumulateAndGet(latencyMs, math.max): Unit
+    }
+    def recordFailure(err: Throwable): Unit = {
+      val msg = Option(err.getMessage).getOrElse(err.getClass.getName)
+      val kind =
+        if (msg.contains("failed to start within")) { bricks.incrementAndGet(); "BRICK: failed-to-start-vs-live-daemon" }
+        else if (msg.contains("Broken pipe") || msg.contains("reset") || msg.contains("closed") || msg.contains("EOF")) "churn: daemon killed mid-use"
+        else if (msg.contains("connection lost") || msg.contains("connect")) "connect failure"
+        else s"other: ${msg.take(60)}"
+      failuresByKind.computeIfAbsent(kind, _ => new AtomicLong(0)).incrementAndGet(): Unit
+    }
+  }
+
+  override def run(started: Started, commands: Commands, args: List[String]): Unit = {
+    val a = parseArgs(args)
+    val logger = started.logger
+    // Per-client BSP lifecycle logging is deafening at N=thousands; keep only warnings/errors from the machinery itself.
+    val quiet = logger.withMinLogLevel(LogLevel.warn)
+
+    val baseConfig = SetupBleepBsp(
+      compileServerMode = started.config.compileServerModeOrDefault,
+      config = started.config,
+      resolvedJvm = started.resolvedJvm.forceGet,
+      userPaths = started.pre.userPaths,
+      resolver = started.resolver,
+      logger = logger,
+      javaSemanticdbVersion = SetupBleepBsp.DefaultJavaSemanticdbVersion
+    ).fold(
+      e => throw new RuntimeException(s"Could not resolve the bleep-bsp server classpath — did you `bleep publish local-ivy`? ${e.getMessage}", e),
+      identity
+    )
+
+    // Isolate to a throwaway socket dir so the swarm and the kills never touch the user's real daemons.
+    val stressDir = Files.createTempDirectory("bleep-bsp-stress-")
+    val config = baseConfig.copy(
+      address = BspRifleConfig.Address.DomainSocket(stressDir.resolve("socket")),
+      workingDir = stressDir
+    )
+    val pidFile = stressDir.resolve("pid")
+
+    logger.info(s"BSP stress: ${a.clients} clients, ${a.durationSec}s, kill every ${a.killEveryMs}ms, socket dir $stressDir")
+
+    val stats = new Stats
+
+    def readPid(): Option[Long] =
+      try if (Files.exists(pidFile)) Some(Files.readString(pidFile).trim.toLong) else None
+      catch { case _: Throwable => None }
+
+    def alive(pid: Long): Boolean =
+      try new ProcessBuilder("kill", "-0", pid.toString).start().waitFor() == 0
+      catch { case _: Throwable => false }
+
+    /** One client attempt: connect (spawning the daemon if needed), send initialize, read one framed reply. */
+    def oneAttempt: IO[Unit] = {
+      val startNanos = new AtomicReference[Long](0L)
+      IO(startNanos.set(System.nanoTime())) >>
+        BspRifle
+          .ensureRunningAndConnect(config, quiet)
+          .use { conn =>
+            IO.blocking {
+              readPid().foreach(stats.distinctPids.add)
+              val body =
+                """{"jsonrpc":"2.0","id":1,"method":"build/initialize","params":{"displayName":"stress","version":"0","bspVersion":"2.1.0","rootUri":"file:///tmp","capabilities":{"languageIds":["scala"]}}}"""
+                  .getBytes("UTF-8")
+              conn.output.write(s"Content-Length: ${body.length}\r\n\r\n".getBytes("US-ASCII"))
+              conn.output.write(body)
+              conn.output.flush()
+              readFramedReply(conn.input)
+            }
+          }
+          .timeout((a.connectTimeoutSec + 30).seconds)
+          .attempt
+          .flatMap {
+            case Right(_) => IO(stats.recordSuccess((System.nanoTime() - startNanos.get()) / 1000000L))
+            case Left(e)  => IO(stats.recordFailure(e))
+          }
+          .guarantee(IO(stats.attempts.incrementAndGet()).void)
+    }
+
+    def clientLoop(deadlineMs: Long): IO[Unit] =
+      IO.realTime.flatMap { now =>
+        if (now.toMillis >= deadlineMs) IO.unit
+        else oneAttempt >> IO.sleep(5.millis) >> clientLoop(deadlineMs)
+      }
+
+    def chaosLoop(deadlineMs: Long): IO[Unit] =
+      IO.sleep(a.killEveryMs.millis) >> IO.realTime.flatMap { now =>
+        if (now.toMillis >= deadlineMs) IO.unit
+        else {
+          val kill = IO
+            .blocking {
+              readPid() match {
+                case Some(pid) if alive(pid) =>
+                  new ProcessBuilder("kill", "-9", pid.toString).start().waitFor()
+                  stats.kills.incrementAndGet(); ()
+                case _ => ()
+              }
+            }
+            .attempt
+            .void
+          kill >> chaosLoop(deadlineMs)
+        }
+      }
+
+    val program = for {
+      startMs <- IO.realTime.map(_.toMillis)
+      deadlineMs = startMs + a.durationSec * 1000L
+      clients = List.fill(a.clients)(clientLoop(deadlineMs))
+      chaosFiber <- chaosLoop(deadlineMs).start
+      _ <- clients.parSequence_
+      _ <- chaosFiber.join.attempt
+    } yield ()
+
+    try program.unsafeRunSync()
+    finally cleanup(stressDir, readPid(), logger)
+
+    report(stats, logger)
+    if (stats.bricks.get() > 0 || stats.successes.get() == 0) {
+      logger.error("BSP stress FAILED — see report above")
+      sys.exit(1)
+    }
+  }
+
+  /** Read exactly one `Content-Length`-framed JSON-RPC message, or throw on EOF/short read. */
+  private def readFramedReply(in: java.io.InputStream): Unit = {
+    val header = new StringBuilder
+    var b = in.read()
+    while (b != -1 && !header.endsWith("\r\n\r\n")) { header.append(b.toChar); b = in.read() }
+    if (b == -1) throw new java.io.EOFException("stream closed before reply header")
+    val len = header
+      .toString()
+      .linesIterator
+      .collectFirst { case l if l.toLowerCase.startsWith("content-length:") => l.split(":", 2)(1).trim.toInt }
+      .getOrElse(throw new RuntimeException("no Content-Length in reply"))
+    var remaining = len
+    val buf = new Array[Byte](8192)
+    while (remaining > 0) {
+      val n = in.read(buf, 0, math.min(buf.length, remaining))
+      if (n == -1) throw new java.io.EOFException("stream closed mid-reply")
+      remaining -= n
+    }
+  }
+
+  private def cleanup(stressDir: Path, survivingPid: Option[Long], logger: ryddig.Logger): Unit = {
+    survivingPid.foreach { pid =>
+      try new ProcessBuilder("kill", "-9", pid.toString).start().waitFor()
+      catch { case _: Throwable => () }
+    }
+    try Files.walk(stressDir).iterator().asScala.toList.reverse.foreach(p => Files.deleteIfExists(p): Unit)
+    catch { case e: Throwable => logger.warn(s"Could not fully delete $stressDir: ${e.getMessage}") }
+  }
+
+  private def report(stats: Stats, logger: ryddig.Logger): Unit = {
+    val att = stats.attempts.get()
+    val ok = stats.successes.get()
+    val meanMs = if (ok == 0) 0 else stats.sumLatencyMs.get() / ok
+    logger.info("──────── BSP stress report ────────")
+    logger.info(s"attempts=$att  successes=$ok (${if (att == 0) 0 else ok * 100 / att}%)  mean=${meanMs}ms  max=${stats.maxLatencyMs.get()}ms")
+    logger.info(s"daemon kills=${stats.kills.get()}  distinct daemon pids seen=${stats.distinctPids.size()} (want > 1: proves respawn was exercised)")
+    if (stats.failuresByKind.isEmpty) logger.info("failures: none")
+    else {
+      logger.info("failures by kind:")
+      stats.failuresByKind.asScala.toList.sortBy(-_._2.get()).foreach { case (k, n) => logger.info(f"  ${n.get()}%6d  $k") }
+    }
+    val bricks = stats.bricks.get()
+    if (bricks > 0) logger.error(s"*** $bricks BRICK(s): a live daemon was reported 'failed to start' — the readiness bug reproduced ***")
+    else logger.info("no bricks — readiness held under contention")
+  }
+}


### PR DESCRIPTION
Stacked on the readiness fix (#617, now merged). This is the rest of the BSP daemon-lifecycle work that grew out of a session-long incident where agents' `bleep` commands kept failing against healthy daemons and daemons piled up across worktrees. Squash-merge — the branch history includes discarded experiments (a create/delete spawn-lock, a pidfile-based fast-exit) that the stress harness disproved; only the final design matters.

## The problems (all observed live)

- **Bricking** — a healthy, listening daemon reported to every client as "failed to start" (fixed in #617; the rest here builds on it).
- **Proliferation** — daemons abandoned by closed worktrees, JVM bumps, and client redeploys lingered for days (we found a jdk-25.0.0 daemon still resident beside the current jdk-25.0.1 ones).
- **Fork storm** — a swarm of clients hitting a cold daemon each forked a server JVM, spiking dozens of JVMs at once and starving the shared build server so even unrelated compiles stalled.

## The fixes

**Connect-or-spawn** (`BspRifle.ensureRunning`). The socket is the single source of truth: a successful connect proves a daemon owns it (reuse); only a connect *refusal* triggers a spawn. Load-blind — connecting to a bound unix socket completes at the kernel level regardless of daemon busyness, so a busy server is never mistaken for a missing one. The old pid-file / zombie / lock-file branch tree is gone.

**Idle self-shutdown** (default 1h, `bleep config compile-server idle-timeout`). A watchdog reaps a daemon that has had no connected client for the timeout — the clock resets on connect and on each client's exit, so a compile or an open editor is never reaped. Bounds proliferation.

**Single-spawner election** — the fork-storm fix. Two primitives, one per contention kind, because neither alone suffices:
- a JVM-wide **`Semaphore`** permit per socket dir excludes concurrent fibers/threads within one process (the MCP server; the stress harness). A `Semaphore`, not a `ReentrantLock`, because cats-effect runs a Resource's acquire and release on different pool threads and a `ReentrantLock` may only be unlocked by the locking thread.
- a **`FileChannel.tryLock`** advisory lock on `.spawn-lock` excludes separate client *processes* — the real case. It auto-releases on channel close or process death: no stale-lock timeout, no delete race.

Whoever holds both spawns; everyone else waits for that daemon via the connect probe. libdaemonjvm's lock stays the correctness backstop.

**`bleep bsp-stress`** (scripts-dev) — an adversarial harness that fans out N clients (connect → initialize → hold → disconnect) against a throwaway socket dir while a chaos fiber `kill -9`s the daemon, and reports peak-concurrent daemons (the honest fork-storm signal), success rate, and the brick signature.

## Validation

- `bleep-bsp-tests`: 611/611.
- Fork storm: **peak 2 concurrent daemons at 40 clients** under kill-every-4s (was 39 before election), **100% success, zero bricks, zero leaks**. Cross-process exclusion proven independently: of 30 concurrent processes each calling `FileChannel.tryLock`, exactly one acquires.
- Bricking: zero bricks across every harness run.

The readiness + idle-shutdown parts are already deployed locally (`+75`); the single-spawner election is validated but built after that deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)