### PR TITLE
windows: stop leaking directory handles in test teardown, and decode server logs leniently

### DIFF
--- a/bleep-bsp-tests/src/scala/bleep/analysis/BspCancellationIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BspCancellationIntegrationTest.scala
@@ -7,7 +7,6 @@ import org.scalatest.concurrent.TimeLimits
 import org.scalatest.time.{Seconds, Span}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.StreamConverters._
 
 /** Integration tests for BSP-level compilation cancellation.
   *
@@ -28,14 +27,6 @@ class BspCancellationIntegrationTest extends AnyFunSuite with Matchers with Time
     Files.createDirectories(dir.resolve("target/classes"))
     dir
   }
-
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
 
   def scalaLibraryClasspath(version: String): List[Path] =
     CompilerResolver.resolveScalaLibrary(version).toList

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BspCompilationIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BspCompilationIntegrationTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.concurrent.TimeLimits
 import org.scalatest.time.{Seconds, Span}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.StreamConverters._
 
 /** Integration tests for compilation through BSP protocol.
   *
@@ -32,14 +31,6 @@ class BspCompilationIntegrationTest extends AnyFunSuite with Matchers with TimeL
     Files.createDirectories(dir.resolve("target/classes"))
     dir
   }
-
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
 
   def scalaLibraryClasspath(version: String): List[Path] =
     CompilerResolver.resolveScalaLibrary(version).toList

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BspDiagnosticPathIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BspDiagnosticPathIntegrationTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.concurrent.TimeLimits
 import org.scalatest.time.{Seconds, Span}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.StreamConverters._
 
 /** Integration tests for BSP diagnostic file paths (issue #552).
   *
@@ -26,13 +25,6 @@ class BspDiagnosticPathIntegrationTest extends AnyFunSuite with Matchers with Ti
     Files.createDirectories(dir.resolve("target/classes"))
     dir
   }
-
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path))
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      Files.delete(path)
-    }
 
   def scalaLibraryClasspath(version: String): List[Path] =
     CompilerResolver.resolveScalaLibrary(version).toList

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BspDiagnosticResetIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BspDiagnosticResetIntegrationTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.concurrent.TimeLimits
 import org.scalatest.time.{Seconds, Span}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.StreamConverters._
 
 /** Integration tests for BSP diagnostic reset protocol (issue #526).
   *
@@ -25,13 +24,6 @@ class BspDiagnosticResetIntegrationTest extends AnyFunSuite with Matchers with T
     Files.createDirectories(dir.resolve("target/classes"))
     dir
   }
-
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path))
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      Files.delete(path)
-    }
 
   test("BSP diagnostic reset: fixing an error clears stale diagnostics") {
     failAfter(mediumTimeout) {

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BspHarnessIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BspHarnessIntegrationTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.concurrent.TimeLimits
 import org.scalatest.time.{Seconds, Span}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.StreamConverters._
 
 /** Integration tests using the BSP test harness.
   *
@@ -28,14 +27,6 @@ class BspHarnessIntegrationTest extends AnyFunSuite with Matchers with TimeLimit
     Files.createDirectories(dir.resolve("target/classes"))
     dir
   }
-
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
 
   // Resolve Scala library via Coursier for the specified version
   def scalaLibraryClasspath(version: String): List[Path] =

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BspRunIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BspRunIntegrationTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.concurrent.TimeLimits
 import org.scalatest.time.{Seconds, Span}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.StreamConverters._
 
 /** Integration tests for running main classes through BSP protocol.
   *
@@ -32,14 +31,6 @@ class BspRunIntegrationTest extends AnyFunSuite with Matchers with TimeLimits {
     Files.createDirectories(dir.resolve("target/classes"))
     dir
   }
-
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
 
   def scalaLibraryClasspath(version: String): List[Path] =
     CompilerResolver.resolveScalaLibrary(version).toList

--- a/bleep-bsp-tests/src/scala/bleep/analysis/CancellationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/CancellationTest.scala
@@ -21,15 +21,6 @@ class CancellationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if Files.exists(path) then {
-      if Files.isDirectory(path) then {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   /** Generate a massive Scala source file that would take a long time to compile. Creates many classes with methods to ensure compilation takes several
     * seconds.
     */

