### PR TITLE
bsp: stopping a connection by interrupting its thread is not a crash

### DIFF
--- a/bleep-bsp-tests/src/scala/bleep/bsp/ServerRunInterruptTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/bsp/ServerRunInterruptTest.scala
@@ -1,0 +1,69 @@
+package bleep.bsp
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration.*
+
+/** Interrupting the thread that owns a BSP connection is how a caller stops it — `BspTestHarness` does exactly that in teardown. These pin what that does.
+  *
+  * The observable symptom lives in the harness, not here: it prints `[BSP Test Server] Server thread crashed: NoSuchElementException: None.get` for a clean
+  * shutdown, but only when the interrupt beats the transport close, so grepping a suite run reproduces it on a loaded CI runner and not on an idle laptop.
+  * These tests take the race out of it by interrupting a program that is guaranteed to still be running.
+  */
+class ServerRunInterruptTest extends AnyFunSuite with Matchers {
+
+  /** Run `body` on a fresh thread, interrupt it once it signals that it is parked, and return whatever escaped. */
+  private def interruptWhileRunning(body: CountDownLatch => Unit): Option[Throwable] = {
+    val parked = new CountDownLatch(1)
+    val thrown = new AtomicReference[Option[Throwable]](None)
+
+    val t = new Thread(
+      () =>
+        try body(parked)
+        catch { case e: Throwable => thrown.set(Some(e)) }, "interrupt-under-test"
+    )
+    t.setDaemon(true)
+    t.start()
+
+    parked.await()
+    // The latch says the IO started, not that the runtime has parked the caller. Without this the interrupt can land before
+    // `unsafeRunTimed` reaches its `queue.poll`, and the test measures nothing.
+    Thread.sleep(200)
+    t.interrupt()
+    t.join(10000)
+    withClue("thread did not return within 10s of being interrupted: ")(t.isAlive shouldBe false)
+    thrown.get()
+  }
+
+  test("unsafeRunSync turns an interrupt into NoSuchElementException — the reason runToCompletion exists") {
+    val escaped = interruptWhileRunning { parked =>
+      (IO.delay(parked.countDown()) >> IO.never).unsafeRunSync()
+    }
+    // Guards the premise rather than our code: `unsafeRunSync` is `unsafeRunTimed(Long.MaxValue.nanos).get`, and `unsafeRunTimed`
+    // answers None on InterruptedException. If a cats-effect upgrade ever changes that, this fails and the doc on
+    // `runToCompletion` needs revisiting.
+    escaped.map(_.getClass.getName) shouldBe Some("java.util.NoSuchElementException")
+  }
+
+  test("runToCompletion returns cleanly on interrupt and re-asserts the flag") {
+    @volatile var flagAfter = false
+    val escaped = interruptWhileRunning { parked =>
+      MultiWorkspaceBspServer.runToCompletion(IO.delay(parked.countDown()) >> IO.never)
+      flagAfter = Thread.currentThread().isInterrupted
+    }
+    escaped shouldBe None
+    withClue("interrupt status must survive, so callers that check it still see the stop request: ")(flagAfter shouldBe true)
+  }
+
+  test("runToCompletion still returns normally when the program completes on its own") {
+    val escaped = interruptWhileRunning { parked =>
+      MultiWorkspaceBspServer.runToCompletion(IO.delay(parked.countDown()) >> IO.sleep(50.millis))
+    }
+    escaped shouldBe None
+  }
+}

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -125,6 +125,8 @@ class MultiWorkspaceBspServer(
   /** Run the server message loop with concurrent request handling.
     *
     * Notifications (like $/cancelRequest) are processed immediately. Requests are spawned in background fibers so the main loop stays responsive.
+    *
+    * Returns when the transport closes, or when this thread is interrupted — see [[runProgram]] for why the latter needs saying.
     */
   def run(): Unit = {
     val program = runConcurrent
@@ -158,7 +160,7 @@ class MultiWorkspaceBspServer(
             }
         }
       )
