### PR TITLE
bsp: a cancelled run must answer Cancelled, not -32603 Stream closed

### DIFF
--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -1034,6 +1034,22 @@ class MultiWorkspaceBspServer(
         sendLogMessage(line, MessageType.Log)
         line = reader.readLine()
       }
+    } catch {
+      // `Process.destroy()` closes the parent's ends of the pipes. On Linux/BSD/AIX `ProcessImpl.destroy(boolean)` calls `stdout.close()` outright, right
+      // after signalling — and `BufferedInputStream.close()` nulls `buf`, so a thread parked in `readLine()` on that same stream wakes up in
+      // `getBufIfOpen` and throws `IOException("Stream closed")` rather than seeing EOF.
+      //
+      // Which happens here is a race. `$/cancelRequest` is in `immediatelyHandled`, so the `onCancel` above runs inline on the message-loop thread while
+      // this fiber is still parked in the read below. If the blocked read completes before `close()` nulls the buffer, the loop ends on a clean EOF; if
+      // `close()` wins, it throws. Both are the same event — the run was cancelled — reported two different ways.
+      //
+      // Without this catch the throwing half escaped `handleRun` before the status below could be computed, so `dispatch(...).attempt` saw `Left(...)` and
+      // answered the client `-32603 Stream closed` instead of `StatusCode.Cancelled`. That is why
+      // `BspRunIntegrationTest / BSP: async run can be cancelled` looked flaky rather than broken: same run, ubuntu-22.04 green and ubuntu-22.04-arm red.
+      //
+      // Guarded on the token rather than swallowed: an IOException on a run nobody cancelled still propagates and still fails loudly. The guard cannot
+      // race, because `CancellationToken.create()` flips `cancelled` before it fires any listener, so the flag is already set by the time `destroy()` runs.
+      case _: java.io.IOException if cancellation.isCancelled => ()
     } finally
       try reader.close()
       catch { case _: Exception => () }


### PR DESCRIPTION
`BspRunIntegrationTest / BSP: async run can be cancelled` has been failing intermittently on master. It is not a flaky test — it is a real race with two outcomes, and the test only ever sees one of them.

## The race

`handleRun` drains the child's stdout in a `try`/`finally` with **no `catch`**, and computes the run's status *after* the loop:

```scala
try { var line = reader.readLine(); while (line != null) { sendLogMessage(line, Log); line = reader.readLine() } }
finally reader.close()

val exitCode = process.waitFor()
val status = if (cancellation.isCancelled) StatusCode.Cancelled else ...
```

`$/cancelRequest` is in `immediatelyHandled`, so the `onCancel` callback runs inline on the message-loop thread while the request's own fiber is still parked in that `readLine()`. `Process.destroy()` then closes the parent's ends of the pipes — on Linux/BSD/AIX `ProcessImpl.destroy(boolean)` calls `stdout.close()` outright, right after signalling — and `BufferedInputStream.close()` nulls `buf`, so the parked reader wakes up in `getBufIfOpen` and throws rather than seeing EOF.

Server-side stack, from the `bsp-diagnostics-ubuntu-22.04-arm` artifact of the failing run:

```
[BSP] Error handling buildTarget/run: Stream closed
java.io.IOException: Stream closed
	at java.base/java.io.BufferedInputStream.getBufIfOpen(BufferedInputStream.java:189)
	at java.base/java.io.BufferedInputStream.read1(BufferedInputStream.java:326)
	...
	at java.base/java.io.BufferedReader.readLine(BufferedReader.java:400)
	at bleep.bsp.MultiWorkspaceBspServer.handleRun(MultiWorkspaceBspServer.scala:1032)
	at bleep.bsp.MultiWorkspaceBspServer.dispatchMethod$$anonfun$12(MultiWorkspaceBspServer.scala:355)
```

Which of the two wins decides what the client is told:

| | outcome |
|---|---|
| blocked read completes before `close()` nulls the buffer | clean EOF → falls through → `StatusCode.Cancelled` → **test passes** |
| `close()` wins | exception escapes `handleRun` before the status is computed → `dispatch(...).attempt` sees `Left(...)` → client gets `-32603 Stream closed` → **test fails** |

Both are the same event — the run was cancelled — reported two different ways. Timestamps in the failing log confirm it fires immediately on cancel: `Received cancelRequest` at `19:34:43.0539`, the client's teardown `build/shutdown` 0.8ms later at `19:34:43.0547`.

This is why it presents as flakiness: in a single CI run, `ubuntu-22.04` was green and `ubuntu-22.04-arm` was red.

## The fix

Catch it and fall through to the status computation, which already knows the right answer:

```scala
case _: java.io.IOException if cancellation.isCancelled => ()
```

Guarded on the token rather than swallowed — an IOException on a run nobody cancelled still propagates and still fails loudly, per the project's no-fallback rule. The guard cannot race: `CancellationToken.create()` flips `cancelled` before it fires any listener (`Compiler.scala:37-40`), so the flag is already set by the time `destroy()` runs.

## Verification

`BspRunIntegrationTest` — 7 passed locally against this change. That is weak evidence on its own, since the losing branch does not reproduce on macOS (I ran a standalone harness of the same shape 20× and got a clean EOF every time — this JDK/OS combination consistently resolves the race the other way). The real check is `ubuntu-22.04-arm` in CI, which is where it has actually been failing.

## Not in this PR

`BspTestHarness` interrupts the server thread in its `finally` (`:244`). cats-effect's `unsafeRunTimed` catches `InterruptedException` and returns `None`, so `unsafeRunSync`'s `.get` throws `NoSuchElementException: None.get` out of `MultiWorkspaceBspServer.run:161` on **every** BSP test teardown. It is caught and printed by the harness, so it is harmless — but it prints a full stack trace that looks like a server crash, right next to the real failure in the log. It is what made this bug look like something it wasn't. Worth silencing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)