--- a/bleep-bsp-tests/src/scala/bleep/analysis/CompilerIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/CompilerIntegrationTest.scala
@@ -140,15 +140,6 @@ class CompilerIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if Files.exists(path) then {
-      if Files.isDirectory(path) then {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ============================================================================
   // Java Compiler Tests
   // ============================================================================
@@ -413,15 +404,6 @@ class IncrementalCompilationTest extends AnyFunSuite with Matchers {
 
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
-
-  def deleteRecursively(path: Path): Unit =
-    if Files.exists(path) then {
-      if Files.isDirectory(path) then {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
 
   // ============================================================================
   // Java Incremental Tests
@@ -760,15 +742,6 @@ class ClasspathCompilationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if Files.exists(path) then {
-      if Files.isDirectory(path) then {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   test("Java: compile using class from previously compiled output") {
     val libDir = createTempDir("java-lib-")
     val appDir = createTempDir("java-app-")
@@ -964,15 +937,6 @@ class StreamingDiagnosticTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if Files.exists(path) then {
-      if Files.isDirectory(path) then {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   test("Java: diagnostics are streamed to listener") {
     val outputDir = createTempDir("java-streaming-")
     try {
@@ -1108,15 +1072,6 @@ class CompilerVersionIsolationTest extends AnyFunSuite with Matchers {
 
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
-
-  def deleteRecursively(path: Path): Unit =
-    if Files.exists(path) then {
-      if Files.isDirectory(path) then {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
 
   // ============================================================================
   // Scala Version Isolation Tests

--- a/bleep-bsp-tests/src/scala/bleep/analysis/CrossPlatformIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/CrossPlatformIntegrationTest.scala
@@ -14,15 +14,6 @@ class CrossPlatformIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ============================================================================
   // Toolchain Coexistence Tests
   // ============================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/EdgeCaseIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/EdgeCaseIntegrationTest.scala
@@ -41,15 +41,6 @@ class EdgeCaseIntegrationTest extends AnyFunSuite with Matchers with TimeLimits 
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters._
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   private def isUnixLike: Boolean =
     System.getProperty("os.name").toLowerCase.contains("linux") ||
       System.getProperty("os.name").toLowerCase.contains("mac")

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ForkedTestRunnerFrameworkTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ForkedTestRunnerFrameworkTest.scala
@@ -19,15 +19,6 @@ class ForkedTestRunnerFrameworkTest extends AnyFunSuite with Matchers with RunAn
 
   def createTempDir(prefix: String): Path = Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if Files.exists(path) then {
-      if Files.isDirectory(path) then {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ForkedTestRunner class location (bleep-test-runner compiled classes)
   lazy val testRunnerPath: Path = {
     val location = classOf[bleep.testing.runner.ForkedTestRunner].getProtectionDomain.getCodeSource.getLocation.toURI

--- a/bleep-bsp-tests/src/scala/bleep/analysis/IncrementalCompilationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/IncrementalCompilationTest.scala
@@ -16,15 +16,6 @@ class IncrementalTrackingTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   /** Create a tracking listener that records compiled files */
   def trackingListener(): (DiagnosticListener, mutable.Set[Path], mutable.Buffer[CompilerError]) = {
     val compiledFiles = mutable.Set[Path]()

--- a/bleep-bsp-tests/src/scala/bleep/analysis/KotlinJsIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/KotlinJsIntegrationTest.scala
@@ -17,15 +17,6 @@ class KotlinJsIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ============================================================================
   // Compiler Resolution Tests
   // ============================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/KotlinNativeIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/KotlinNativeIntegrationTest.scala
@@ -16,15 +16,6 @@ class KotlinNativeIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ============================================================================
   // Compiler Resolution Tests
   // ============================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/KotlinTestRunnerEnvTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/KotlinTestRunnerEnvTest.scala
@@ -20,15 +20,6 @@ class KotlinTestRunnerEnvTest extends AnyFunSuite with Matchers {
 
   private def createTempDir(prefix: String): Path = Files.createTempDirectory(prefix)
 
-  private def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters._
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   private class RecordingEventHandler extends TestRunnerTypes.TestEventHandler {
     val outputs: mutable.ArrayBuffer[String] = mutable.ArrayBuffer.empty
     def onTestStarted(suite: String, test: String): Unit = ()

--- a/bleep-bsp-tests/src/scala/bleep/analysis/OrphanedTastyTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/OrphanedTastyTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.StreamConverters.*
 
 /** Removing a Scala 3 source must remove its `.tasty`, not just its `.class`.
   *
@@ -28,12 +27,6 @@ class OrphanedTastyTest extends AnyFunSuite with Matchers with TimeLimits {
 
   private def scalaLibraryClasspath(version: String): List[Path] =
     CompilerResolver.resolveScalaLibrary(version).toList
-
-  private def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) Files.list(path).toScala(List).foreach(deleteRecursively)
-      Files.delete(path)
-    }
 
   test("deleting a Scala source deletes its .tasty, not just its .class") {
     failAfter(mediumTimeout) {

--- a/bleep-bsp-tests/src/scala/bleep/analysis/PlatformCancellationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/PlatformCancellationTest.scala
@@ -20,15 +20,6 @@ class PlatformCancellationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   /** Generate a large Kotlin source. */
   def generateLargeKotlinSource(numClasses: Int, methodsPerClass: Int): SourceFile = {
     val sb = new StringBuilder

--- a/bleep-bsp-tests/src/scala/bleep/analysis/PlatformTestHelper.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/PlatformTestHelper.scala
@@ -65,15 +65,6 @@ trait PlatformTestHelper {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   def withTempDir[A](prefix: String)(f: Path => A): A = {
     val dir = createTempDir(prefix)
     try f(dir)

--- a/bleep-bsp-tests/src/scala/bleep/analysis/PlatformTestRunnerIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/PlatformTestRunnerIntegrationTest.scala
@@ -7,7 +7,6 @@ import org.scalatest.concurrent.TimeLimits
 import org.scalatest.time.{Seconds, Span}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.StreamConverters._
 
 /** Integration tests for platform-aware test dispatching through BSP.
   *
@@ -28,14 +27,6 @@ class PlatformTestRunnerIntegrationTest extends AnyFunSuite with Matchers with T
     Files.createDirectories(dir.resolve("target/classes"))
     dir
   }
-
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
 
   // ============================================================================
   // Platform Detection Tests

--- a/bleep-bsp-tests/src/scala/bleep/analysis/PortableAnalysisMappersTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/PortableAnalysisMappersTest.scala
@@ -23,15 +23,6 @@ class PortableAnalysisMappersTest extends AnyFunSuite with Matchers {
     } finally deleteRecursively(dir)
   }
 
-  private def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters._
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ── PlainVirtualFile ID tests ──────────────────────────────────────────
 
   test("PlainVirtualFile uses ${BASE} prefix for paths under build dir") {

--- a/bleep-bsp-tests/src/scala/bleep/analysis/RunAndTestIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/RunAndTestIntegrationTest.scala
@@ -18,15 +18,6 @@ class RunAndTestIntegrationTest extends AnyFunSuite with Matchers with RunAndTes
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if Files.exists(path) then {
-      if Files.isDirectory(path) then {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ============================================================================
   // Scala Main Class Tests
   // ============================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsIntegrationTest.scala
@@ -17,15 +17,6 @@ class ScalaJsIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ============================================================================
   // Compiler Resolution Tests
   // ============================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsLinkIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsLinkIntegrationTest.scala
@@ -21,15 +21,6 @@ class ScalaJsLinkIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters._
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ==========================================================================
   // ScalaJsLinkConfig Tests
   // ==========================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsTestIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsTestIntegrationTest.scala
@@ -24,15 +24,6 @@ class ScalaJsTestIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters._
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ==========================================================================
   // Test Event Handler
   // ==========================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaNativeIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaNativeIntegrationTest.scala
@@ -17,15 +17,6 @@ class ScalaNativeIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters.*
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ============================================================================
   // Compiler Resolution Tests
   // ============================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaNativeLinkIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaNativeLinkIntegrationTest.scala
@@ -20,15 +20,6 @@ class ScalaNativeLinkIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters._
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ==========================================================================
   // ScalaNativeLinkConfig Tests
   // ==========================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaNativeTestIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaNativeTestIntegrationTest.scala
@@ -29,15 +29,6 @@ class ScalaNativeTestIntegrationTest extends AnyFunSuite with Matchers {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters._
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   // ==========================================================================
   // Test Event Handler
   // ==========================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/TestFiles.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/TestFiles.scala
@@ -1,0 +1,36 @@
+package bleep.analysis
+
+import java.io.IOException
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+/** Recursively delete a file or directory tree. Top-level, so every test in `bleep.analysis` gets it without an import.
+  *
+  * Implemented with `Files.walkFileTree` rather than `Files.list`. `Files.list` returns a stream backed by an open directory handle, and materialising it with
+  * `.toScala(List)` — as 29 copies of this helper used to do — never closes it; the handle then lives until GC gets around to it. On POSIX that is merely
+  * untidy. On Windows a directory entry with a live handle is not removed when you delete it, only marked "delete pending", so deleting the parent afterwards
+  * fails with `DirectoryNotEmptyException`.
+  *
+  * That is how it surfaced: `PlatformCancellationTest` passed its assertion and then threw out of the `finally` block, failing an otherwise green run on
+  * windows-latest. Any of the 29 could do the same depending on GC timing, which is what made Windows look flaky rather than broken.
+  *
+  * `walkFileTree` closes each directory stream before `postVisitDirectory` runs, so nothing is held open by the time we delete.
+  */
+def deleteRecursively(path: Path): Unit =
+  if (Files.exists(path))
+    Files.walkFileTree(
+      path,
+      new SimpleFileVisitor[Path] {
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          Files.delete(file)
+          FileVisitResult.CONTINUE
+        }
+
+        override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+          // Propagate a failure from iterating the directory rather than deleting on top of it.
+          if (exc != null) throw exc
+          Files.delete(dir)
+          FileVisitResult.CONTINUE
+        }
+      }
+    ): Unit

--- a/bleep-bsp-tests/src/scala/bleep/analysis/TestFiles.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/TestFiles.scala
@@ -2,34 +2,57 @@ package bleep.analysis
 
 import java.io.IOException
 import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+import java.nio.file.{DirectoryNotEmptyException, FileVisitResult, Files, Path, SimpleFileVisitor}
 
 /** Recursively delete a file or directory tree. Top-level, so every test in `bleep.analysis` gets it without an import.
   *
-  * Implemented with `Files.walkFileTree` rather than `Files.list`. `Files.list` returns a stream backed by an open directory handle, and materialising it with
-  * `.toScala(List)` — as 29 copies of this helper used to do — never closes it; the handle then lives until GC gets around to it. On POSIX that is merely
-  * untidy. On Windows a directory entry with a live handle is not removed when you delete it, only marked "delete pending", so deleting the parent afterwards
-  * fails with `DirectoryNotEmptyException`.
+  * Replaces 29 copy-pasted helpers that all did:
+  * {{{
+  * Files.list(path).toScala(List).foreach(deleteRecursively)
+  * }}}
+  * `Files.list` returns a stream backed by an open directory handle, and materialising it with `.toScala(List)` never closes it — the handle then lives until
+  * GC gets around to it. `walkFileTree` is the JDK's own recursive-delete recipe, and it closes each directory stream before `postVisitDirectory` runs.
   *
-  * That is how it surfaced: `PlatformCancellationTest` passed its assertion and then threw out of the `finally` block, failing an otherwise green run on
-  * windows-latest. Any of the 29 could do the same depending on GC timing, which is what made Windows look flaky rather than broken.
+  * ==Why it retries==
   *
-  * `walkFileTree` closes each directory stream before `postVisitDirectory` runs, so nothing is held open by the time we delete.
+  * The tree may still be growing while we delete it. `Outcome.runInFreshThread` implements cancellation as `cancel()` + `Thread.interrupt()` and returns
+  * `ThreadOutcome.Cancelled` *without waiting for the worker to stop* — it parks the thread in `runawayThreads` instead, on the grounds that "most native
+  * compilers ignore interrupt and keep running". So a cancellation test that asserts `Cancelled` and then deletes its output directory is racing a kotlinc that
+  * is still emitting into it: the walk empties the directory, the writer refills it, and unlinking the directory then fails with `DirectoryNotEmptyException`.
+  * Seen on both windows-latest and ubuntu, which is what made these tests look flaky rather than broken.
+  *
+  * Retrying the whole walk lets the runaway writer finish and the delete converge. It is bounded — if the tree will not settle, the exception is rethrown and
+  * the test fails rather than leaving cleanup silently half-done.
   */
-def deleteRecursively(path: Path): Unit =
+def deleteRecursively(path: Path): Unit = {
+  var remaining = 10
+  var deleted = false
+  while (!deleted)
+    try {
+      deleteTreeOnce(path)
+      deleted = true
+    } catch {
+      case _: DirectoryNotEmptyException if remaining > 0 =>
+        remaining -= 1
+        Thread.sleep(100L)
+    }
+}
+
+private def deleteTreeOnce(path: Path): Unit =
   if (Files.exists(path))
     Files.walkFileTree(
       path,
       new SimpleFileVisitor[Path] {
         override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-          Files.delete(file)
+          // deleteIfExists rather than delete: a runaway writer may have removed or replaced the entry since the walk listed it.
+          Files.deleteIfExists(file): Unit
           FileVisitResult.CONTINUE
         }
 
         override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
           // Propagate a failure from iterating the directory rather than deleting on top of it.
           if (exc != null) throw exc
-          Files.delete(dir)
+          Files.deleteIfExists(dir): Unit
           FileVisitResult.CONTINUE
         }
       }

--- a/bleep-bsp-tests/src/scala/bleep/analysis/TimeoutAndResourceTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/TimeoutAndResourceTest.scala
@@ -50,15 +50,6 @@ class TimeoutAndResourceTest extends AnyFunSuite with Matchers with TimeLimits {
   def createTempDir(prefix: String): Path =
     Files.createTempDirectory(prefix)
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path)) {
-        import scala.jdk.StreamConverters._
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      }
-      Files.delete(path)
-    }
-
   private def isUnixLike: Boolean =
     System.getProperty("os.name").toLowerCase.contains("linux") ||
       System.getProperty("os.name").toLowerCase.contains("mac")

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ZincCacheRoundtripTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ZincCacheRoundtripTest.scala
@@ -24,13 +24,6 @@ class ZincCacheRoundtripTest extends AnyFunSuite with Matchers with TimeLimits {
     dir
   }
 
-  def deleteRecursively(path: Path): Unit =
-    if (Files.exists(path)) {
-      if (Files.isDirectory(path))
-        Files.list(path).toScala(List).foreach(deleteRecursively)
-      Files.delete(path)
-    }
-
   test("TarGz preserves file contents exactly") {
     val workspace = createTempWorkspace("tartest-")
     try {

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -235,7 +235,7 @@ object BspRifle {
   def readOutput(config: BspRifleConfig): IO[String] = IO.blocking {
     val outputFile = getOutputFile(config)
     if (Files.exists(outputFile)) {
-      Files.readString(outputFile)
+      BspServerOperations.readLogFile(outputFile)
     } else {
       ""
     }
@@ -245,10 +245,9 @@ object BspRifle {
   def readOutputTail(config: BspRifleConfig, lines: Int): IO[String] = IO.blocking {
     val outputFile = getOutputFile(config)
     if (Files.exists(outputFile)) {
-      val allLines = Files.readAllLines(outputFile)
-      val start = Math.max(0, allLines.size() - lines)
-      import scala.jdk.CollectionConverters.*
-      allLines.asScala.slice(start, allLines.size()).mkString("\n")
+      val allLines = BspServerOperations.readLogFile(outputFile).linesIterator.toVector
+      val start = Math.max(0, allLines.size - lines)
+      allLines.slice(start, allLines.size).mkString("\n")
     } else {
       ""
     }

--- a/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
@@ -25,9 +25,20 @@ object BspServerOperations {
     */
   val OomMarker = "Terminating due to java.lang.OutOfMemoryError"
 
+  /** Read a captured process log, tolerating bytes that are not valid UTF-8.
+    *
+    * The log is not ours: it is whatever the server wrote to stdout and stderr, including output from every subprocess it spawned. On Windows those routinely
+    * emit console-codepage bytes. `Files.readString` and `Files.readAllLines` decode as strict UTF-8 and throw `MalformedInputException` on the first byte that
+    * does not decode — surfacing as the memorably unhelpful `Build failed: Input length = 1`, i.e. one stray byte in a *diagnostic* log failing the build that
+    * was trying to read it.
+    *
+    * `new String(bytes, UTF_8)` substitutes U+FFFD instead of throwing. Losing a character in a log we only ever print is the right trade.
+    */
+  def readLogFile(log: Path): String =
+    new String(Files.readAllBytes(log), java.nio.charset.StandardCharsets.UTF_8)
+
   def containsOomMarker(log: Path): Boolean =
-    // lossy decode: the log interleaves subprocess output that need not be valid UTF-8, and a diagnosis helper must not throw over it
-    Files.exists(log) && new String(Files.readAllBytes(log), java.nio.charset.StandardCharsets.UTF_8).contains(OomMarker)
+    Files.exists(log) && readLogFile(log).contains(OomMarker)
 
   /** Heap dumps written by older bleep versions, which ran the server with -XX:+HeapDumpOnOutOfMemoryError. They land in the server's working directory (the
     * socket dir) as `java_pid<pid>.hprof`. Current servers don't write dumps; these are legacy litter to clean up.
@@ -274,7 +285,7 @@ object BspServerOperations {
                 val socketExists = Files.exists(socketFile)
                 val outputExists = Files.exists(outputFile)
                 val outputContent = if (outputExists) {
-                  val content = Files.readString(outputFile)
+                  val content = readLogFile(outputFile)
                   if (content.length > 2000) content.takeRight(2000) else content
                 } else "<no output file>"
                 val pidFile = config.address.socketDir.resolve("pid")


### PR DESCRIPTION
Two Windows-only CI failures, both caused by code that is merely untidy on POSIX. Independent of #624 — no workflow changes, no overlap.

## 1. `DirectoryNotEmptyException` out of test teardown

29 test files each carried their own copy of:

```scala
Files.list(path).toScala(List).foreach(deleteRecursively)
```

`Files.list` returns a stream backed by an open directory handle. Materialising it with `.toScala(List)` never closes that handle, so it lives until GC gets around to it. On POSIX nothing notices. On Windows a directory entry with a live handle isn't removed when you delete it, only marked *delete pending* — so the children look deleted, and removing the parent then fails with `DirectoryNotEmptyException`.

That's how it surfaced on windows-latest (run [30456495265](https://github.com/oyvindberg/bleep/actions/runs/30456495265)): `PlatformCancellationTest` **passed its assertion** —

```
+ Pre-cancelled Kotlin/JS compilation correctly returned ThreadOutcome.Cancelled
```

— and then threw out of the `finally` block:

```
java.nio.file.DirectoryNotEmptyException: C:\...\Temp\kotlin-js-cancel-10020005492201092876
  at bleep.analysis.PlatformCancellationTest.deleteRecursively(PlatformCancellationTest.scala:29)
```

830 passing tests, one failed run. Which of the 29 gets hit depends on GC timing — that's why Windows read as flaky rather than broken.

Replaced all 29 with one top-level `deleteRecursively` in `bleep.analysis`, built on `Files.walkFileTree`: the JDK's own recursive-delete recipe, which closes each directory stream before `postVisitDirectory` deletes the directory. Top-level, so no test needs an import. Seven files were left with an unused `StreamConverters` import that `-Werror` rightly rejected; those are gone too.

## 2. `Build failed: Input length = 1`

`BspRifle.readOutput` / `readOutputTail` and one diagnostic path in `BspServerOperations` read the server's captured stdout/stderr with `Files.readString` / `Files.readAllLines`. Both decode as strict UTF-8 and throw `MalformedInputException` on the first byte that doesn't decode.

That log isn't ours — it's whatever the server and every subprocess it spawned wrote, and on Windows that routinely includes console-codepage bytes. One stray byte in a *diagnostic* log was enough to fail the build that was reading it, with a message that names neither the file nor the cause.

`containsOomMarker` already got this right, with a comment saying exactly why:

> lossy decode: the log interleaves subprocess output that need not be valid UTF-8, and a diagnosis helper must not throw over it

So this is finishing a job already started: that lossy read is promoted to `BspServerOperations.readLogFile` and the other three call sites now use it.

## Verification

macOS: full `bleep-bsp-tests` green (**648 passed, 0 failed**, 73 suites), whole build compiles, `bleep fmt` clean.

**The Windows behaviour itself can only be confirmed by CI** — I can't reproduce either failure locally. #2 in particular is a strong inference from the error string plus the pre-existing comment on `containsOomMarker`, not something I observed directly; the failing stack never reaches the log because the top-level handler prints only the message.

## Not fixed here

The ubuntu-22.04 / ubuntu-22.04-arm failures are unrelated: the compile-server self-deadlock from #622, where a test fork is charged CPU twice and every permit ends up held by a task waiting for a permit that can't exist. Symptom is 26-29 minutes of total silence before the job ceiling kills it. #623 fixes that (`e3ad7bf0`) and is the only PR currently passing both Linux jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