-    program.unsafeRunSync()
+    MultiWorkspaceBspServer.runToCompletion(program)
   }
 
   private def runConcurrent: IO[Unit] = {
@@ -4144,6 +4146,32 @@ class MultiWorkspaceBspServer(
 }
 
 object MultiWorkspaceBspServer {
+
+  /** Run the message loop to completion, treating an interrupt of this thread as the stop signal it is.
+    *
+    * Not `program.unsafeRunSync()`. That is defined as `unsafeRunTimed(Long.MaxValue.nanos).get`, and `unsafeRunTimed` answers `None` in exactly one reachable
+    * case here — the calling thread was interrupted while parked waiting for the result. (The other case is the timeout, which `Long.MaxValue` nanoseconds does
+    * not reach.) So `.get` turned "someone asked this connection to stop" into `NoSuchElementException: None.get` thrown out of the middle of the cats-effect
+    * runtime, with a stack trace pointing at `IOPlatform.unsafeRunSync` and nothing naming the interrupt.
+    *
+    * Interrupting the thread that owns a connection is a legitimate way to stop it, and `BspTestHarness` does precisely that in its teardown. It closes the
+    * transport first, so usually the loop has already returned by the time the interrupt lands and nothing is thrown — but when the interrupt wins the race the
+    * harness prints `[BSP Test Server] Server thread crashed: java.util.NoSuchElementException: None.get` for what is a clean shutdown. It is load-dependent
+    * rather than constant: six occurrences in one ubuntu-22.04-arm CI job, none in the same suite on an idle dev machine. Landing next to a genuine failure, it
+    * reads as the cause of it — which is exactly what it did while #628 was being diagnosed.
+    *
+    * `unsafeRunTimed` has already cancelled the program by the time it answers `None`, so the `guarantee` above still runs. Note it runs *asynchronously* —
+    * cancellation is `fiber.cancel.unsafeRunAndForget()` — so this returns without waiting for cleanup. That was equally true before; it is called out here
+    * because "run() returned" does not mean this connection's locks are released.
+    *
+    * The interrupt flag is re-asserted rather than consumed: `unsafeRunTimed` cleared it by catching `InterruptedException`, and swallowing that would hide the
+    * stop request from any caller that checks.
+    */
+  private[bsp] def runToCompletion(program: IO[Unit]): Unit =
+    program.unsafeRunTimed(Long.MaxValue.nanos) match {
+      case Some(()) => ()
+      case None     => Thread.currentThread().interrupt()
+    }
 
   /** Enable debug logging to stderr (for development only) */
   val DebugLogging: Boolean = sys.env.get("BLEEP_BSP_DEBUG").contains("true")


### PR DESCRIPTION
Follow-up to #628, where this was the noise that looked like the bug.

`MultiWorkspaceBspServer.run()` ended in `program.unsafeRunSync()`. That is defined as `unsafeRunTimed(Long.MaxValue.nanos).get`, and `unsafeRunTimed` answers `None` in exactly one reachable case here — the calling thread was interrupted while parked waiting for the result. The other case is the timeout, which `Long.MaxValue` nanoseconds does not reach.

So `.get` turned *"someone asked this connection to stop"* into:

```
[BSP Test Server] Server thread crashed: java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:628)
	at cats.effect.IOPlatform.unsafeRunSync(IOPlatform.scala:42)
	at bleep.bsp.MultiWorkspaceBspServer.run(MultiWorkspaceBspServer.scala:161)
	at bleep.analysis.BspTestHarness.$anonfun$2(BspTestHarness.scala:220)
```

— thrown out of the middle of the cats-effect runtime, with nothing in the trace naming the interrupt that caused it.

Interrupting the owning thread is a legitimate way to stop a connection, and `BspTestHarness` does it in teardown (`:244`). It closes the transport first, so usually the loop has already returned by then and nothing throws. When the interrupt wins that race, a clean shutdown gets reported as a crash.

It is load-dependent rather than constant — **six occurrences in one `ubuntu-22.04-arm` job, zero in the same suite on an idle dev machine.** That is precisely what makes it expensive: it appears under load, which is when real failures appear, and it lands next to them in the log looking far more alarming than they do. It cost an hour during #628.

## Change

`runToCompletion` matches on the `Option` instead of calling `.get`, and re-asserts the interrupt flag that `unsafeRunTimed` cleared, so callers that check it still see the stop request. `unsafeRunTimed` has already cancelled the program by the time it answers `None`, so the `guarantee` still runs — *asynchronously*, as it already did. That last part is now written down in the doc, because "`run()` returned" does not mean this connection's locks are released.

Moved to the companion object as `private[bsp]` so it is directly testable without standing up a whole server.

## Tests

Grepping a suite run is not a usable check for this, since it does not reproduce on an idle machine. The three new tests take the race out of it by interrupting a program guaranteed to still be running:

- `unsafeRunSync turns an interrupt into NoSuchElementException` — guards the **premise**, not our code. If a cats-effect upgrade stops turning an interrupt into `None`, this fails and the reasoning on `runToCompletion` needs revisiting.
- `runToCompletion returns cleanly on interrupt and re-asserts the flag` — the fix.
- `runToCompletion still returns normally when the program completes on its own` — the ordinary path.

All three pass locally; `BspRunIntegrationTest` still 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)