### PR TITLE
telemetry: say why a compile was deferred, and for how long

### DIFF
--- a/.github/scripts/summarise-bsp-metrics.py
+++ b/.github/scripts/summarise-bsp-metrics.py
@@ -67,6 +67,20 @@ def summarise(path: pathlib.Path, rows: list[dict]) -> None:
         for proj, mb in sorted(per.items(), key=lambda kv: -kv[1])[:5]:
             print(f"    {mb:>8} MB  {proj}")
 
+    defers = [r for r in rows if r.get("type") == "admission_defer"] or [r for r in rows if r.get("type") == "heap_pressure_stall"]
+    if defers:
+        # Split by reason. Anything without one is a pre-rename event, which had no reason field and was labelled as pressure regardless of what it was.
+        by_reason = {}
+        for r in defers:
+            by_reason.setdefault(r.get("reason", "unlabelled(pre-rename)"), []).append(r)
+        total_delay = sum(r.get("delay_ms", 0) for r in defers)
+        print(f"\n  admission defers: {len(defers)}, {total_delay/1000:.1f}s of stagger requested")
+        for reason, rs in sorted(by_reason.items()):
+            worst = max((r["heap_used_mb"] / r["heap_max_mb"] for r in rs if r.get("heap_max_mb")), default=0)
+            print(f"    {reason:<24} {len(rs):>4}   worst heap seen {worst:.0%}")
+        if "heap_pressure" not in by_reason and "unlabelled(pre-rename)" not in by_reason:
+            print("    (none were memory — the gate was spreading compiles out, not waiting on heap)")
+
     machine = [r for r in rows if r.get("type") == "machine"]
     if machine:
         samples = len(machine)

--- a/bleep-bsp/src/scala/bleep/bsp/BspMetrics.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspMetrics.scala
@@ -322,11 +322,24 @@ object BspMetrics {
       s"""{"type":"compile_phase","ts":${now()},"project":"${esc(project)}","phase":"${esc(phase)}","tracked_apis":$trackedApis}"""
     )
 
-  def recordHeapPressureStall(project: String, heapUsedMb: Long, heapMaxMb: Long): Unit =
+  /** A compile the admission gate declined to start, and why.
+    *
+    * Was `heap_pressure_stall`, which is what it is called when it fires and what it almost never is. Across two full CI runs, 74 of 74 events were recorded
+    * below the pressure threshold — the server never crossed it at all, peaking at 65-69% of a 4GB heap. Every one was the gate's deliberate stagger, which
+    * defers a project's first admission attempt whenever anything else is compiling, at 5% heap as readily as at 79%. Named and shaped as it was, the data said
+    * "this build spent its time starved of memory" when it meant "these compiles were spread out on purpose".
+    *
+    * `delay_ms` because the previous event carried none: [[HeapPressureGate.decide]] computes the stagger and hands it to the listener, and it stopped there.
+    * The event whose job is explaining a slow build could not say whether 36 defers cost 7 seconds or 70.
+    *
+    * `others_compiling` is what the gate actually consulted (`machine.activeCompiles`), not [[concurrentCompiles]], which counts something else and disagreed —
+    * events recorded `concurrent_compiles: 0` while the gate was deferring precisely because others were compiling.
+    */
+  def recordAdmissionDefer(project: String, reason: String, heapUsedMb: Long, heapMaxMb: Long, delayMs: Long, othersCompiling: Int): Unit =
     writeEvent(
-      s"""{"type":"heap_pressure_stall","ts":${now()},"project":"${esc(
-          project
-        )}","heap_used_mb":$heapUsedMb,"heap_max_mb":$heapMaxMb,"concurrent_compiles":${concurrentCompiles.get()}}"""
+      s"""{"type":"admission_defer","ts":${now()},"project":"${esc(project)}","reason":"${esc(
+          reason
+        )}","heap_used_mb":$heapUsedMb,"heap_max_mb":$heapMaxMb,"delay_ms":$delayMs,"others_compiling":$othersCompiling}"""
     )
 
   def recordOomCrash(threadName: String, message: String): Unit = {

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -1912,7 +1912,18 @@ class MultiWorkspaceBspServer(
           case HeapPressureGate.Decision.Defer(delayMs) =>
             firstRefusedAt.update(m => m.updated(projectName, m.getOrElse(projectName, nowMs))) >>
               IO(listener.onWait(projectName, usage.usedMb, usage.maxMb, delayMs, nowMs)) >>
-              IO(BspMetrics.recordHeapPressureStall(projectName, usage.usedMb.value, usage.maxMb.value)).as(false)
+              IO(
+                BspMetrics.recordAdmissionDefer(
+                  project = projectName,
+                  // The gate defers for two unrelated reasons and only one of them is memory. Recording which is the difference between reading this data and
+                  // misreading it.
+                  reason = if (usage.fraction >= threshold) "heap_pressure" else "stagger",
+                  heapUsedMb = usage.usedMb.value,
+                  heapMaxMb = usage.maxMb.value,
+                  delayMs = delayMs,
+                  othersCompiling = compiling
+                )
+              ).as(false)
         }
       } yield admit
     }


### PR DESCRIPTION
`heap_pressure_stall` is what the event is called when it fires and what it almost never is.

Across two full CI runs — the first with #627's telemetry on every arch — **74 of 74 events were recorded below the pressure threshold.** The server never crossed it at all, peaking at 65–69% of a 4 GB heap against a 0.80 gate.

| | windows | macos-15-intel |
|---|---|---|
| `heap_pressure_stall` events | 36 | 38 |
| at or above the 0.80 threshold | **0** | **0** |
| median heap at the event | 30.9% | 24.2% |
| peak heap over the whole run | 65% | 69% |

Every one was the gate's deliberate stagger. `HeapPressureGate.decide` defers a project's first admission attempt whenever anything else is compiling — at 5% heap as readily as at 79%:

```scala
if (!othersCompiling) Admit
else if (firstRefusedAt.isDefined && usage.fraction < threshold) Admit
else if (deadline reached) Admit
else Defer(stagger)      // first attempt, any heap level
```

That is reasonable behaviour wearing a name that says the build was starved of memory, in an artifact whose whole purpose is telling someone what a slow build was doing. It sent me looking for a leak that did not exist.

## Change

Renamed to `admission_defer`, carrying `reason`, plus two fields it should always have had:

- **`delay_ms`** — `decide` computes the stagger, hands it to the listener, and it stopped there. The event could not say whether 36 defers cost 7 seconds or 70.
- **`others_compiling`** — the value the gate actually consulted (`machine.activeCompiles`). It previously recorded `BspMetrics.concurrentCompiles`, a different counter that disagreed: events read `concurrent_compiles: 0` while the gate was deferring *because* others were compiling.

New summary section:

```
  admission defers: 36, 7.2s of stagger requested
    stagger                     36   worst heap seen 61%
    (none were memory — the gate was spreading compiles out, not waiting on heap)
```

## Compatibility

Artifacts already uploaded carry the old event with no `reason`. The summariser accepts both and labels those `unlabelled(pre-rename)` rather than silently counting them as pressure — verified against the real `bsp-diagnostics-windows-latest` artifact, and against a synthetic new-format file.

## Not changed

The staggering itself. `STARVED` is 0% on both arches and `deepest queue` is 0 on macOS, so admission is not refusing work it could take — the build is dependency-bound there, not capacity-bound. This is a diagnosability fix, not a scheduling one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)