### PR TITLE
ci: surface compile errors and test failures as GitHub Actions annotations

### DIFF
--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
@@ -220,21 +220,39 @@ object BleepBspProtocol {
   /** A compiler diagnostic with severity.
     *
     * `message` is the short/plain error text (from problem.message()). `rendered` is the compiler's rich formatted output including source line and caret (from
-    * problem.rendered()). `path` is the full file path with line:col suffix.
+    * problem.rendered()).
+    *
+    * Position is carried structurally — `path` is the file path alone, with `line`/`column` beside it. It used to be a single `path:line:col` string, which
+    * every consumer then had to take apart again. That is unparseable on Windows: `BuildDiff.diagKey` recovered the file with `p.indexOf(':')`, so
+    * `C:\foo\Bar.scala:12:5` yielded `"C"` and every diagnostic on the platform collapsed into one dedup key. The compiler hands us `line`/`column` as integers
+    * to begin with (see `CompilerError`), so nothing needs flattening — use [[Diagnostic.displayPath]] when a human-readable location is wanted.
     */
   case class Diagnostic(
       severity: DiagnosticSeverity,
       message: String,
       rendered: Option[String],
-      path: Option[String] // full path:line:col for file-associated diagnostics
-  )
+      path: Option[String], // file path only, no location suffix
+      line: Option[Int], // 1-based, absent when the compiler reported no position
+      column: Option[Int] // 1-based
+  ) {
+
+    /** `path:line:col`, omitting whichever trailing parts the compiler did not report. For display only — never parse this back. */
+    def displayPath: Option[String] =
+      path.map { p =>
+        (line, column) match {
+          case (Some(l), Some(c)) => s"$p:$l:$c"
+          case (Some(l), None)    => s"$p:$l"
+          case _                  => p
+        }
+      }
+  }
 
   object Diagnostic {
     implicit val codec: Codec[Diagnostic] = deriveCodec
 
-    def error(message: String): Diagnostic = Diagnostic(DiagnosticSeverity.Error, message, None, None)
-    def warning(message: String): Diagnostic = Diagnostic(DiagnosticSeverity.Warning, message, None, None)
-    def info(message: String): Diagnostic = Diagnostic(DiagnosticSeverity.Info, message, None, None)
+    def error(message: String): Diagnostic = Diagnostic(DiagnosticSeverity.Error, message, None, None, None, None)
+    def warning(message: String): Diagnostic = Diagnostic(DiagnosticSeverity.Warning, message, None, None, None, None)
+    def info(message: String): Diagnostic = Diagnostic(DiagnosticSeverity.Info, message, None, None, None, None)
   }
 
   // ==========================================================================

--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
@@ -225,7 +225,16 @@ object BleepBspProtocol {
     * Deliberately only the suite's own frames: the first frame overall is usually inside the assertion library, and an annotation pointing at someone else's
     * source is worse than no annotation. Absent when the throwable has no frame in the suite (or there is no throwable at all).
     */
-  case class SourceLocation(declaringClass: String, file: String, line: Int)
+  case class SourceLocation(
+      declaringClass: String,
+      file: String,
+      line: Int,
+      /** Build-relative source path, resolved server-side from zinc's analysis (`ZincSourceLookup`). Absent when analysis cannot answer — no analysis yet, or a
+        * language that does not produce one, which today means Kotlin. Consumers that need a path fall back to `declaringClass` + `file`, which locate the
+        * failure for a human but not precisely enough to annotate a line in a diff.
+        */
+      path: Option[String]
+  )
 
   object SourceLocation {
     implicit val codec: Codec[SourceLocation] = deriveCodec

--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepBspProtocol.scala
@@ -217,6 +217,20 @@ object BleepBspProtocol {
   // Shared types
   // ==========================================================================
 
+  /** Where a test failed, recovered from the first stack frame belonging to the suite class itself.
+    *
+    * `file` is the bare file name the JVM records in the class file (`MyTest.scala`), not a path — `declaringClass` supplies the package, and only the client
+    * knows the project's source directories, so turning the pair into a real path happens there (see `TestFailure.resolvedPath`).
+    *
+    * Deliberately only the suite's own frames: the first frame overall is usually inside the assertion library, and an annotation pointing at someone else's
+    * source is worse than no annotation. Absent when the throwable has no frame in the suite (or there is no throwable at all).
+    */
+  case class SourceLocation(declaringClass: String, file: String, line: Int)
+
+  object SourceLocation {
+    implicit val codec: Codec[SourceLocation] = deriveCodec
+  }
+
   /** A compiler diagnostic with severity.
     *
     * `message` is the short/plain error text (from problem.message()). `rendered` is the compiler's rich formatted output including source line and caret (from
@@ -447,7 +461,8 @@ object BleepBspProtocol {
         durationMs: Long,
         message: Option[String],
         throwable: Option[String],
-        timestamp: Long
+        timestamp: Long,
+        location: Option[SourceLocation]
     ) extends Event
 
     case class SuiteFinished(

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BuildDiffTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BuildDiffTest.scala
@@ -22,14 +22,17 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
   private def sn(name: String): SuiteName = SuiteName(name)
   private def tn(name: String): TestName = TestName(name)
 
-  private def diag(severity: DiagnosticSeverity, message: String, path: String): BleepBspProtocol.Diagnostic =
-    BleepBspProtocol.Diagnostic(severity = severity, message = message, rendered = None, path = Some(path))
+  private def diag(severity: DiagnosticSeverity, message: String, file: String, line: Option[Int], column: Option[Int]): BleepBspProtocol.Diagnostic =
+    BleepBspProtocol.Diagnostic(severity = severity, message = message, rendered = None, path = Some(file), line = line, column = column)
 
-  private def errorDiag(message: String, path: String): BleepBspProtocol.Diagnostic =
-    diag(DiagnosticSeverity.Error, message, path)
+  private def errorDiag(message: String, file: String): BleepBspProtocol.Diagnostic =
+    diag(DiagnosticSeverity.Error, message, file, None, None)
 
-  private def warningDiag(message: String, path: String): BleepBspProtocol.Diagnostic =
-    diag(DiagnosticSeverity.Warning, message, path)
+  private def errorDiagAt(message: String, file: String, line: Int, column: Int): BleepBspProtocol.Diagnostic =
+    diag(DiagnosticSeverity.Error, message, file, Some(line), Some(column))
+
+  private def warningDiagAt(message: String, file: String, line: Int, column: Int): BleepBspProtocol.Diagnostic =
+    diag(DiagnosticSeverity.Warning, message, file, Some(line), Some(column))
 
   private def testFinished(project: CrossProjectName, suite: SuiteName, test: TestName, status: TestStatus): BuildEvent.TestFinished =
     BuildEvent.TestFinished(
@@ -55,7 +58,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
         CompileStatus.Success,
         durationMs = 100,
         timestamp = ts + 1,
-        diagnostics = List(warningDiag("unused import", "Foo.scala:10:5")),
+        diagnostics = List(warningDiagAt("unused import", "Foo.scala", 10, 5)),
         skippedBecause = None
       ),
       BuildEvent.CompileStarted(cpn("proj-b"), ts + 2),
@@ -64,7 +67,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
         CompileStatus.Failed,
         durationMs = 200,
         timestamp = ts + 3,
-        diagnostics = List(errorDiag("type mismatch", "Bar.scala:20:3")),
+        diagnostics = List(errorDiagAt("type mismatch", "Bar.scala", 20, 3)),
         skippedBecause = None
       )
     )
@@ -114,7 +117,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
         project = cpn("proj-a"),
         status = CompileStatus.Success,
         durationMs = 100,
-        diagnostics = List(warningDiag("unused", "A.scala:1:1")),
+        diagnostics = List(warningDiagAt("unused", "A.scala", 1, 1)),
         skippedBecause = None,
         timestamp = ts
       ),
@@ -160,8 +163,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
 
   test("diffCompile: new errors where none existed before") {
     val current = List(
-      errorDiag("type mismatch", "Foo.scala:10:5"),
-      errorDiag("not found: value x", "Bar.scala:20:3")
+      errorDiagAt("type mismatch", "Foo.scala", 10, 5),
+      errorDiagAt("not found: value x", "Bar.scala", 20, 3)
     )
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, current, Nil, 200)
@@ -173,8 +176,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
 
   test("diffCompile: all errors fixed") {
     val previous = List(
-      errorDiag("type mismatch", "Foo.scala:10:5"),
-      errorDiag("not found: value x", "Bar.scala:20:3")
+      errorDiagAt("type mismatch", "Foo.scala", 10, 5),
+      errorDiagAt("not found: value x", "Bar.scala", 20, 3)
     )
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Success, Nil, previous, 100)
@@ -186,13 +189,13 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
 
   test("diffCompile: some errors fixed, some new, some remaining") {
     val previous = List(
-      errorDiag("type mismatch", "Foo.scala:10:5"),
-      errorDiag("not found: value x", "Bar.scala:20:3"),
-      errorDiag("missing argument", "Baz.scala:5:1")
+      errorDiagAt("type mismatch", "Foo.scala", 10, 5),
+      errorDiagAt("not found: value x", "Bar.scala", 20, 3),
+      errorDiagAt("missing argument", "Baz.scala", 5, 1)
     )
     val current = List(
-      errorDiag("not found: value x", "Bar.scala:25:3"), // same file+message, different line — matches
-      errorDiag("implicit not found", "Qux.scala:1:1") // new error
+      errorDiagAt("not found: value x", "Bar.scala", 25, 3), // same file+message, different line — matches
+      errorDiagAt("implicit not found", "Qux.scala", 1, 1) // new error
     )
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, current, previous, 300)
@@ -203,8 +206,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("diffCompile: line number change does not affect matching") {
-    val previous = List(errorDiag("type mismatch", "Foo.scala:10:5"))
-    val current = List(errorDiag("type mismatch", "Foo.scala:42:8"))
+    val previous = List(errorDiagAt("type mismatch", "Foo.scala", 10, 5))
+    val current = List(errorDiagAt("type mismatch", "Foo.scala", 42, 8))
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, current, previous, 100)
 
@@ -216,12 +219,12 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
 
   test("diffCompile: warnings are tracked separately from errors") {
     val previous = List(
-      warningDiag("unused import", "A.scala:1:1"),
-      errorDiag("type mismatch", "B.scala:2:1")
+      warningDiagAt("unused import", "A.scala", 1, 1),
+      errorDiagAt("type mismatch", "B.scala", 2, 1)
     )
     val current = List(
-      warningDiag("unused import", "A.scala:1:1"),
-      warningDiag("deprecation", "C.scala:3:1")
+      warningDiagAt("unused import", "A.scala", 1, 1),
+      warningDiagAt("deprecation", "C.scala", 3, 1)
     )
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Success, current, previous, 100)
@@ -235,7 +238,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("diffCompile: diagnostics without path are matched by message only") {
-    val noDiag = BleepBspProtocol.Diagnostic(severity = DiagnosticSeverity.Error, message = "build error", rendered = None, path = None)
+    val noDiag =
+      BleepBspProtocol.Diagnostic(severity = DiagnosticSeverity.Error, message = "build error", rendered = None, path = None, line = None, column = None)
     val previous = List(noDiag)
     val current = List(noDiag)
 
@@ -541,8 +545,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
   // ==========================================================================
 
   test("diffCompile: same file different line numbers treated as same diagnostic") {
-    val prev = List(errorDiag("type mismatch", "src/Foo.scala:10:5"))
-    val curr = List(errorDiag("type mismatch", "src/Foo.scala:99:1"))
+    val prev = List(errorDiagAt("type mismatch", "src/Foo.scala", 10, 5))
+    val curr = List(errorDiagAt("type mismatch", "src/Foo.scala", 99, 1))
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, curr, prev, 100)
     // Line stripped — same file + same message = same error
@@ -551,12 +555,24 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("diffCompile: same message different file treated as different diagnostic") {
-    val prev = List(errorDiag("type mismatch", "src/Foo.scala:10:5"))
-    val curr = List(errorDiag("type mismatch", "src/Bar.scala:10:5"))
+    val prev = List(errorDiagAt("type mismatch", "src/Foo.scala", 10, 5))
+    val curr = List(errorDiagAt("type mismatch", "src/Bar.scala", 10, 5))
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, curr, prev, 100)
     diff.newErrors shouldBe 1 // Bar.scala error is new
     diff.fixedErrors shouldBe 1 // Foo.scala error was fixed
+  }
+
+  test("diffCompile: windows drive letters do not collapse distinct files into one diagnostic") {
+    // Regression: position used to be flattened into the path as `file:line:col`, and this diff recovered the file with
+    // `p.indexOf(':')`. On Windows that cut at the drive colon, so every path became "C" and unrelated files shared a
+    // dedup key — a fixed error in one file would cancel out a new error in another, on every Windows build.
+    val prev = List(errorDiagAt("type mismatch", "C:\\proj\\src\\Foo.scala", 10, 5))
+    val curr = List(errorDiagAt("type mismatch", "C:\\proj\\src\\Bar.scala", 10, 5))
+
+    val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, curr, prev, 100)
+    diff.newErrors shouldBe 1
+    diff.fixedErrors shouldBe 1
   }
 
   test("diffCompile: path without line:col is preserved as-is") {
@@ -574,8 +590,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
 
   test("diffCompile: two identical errors same file are both counted as new") {
     val current = List(
-      errorDiag("Found: Int, Required: String", "Foo.scala:10:5"),
-      errorDiag("Found: Int, Required: String", "Foo.scala:20:5") // same file+message — counted via multiset
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 10, 5),
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 20, 5) // same file+message — counted via multiset
     )
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, current, Nil, 100)
@@ -585,11 +601,11 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
 
   test("diffCompile: fixing one of two identical errors shows 1 fixed") {
     val previous = List(
-      errorDiag("Found: Int, Required: String", "Foo.scala:10:5"),
-      errorDiag("Found: Int, Required: String", "Foo.scala:20:5")
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 10, 5),
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 20, 5)
     )
     val current = List(
-      errorDiag("Found: Int, Required: String", "Foo.scala:10:5")
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 10, 5)
     )
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, current, previous, 100)
@@ -600,13 +616,13 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
 
   test("diffCompile: adding a third identical error shows 1 new") {
     val previous = List(
-      errorDiag("Found: Int, Required: String", "Foo.scala:10:5"),
-      errorDiag("Found: Int, Required: String", "Foo.scala:20:5")
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 10, 5),
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 20, 5)
     )
     val current = List(
-      errorDiag("Found: Int, Required: String", "Foo.scala:10:5"),
-      errorDiag("Found: Int, Required: String", "Foo.scala:20:5"),
-      errorDiag("Found: Int, Required: String", "Foo.scala:30:5")
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 10, 5),
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 20, 5),
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 30, 5)
     )
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, current, previous, 100)
@@ -617,8 +633,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
 
   test("diffCompile: different messages same file are distinct") {
     val current = List(
-      errorDiag("Found: Int, Required: String", "Foo.scala:10:5"),
-      errorDiag("Found: Boolean, Required: List[Int]", "Foo.scala:20:5")
+      errorDiagAt("Found: Int, Required: String", "Foo.scala", 10, 5),
+      errorDiagAt("Found: Boolean, Required: List[Int]", "Foo.scala", 20, 5)
     )
 
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Failed, current, Nil, 100)
@@ -663,7 +679,7 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("diffCompile: skipped status with fixed errors reports correctly") {
-    val previous = List(errorDiag("missing import", "A.scala:1:1"))
+    val previous = List(errorDiagAt("missing import", "A.scala", 1, 1))
     val diff = BuildDiff.diffCompile(cpn("proj"), CompileStatus.Skipped, Nil, previous, 0)
 
     diff.status shouldBe CompileStatus.Skipped

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BuildDiffTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BuildDiffTest.scala
@@ -43,7 +43,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
       durationMs = 10,
       message = None,
       throwable = None,
-      timestamp = ts
+      timestamp = ts,
+      location = None
     )
 
   // ==========================================================================
@@ -129,7 +130,8 @@ class BuildDiffTest extends AnyFunSuite with Matchers {
         durationMs = 50,
         message = None,
         throwable = None,
-        timestamp = ts + 1
+        timestamp = ts + 1,
+        location = None
       )
     )
 

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BuildStateReducerTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BuildStateReducerTest.scala
@@ -55,7 +55,8 @@ class BuildStateReducerTest extends AnyFunSuite with Matchers {
         durationMs = 50,
         message = Some("assertion failed"),
         throwable = None,
-        ts + 2
+        ts + 2,
+        location = None
       ),
       BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), SuiteOutcome.Executed(0, 1, 0, 0), 100, ts + 3)
     )
@@ -72,13 +73,13 @@ class BuildStateReducerTest extends AnyFunSuite with Matchers {
       BuildEvent.SuiteStarted(cpn("proj"), sn("com.example.MySuite"), ts),
       BuildEvent.TestStarted(cpn("proj"), sn("com.example.MySuite"), tn("test1"), ts + 1),
       BuildEvent
-        .TestFinished(cpn("proj"), sn("com.example.MySuite"), tn("test1"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 2),
+        .TestFinished(cpn("proj"), sn("com.example.MySuite"), tn("test1"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 2, None),
       BuildEvent.TestStarted(cpn("proj"), sn("com.example.MySuite"), tn("test2"), ts + 3),
       BuildEvent
-        .TestFinished(cpn("proj"), sn("com.example.MySuite"), tn("test2"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 4),
+        .TestFinished(cpn("proj"), sn("com.example.MySuite"), tn("test2"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 4, None),
       BuildEvent.TestStarted(cpn("proj"), sn("com.example.MySuite"), tn("test3"), ts + 5),
       BuildEvent
-        .TestFinished(cpn("proj"), sn("com.example.MySuite"), tn("test3"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 6),
+        .TestFinished(cpn("proj"), sn("com.example.MySuite"), tn("test3"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 6, None),
       BuildEvent.SuiteFinished(cpn("proj"), sn("com.example.MySuite"), SuiteOutcome.Executed(3, 0, 0, 0), 100, ts + 7)
     )
 
@@ -178,7 +179,7 @@ class BuildStateReducerTest extends AnyFunSuite with Matchers {
     val stateBeforeComplete = reduce(
       BuildEvent.SuiteStarted(cpn("proj"), sn("suite1"), ts),
       BuildEvent.TestStarted(cpn("proj"), sn("suite1"), tn("test1"), ts + 1),
-      BuildEvent.TestFinished(cpn("proj"), sn("suite1"), tn("test1"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 2),
+      BuildEvent.TestFinished(cpn("proj"), sn("suite1"), tn("test1"), TestStatus.Passed, durationMs = 10, message = None, throwable = None, ts + 2, None),
       BuildEvent.SuiteFinished(cpn("proj"), sn("suite1"), SuiteOutcome.Executed(1, 0, 0, 0), 50, ts + 3)
     )
 

--- a/bleep-bsp-tests/src/scala/bleep/analysis/JvmTestRunnerIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/JvmTestRunnerIntegrationTest.scala
@@ -63,7 +63,8 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
         status = "failed",
         durationMs = 123,
         message = Some("expected 1 but got 2"),
-        throwable = Some("java.lang.AssertionError: expected 1 but got 2\n\tat MySuite.test(MySuite.scala:10)")
+        throwable = Some("java.lang.AssertionError: expected 1 but got 2\n\tat MySuite.test(MySuite.scala:10)"),
+        location = None
       )
       val encoded = TestProtocol.encodeResponse(response)
       val decoded = TestProtocol.decodeResponse(encoded)
@@ -82,7 +83,8 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
         status = "passed",
         durationMs = 5,
         message = None,
-        throwable = None
+        throwable = None,
+        location = None
       )
       val encoded = TestProtocol.encodeResponse(response)
       val decoded = TestProtocol.decodeResponse(encoded)
@@ -349,7 +351,8 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
         durationMs = 150,
         message = Some("assertion failed: expected true"),
         throwable = Some("java.lang.AssertionError"),
-        timestamp = ts
+        timestamp = ts,
+        location = None
       )
 
       event.status shouldBe TestStatus.Failed
@@ -448,7 +451,8 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
         status = "error",
         durationMs = 10,
         message = Some("boom"),
-        throwable = Some(stackTrace)
+        throwable = Some(stackTrace),
+        location = None
       )
       val encoded = TestProtocol.encodeResponse(response)
       val decoded = TestProtocol.decodeResponse(encoded)
@@ -472,7 +476,8 @@ class JvmTestRunnerIntegrationTest extends AnyFunSuite with Matchers with TimeLi
           status = status,
           durationMs = 10,
           message = None,
-          throwable = None
+          throwable = None,
+          location = None
         )
         val encoded = TestProtocol.encodeResponse(response)
         val decoded = TestProtocol.decodeResponse(encoded)

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ZincSourceLookupTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ZincSourceLookupTest.scala
@@ -1,0 +1,44 @@
+package bleep.analysis
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Path}
+
+class ZincSourceLookupTest extends AnyFunSuite with Matchers {
+
+  test("topLevelClassName reduces a frame's class to what zinc actually records") {
+    // zinc stores top-level names only, so these all have to collapse or the lookup silently misses
+    ZincSourceLookup.topLevelClassName("bleep.GithubActionsTest$$anon$1") shouldBe "bleep.GithubActionsTest"
+    ZincSourceLookup.topLevelClassName("bleep.Outer$Inner") shouldBe "bleep.Outer"
+    ZincSourceLookup.topLevelClassName("bleep.Foo$") shouldBe "bleep.Foo" // scala object
+    ZincSourceLookup.topLevelClassName("bleep.Plain") shouldBe "bleep.Plain"
+  }
+
+  /** Reads bleep's own analysis rather than a fixture: the two things worth guarding — that the marker is what we think and that anonymous classes need
+    * truncating — are properties of what zinc really writes, and a hand-built Relations would just re-encode my assumptions.
+    */
+  test("resolves a class to its build-relative source, straight out of a real analysis") {
+    val analysisFile = Path.of(".bleep/projects/bleep-tests/builds/normal/.zinc/analysis.zip").toAbsolutePath
+    assume(Files.exists(analysisFile), s"no analysis at $analysisFile — run `bleep compile bleep-tests` first")
+
+    val store = sbt.internal.inc.consistent.ConsistentFileAnalysisStore.binary(
+      analysisFile.toFile,
+      ZincBridge.analysisMappers(analysisFile),
+      reproducible = true,
+      parallelism = 4
+    )
+    val analysis = store.get().get().getAnalysis
+
+    // build-relative, no machine-specific prefix, and no ${BASE} left in it
+    ZincSourceLookup.relativeSourceFor(analysis, "bleep.GithubActionsTest") shouldBe
+      Some("bleep-tests/src/scala/bleep/GithubActionsTest.scala")
+
+    // the frame a ScalaTest assertion failure actually produces
+    ZincSourceLookup.relativeSourceFor(analysis, "bleep.GithubActionsTest$$anon$1") shouldBe
+      Some("bleep-tests/src/scala/bleep/GithubActionsTest.scala")
+
+    // a class zinc never compiled resolves to nothing rather than to a plausible-looking wrong file
+    ZincSourceLookup.relativeSourceFor(analysis, "com.example.NotInThisProject") shouldBe None
+  }
+}

--- a/bleep-bsp/src/scala/bleep/analysis/ZincSourceLookup.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ZincSourceLookup.scala
@@ -1,0 +1,89 @@
+package bleep.analysis
+
+import xsbti.compile.CompileAnalysis
+
+import java.nio.file.{Files, Path}
+
+/** Resolves a JVM class name to the source file that defines it, out of zinc's analysis.
+  *
+  * Test failures arrive as a stack frame: a class name, a bare file name (`MyTest.scala`) and a line. The bare name is all the JVM has — it comes from the
+  * class file's `SourceFile` attribute, which by specification holds a file name and never a path — so recovering a usable path means asking something that
+  * recorded where the source actually was. Zinc's `Relations` did exactly that at compile time.
+  *
+  * The alternative was reconstructing a path from the class's package plus the file name and searching the project's source roots. That guesses, and it guesses
+  * wrong for any file whose name differs from its class, for several roots holding the same relative path, and for generated sources.
+  *
+  * Only Scala and Java-through-zinc are covered. Kotlin compiles through kotlinc, which produces no zinc analysis, so those failures keep the bare file name.
+  */
+object ZincSourceLookup {
+
+  /** Zinc records only top-level class names, so a frame inside a nested, inner or anonymous class has to be reduced to its enclosing top-level class before it
+    * will match. Verified against a real analysis: `definesClass("bleep.GithubActionsTest$$anon$1")` is empty while `definesClass("bleep.GithubActionsTest")`
+    * resolves — and anonymous classes are where most assertion failures are raised, so skipping this step would leave nearly every ScalaTest failure
+    * unresolved.
+    *
+    * Truncating at the first `$` also handles a Scala object's binary name (`bleep.Foo$` -> `bleep.Foo`). A class with a literal `$` in its own name resolves
+    * to nothing rather than to the wrong file.
+    */
+  def topLevelClassName(binaryClassName: String): String =
+    binaryClassName.indexOf('$') match {
+      case -1  => binaryClassName
+      case idx => binaryClassName.substring(0, idx)
+    }
+
+  /** The defining source as a build-relative path, or None when analysis does not know the class.
+    *
+    * Build-relative rather than absolute because that is how zinc stores it: bleep writes analysis through portable mappers, so source ids read back as
+    * `${BASE}/bleep-tests/src/scala/bleep/Foo.scala` (see `PortableAnalysisMappers.BaseMarker`). Stripping the marker leaves precisely the repo-relative form a
+    * GitHub annotation needs, with no machine-specific prefix ever entering the protocol.
+    *
+    * A source recorded outside the build directory keeps no `${BASE}` prefix and yields None: it cannot be expressed relative to the repository, and pointing
+    * an annotation at an absolute path on a runner would attach it to nothing.
+    */
+  def relativeSourceFor(analysis: CompileAnalysis, binaryClassName: String): Option[String] = {
+    val relations = analysis.asInstanceOf[sbt.internal.inc.Analysis].relations
+    // A class name maps to one source in every layout zinc supports; `headOption` over a sorted set keeps the answer stable if that ever stops holding.
+    relations
+      .definesClass(topLevelClassName(binaryClassName))
+      .toList
+      .map(_.id())
+      .sorted
+      .headOption
+      .flatMap(stripBaseMarker)
+  }
+
+  /** As [[relativeSourceFor]], but reading the project's analysis from disk through the shared cache.
+    *
+    * Goes through [[AnalysisCache]] because a failing suite reports one location per failing test: a run with fifty failures in one project would otherwise
+    * deserialise the same multi-megabyte analysis fifty times, and the cache is keyed by file and mtime so a stale entry cannot outlive a recompile.
+    *
+    * Returns None for anything that is merely unknown — no analysis yet, an unreadable or half-written file, a class zinc never saw. This decorates output the
+    * user already has, so a failure to resolve costs a bare file name, and letting it throw would take the surrounding test report down with it.
+    */
+  def relativeSourceForProject(analyses: AnalysisCache.Ref, analysisFile: Path, binaryClassName: String): Option[String] =
+    if (!Files.exists(analysisFile)) None
+    else
+      try {
+        val mtime = Files.getLastModifiedTime(analysisFile).toMillis
+        val analysis = analyses.get(analysisFile, mtime).orElse {
+          val store = sbt.internal.inc.consistent.ConsistentFileAnalysisStore.binary(
+            analysisFile.toFile,
+            ZincBridge.analysisMappers(analysisFile),
+            reproducible = true,
+            parallelism = AnalysisReadParallelism
+          )
+          Option(store.get().orElse(null)).map(contents => analyses.put(analysisFile, mtime, contents.getAnalysis))
+        }
+        analysis.flatMap(a => relativeSourceFor(a, binaryClassName))
+      } catch {
+        case _: Exception => None
+      }
+
+  /** Reading here is off the hot path — one file, after the tests have already run — so it does not need the compile path's wider fan-out. */
+  private val AnalysisReadParallelism = 4
+
+  private val BasePrefix: String = PortableAnalysisMappers.BaseMarker + "/"
+
+  private def stripBaseMarker(id: String): Option[String] =
+    if (id.startsWith(BasePrefix)) Some(id.substring(BasePrefix.length)) else None
+}

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -2987,7 +2987,7 @@ class MultiWorkspaceBspServer(
       def onTestFinished(suite: String, test: String, status: bleep.bsp.protocol.TestStatus, durationMs: Long, message: Option[String]): Unit =
         dispatcher.unsafeRunSync(
           eventQueue.offer(
-            Some(TaskDag.DagEvent.TestFinished(project, SuiteName(suite), TestName(test), status, durationMs, message, None, System.currentTimeMillis()))
+            Some(TaskDag.DagEvent.TestFinished(project, SuiteName(suite), TestName(test), status, durationMs, message, None, System.currentTimeMillis(), None))
           )
         )
       def onSuiteStarted(suite: String): Unit = ()
@@ -3597,12 +3597,12 @@ class MultiWorkspaceBspServer(
             val protocolEvent = BleepBspProtocol.Event.TestStarted(project, suite, test, timestamp)
             IO(sendTestEvent(originId, s"test:$project:$suite", protocolEvent))
 
-          case TaskDag.DagEvent.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp) =>
+          case TaskDag.DagEvent.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp, location) =>
             IO(
               sendTestEvent(
                 originId,
                 s"test:$project:$suite",
-                BleepBspProtocol.Event.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp)
+                BleepBspProtocol.Event.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp, location)
               )
             )
 

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -3709,20 +3709,15 @@ class MultiWorkspaceBspServer(
 
   /** Convert a compiler error to a protocol Diagnostic preserving severity */
   private def toDiagnostic(error: CompilerError): BleepBspProtocol.Diagnostic = {
-    val pathStr = error.path.map { p =>
-      val locPart = (error.line, error.column) match {
-        case (0, 0) => ""
-        case (l, 0) => s":$l"
-        case (l, c) => s":$l:$c"
-      }
-      s"$p$locPart"
-    }
+    // 0 is the compiler's "no position reported" sentinel for both, so it becomes None rather than a bogus line 0.
+    val line = Option(error.line).filter(_ > 0)
+    val column = Option(error.column).filter(_ > 0)
     val severity = error.severity match {
       case CompilerError.Severity.Error   => bleep.bsp.protocol.DiagnosticSeverity.Error
       case CompilerError.Severity.Warning => bleep.bsp.protocol.DiagnosticSeverity.Warning
       case CompilerError.Severity.Info    => bleep.bsp.protocol.DiagnosticSeverity.Info
     }
-    BleepBspProtocol.Diagnostic(severity, error.message, error.rendered, pathStr)
+    BleepBspProtocol.Diagnostic(severity, error.message, error.rendered, error.path.map(_.toString), line, column)
   }
 
   private val sendEventCounter = new java.util.concurrent.atomic.AtomicInteger(0)

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -2273,6 +2273,12 @@ class MultiWorkspaceBspServer(
                       environment = testEnv,
                       workingDirectory = projectDir
                     ),
+                    resolveSourcePath = className =>
+                      bleep.analysis.ZincSourceLookup.relativeSourceForProject(
+                        bleep.analysis.AnalysisCache.Ref(analysisCache, started.buildPaths.workspaceKey),
+                        started.buildPaths.variantBuildDir(testTask.project).resolve(".zinc").resolve("analysis.zip"),
+                        className
+                      ),
                     killSignal = taskKillSignal
                   )
               }

--- a/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
@@ -373,7 +373,8 @@ object TaskDag {
         durationMs: Long,
         message: Option[String],
         throwable: Option[String],
-        timestamp: Long
+        timestamp: Long,
+        location: Option[bleep.bsp.protocol.BleepBspProtocol.SourceLocation]
     ) extends DagEvent
 
     // Discovery events

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -58,6 +58,9 @@ object TestRunner {
     * @return
     *   Success or Failure result
     */
+  /** `resolveSourcePath` turns a failing frame's declaring class into a build-relative source path. Passed as a function rather than as the analysis machinery
+    * itself so this stays a process runner: the caller knows where the project's analysis lives, and this only knows it wants a path.
+    */
   def runSuite(
       project: CrossProjectName,
       suiteName: String,
@@ -66,6 +69,7 @@ object TestRunner {
       pool: JvmPool,
       eventQueue: Queue[IO, Option[TaskDag.DagEvent]],
       options: Options,
+      resolveSourcePath: String => Option[String],
       killSignal: Deferred[IO, KillReason]
   ): IO[TaskDag.TaskResult] = {
     val runnerClass = "bleep.testing.runner.ForkedTestRunner"
@@ -79,6 +83,7 @@ object TestRunner {
         eventQueue = eventQueue,
         testArgs = options.testArgs,
         idleTimeout = options.idleTimeout,
+        resolveSourcePath = resolveSourcePath,
         killSignal = killSignal
       )
     }
@@ -96,6 +101,7 @@ object TestRunner {
       eventQueue: Queue[IO, Option[TaskDag.DagEvent]],
       testArgs: List[String],
       idleTimeout: FiniteDuration,
+      resolveSourcePath: String => Option[String],
       killSignal: Deferred[IO, KillReason]
   ): IO[TaskDag.TaskResult] = {
     def now: IO[Long] = IO.realTime.map(_.toMillis)
@@ -145,7 +151,8 @@ object TestRunner {
                         message = message,
                         throwable = throwable,
                         timestamp = ts,
-                        location = location
+                        // The forked JVM knows the class and the bare file name; only this side can say where that source lives.
+                        location = location.map(loc => loc.copy(path = resolveSourcePath(loc.declaringClass)))
                       )
                     )
                 }

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -126,7 +126,7 @@ object TestRunner {
               case TestProtocol.TestResponse.TestStarted(_, test) =>
                 now.flatMap(ts => lastActivityAt.set(ts) >> emit(TaskDag.DagEvent.TestStarted(project, SuiteName(suiteName), TestName(test), ts)))
 
-              case TestProtocol.TestResponse.TestFinished(_, test, statusStr, durationMs, message, throwable) =>
+              case TestProtocol.TestResponse.TestFinished(_, test, statusStr, durationMs, message, throwable, location) =>
                 val status = TestStatus.fromString(statusStr)
                 val updateCount =
                   if (status == TestStatus.Passed) passedCount.update(_ + 1)
@@ -144,7 +144,8 @@ object TestRunner {
                         durationMs = durationMs,
                         message = message,
                         throwable = throwable,
-                        timestamp = ts
+                        timestamp = ts,
+                        location = location
                       )
                     )
                 }

--- a/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
@@ -1399,6 +1399,8 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
           fields += "message" -> Json.fromString(stripAnsi(d.message))
           d.rendered.foreach(r => fields += "rendered" -> Json.fromString(stripAnsi(r)))
           d.path.foreach(p => fields += "path" -> Json.fromString(p))
+          d.line.foreach(l => fields += "line" -> Json.fromInt(l))
+          d.column.foreach(c => fields += "column" -> Json.fromInt(c))
           Json.obj(fields.result()*)
         }
         val totalDiagnostics = allDiagnosticJsons.size
@@ -1456,6 +1458,8 @@ class BleepMcpServer(initialStarted: Started) extends McpServer[IO] {
             val df = List.newBuilder[(String, Json)]
             df += "message" -> Json.fromString(stripAnsi(d.message))
             d.path.foreach(p => df += "path" -> Json.fromString(p))
+            d.line.foreach(l => df += "line" -> Json.fromInt(l))
+            d.column.foreach(c => df += "column" -> Json.fromInt(c))
             Json.obj(df.result()*)
           }
           fields += "topErrors" -> Json.arr(topErrors*)

--- a/bleep-cli/src/scala-3/bleep/mcp/McpEventFilter.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/McpEventFilter.scala
@@ -37,6 +37,8 @@ object McpEventFilter {
               diagFields += "message" -> Json.fromString(stripAnsi(d.message))
               d.rendered.foreach(r => diagFields += "rendered" -> Json.fromString(stripAnsi(r)))
               d.path.foreach(p => diagFields += "path" -> Json.fromString(p))
+              d.line.foreach(l => diagFields += "line" -> Json.fromInt(l))
+              d.column.foreach(c => diagFields += "column" -> Json.fromInt(c))
               Json.obj(diagFields.result()*)
             }*
           )

--- a/bleep-core/src/scala/bleep/GithubActions.scala
+++ b/bleep-core/src/scala/bleep/GithubActions.scala
@@ -1,0 +1,98 @@
+package bleep
+
+import bleep.bsp.protocol.{BleepBspProtocol, DiagnosticSeverity}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, StandardOpenOption}
+
+/** Emits the two things GitHub Actions reads out of a job: workflow commands on stdout, and markdown appended to `$GITHUB_STEP_SUMMARY`.
+  *
+  * Both are plain text protocols, so there is no dependency and nothing to configure — a run outside Actions produces neither. Detection is `GITHUB_ACTIONS`,
+  * which the runner sets to `true` for every step, exactly as `@actions/core` does it.
+  *
+  * @param annotationsEnabled
+  *   whether `::error`/`::warning` annotations are emitted
+  * @param stepSummaryFile
+  *   `$GITHUB_STEP_SUMMARY` if the runner provided one
+  */
+case class GithubActions(annotationsEnabled: Boolean, stepSummaryFile: Option[Path]) {
+
+  /** Annotate a source location so the diagnostic shows up inline on the pull request diff.
+    *
+    * `file` must be relative to the repository root — the runner resolves it against the workspace, and an absolute path silently fails to attach to any line.
+    * See [[GithubActions.relativize]].
+    */
+  def annotate(severity: DiagnosticSeverity, file: Option[String], line: Option[Int], column: Option[Int], title: String, message: String): Unit =
+    if (annotationsEnabled) {
+      val command = severity match {
+        case DiagnosticSeverity.Error   => "error"
+        case DiagnosticSeverity.Warning => "warning"
+        case DiagnosticSeverity.Info    => "notice"
+      }
+      val props = List(
+        file.map(f => "file" -> f),
+        line.map(l => "line" -> l.toString),
+        column.map(c => "col" -> c.toString),
+        Some("title" -> title)
+      ).flatten
+        .map { case (k, v) => s"$k=${GithubActions.escapeProperty(v)}" }
+        .mkString(",")
+
+      println(s"::$command $props::${GithubActions.escapeData(message)}")
+    }
+
+  /** Append a markdown section to the job summary, rendered on the run page. No-op when the runner did not provide the file. */
+  def appendStepSummary(markdown: String): Unit =
+    stepSummaryFile.foreach { file =>
+      val bytes = (markdown.stripLineEnd + "\n").getBytes(StandardCharsets.UTF_8)
+      Files.write(file, bytes, StandardOpenOption.CREATE, StandardOpenOption.APPEND).discard()
+    }
+}
+
+object GithubActions {
+
+  /** `GITHUB_ACTIONS=true` is set for every step the runner executes, and is what `@actions/core` keys off. */
+  def fromEnv(env: Map[String, String]): GithubActions =
+    GithubActions(
+      annotationsEnabled = env.get("GITHUB_ACTIONS").contains("true"),
+      stepSummaryFile = env.get("GITHUB_STEP_SUMMARY").filter(_.nonEmpty).map(Path.of(_))
+    )
+
+  val disabled: GithubActions = GithubActions(annotationsEnabled = false, stepSummaryFile = None)
+
+  /** Annotations only attach to a line when the path is relative to the repo root. Diagnostics carry absolute paths, so strip the workspace prefix; a file
+    * outside the build (a dependency source, say) has no place on the diff and loses its position rather than pointing at the wrong file.
+    */
+  def relativize(buildDir: Path, path: String): Option[String] =
+    try {
+      val abs = Path.of(path).toAbsolutePath.normalize()
+      val base = buildDir.toAbsolutePath.normalize()
+      if (abs.startsWith(base)) Some(base.relativize(abs).toString.replace('\\', '/')) else None
+    } catch {
+      // Path.of throws on strings the platform cannot parse as a path. A diagnostic is not worth failing a build over, and the
+      // annotation is decoration on top of output the user already has.
+      case _: java.nio.file.InvalidPathException => None
+    }
+
+  /** GitHub caps how many annotations it renders per level per step (10 at time of writing); the rest reach the log but never the diff. So the budget is spent
+    * worst-first: errors before warnings, and positioned diagnostics before unpositioned ones, since an annotation with no file cannot appear inline anyway.
+    */
+  val maxAnnotationsPerLevel: Int = 10
+
+  def rank(d: BleepBspProtocol.Diagnostic): (Int, Int) = {
+    val bySeverity = d.severity match {
+      case DiagnosticSeverity.Error   => 0
+      case DiagnosticSeverity.Warning => 1
+      case DiagnosticSeverity.Info    => 2
+    }
+    (bySeverity, if (d.path.isDefined) 0 else 1)
+  }
+
+  /** Workflow-command data must not contain raw newlines or the runner truncates at the first one. */
+  private[bleep] def escapeData(s: String): String =
+    s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+  /** Property values additionally escape the delimiters of the `k=v,k=v` list. */
+  private[bleep] def escapeProperty(s: String): String =
+    escapeData(s).replace(":", "%3A").replace(",", "%2C")
+}

--- a/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
+++ b/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
@@ -863,8 +863,8 @@ class ReactiveBspClient(
       case PE.TestStarted(project, suite, test, timestamp) =>
         Some(BuildEvent.TestStarted(project, suite, test, timestamp))
 
-      case PE.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp) =>
-        Some(BuildEvent.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp))
+      case PE.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp, location) =>
+        Some(BuildEvent.TestFinished(project, suite, test, status, durationMs, message, throwable, timestamp, location))
 
       case PE.SuiteFinished(project, suite, outcome, durationMs, timestamp) =>
         Some(BuildEvent.SuiteFinished(project, suite, outcome, durationMs, timestamp))

--- a/bleep-core/src/scala/bleep/testing/BuildDiff.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDiff.scala
@@ -58,13 +58,10 @@ object BuildDiff {
     */
   case class DiagKey(file: Option[String], message: String)
 
-  private def diagKey(d: BleepBspProtocol.Diagnostic): DiagKey = {
-    val fileOnly = d.path.map { p =>
-      val colonIdx = p.indexOf(':')
-      if (colonIdx > 0) p.substring(0, colonIdx) else p
-    }
-    DiagKey(fileOnly, d.message)
-  }
+  // `d.path` is already the file alone. This used to chop at the first ':' to strip a `line:col` suffix, which on Windows turned every
+  // `C:\...` path into `"C"` — collapsing unrelated files into a single dedup key across the whole platform.
+  private def diagKey(d: BleepBspProtocol.Diagnostic): DiagKey =
+    DiagKey(d.path, d.message)
 
   /** Result of diffing diagnostics for a single project */
   case class CompileDiff(

--- a/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildDisplay.scala
@@ -550,7 +550,10 @@ case class TestFailure(
     message: Option[String],
     throwable: Option[String],
     output: List[String],
-    category: FailureCategory
+    category: FailureCategory,
+    // Where in the suite it was raised, when the forked JVM runner could recover it. Absent for the JS/Native/Kotlin
+    // runners, for timeouts and cancellations (no throwable), and for failures raised outside the suite class.
+    location: Option[bleep.bsp.protocol.BleepBspProtocol.SourceLocation]
 )
 
 case class TestSkipped(
@@ -727,7 +730,7 @@ object BuildDisplay {
       case BuildEvent.TestStarted(_, _, _, _) =>
         IO.unit
 
-      case BuildEvent.TestFinished(_, suite, test, status, durationMs, _, _, _) =>
+      case BuildEvent.TestFinished(_, suite, test, status, durationMs, _, _, _, _) =>
         if (!quietMode) printTestResult(test, status) else IO.unit
 
       case BuildEvent.SuiteFinished(_, suite, outcome, durationMs, _) =>

--- a/bleep-core/src/scala/bleep/testing/BuildEvent.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildEvent.scala
@@ -149,7 +149,8 @@ object BuildEvent {
       durationMs: Long,
       message: Option[String],
       throwable: Option[String],
-      timestamp: Long
+      timestamp: Long,
+      location: Option[bleep.bsp.protocol.BleepBspProtocol.SourceLocation]
   ) extends BuildEvent
 
   /** A test suite has finished execution. `outcome` distinguishes executed-with-counts from empty / no-framework / errored — never conflated as `(0,0,0,0)`. */

--- a/bleep-core/src/scala/bleep/testing/BuildState.scala
+++ b/bleep-core/src/scala/bleep/testing/BuildState.scala
@@ -216,20 +216,20 @@ object BuildStateReducer {
         runningTests = state.runningTests + key
       )
 
-    case BuildEvent.TestFinished(project, suite, test, status, durationMs, message, _, _) =>
+    case BuildEvent.TestFinished(project, suite, test, status, durationMs, message, _, _, location) =>
       val testKey = TestKey(project, suite, test)
       val suiteKey = testKey.suiteKey
 
       val updatedFailures = status match {
         case TestStatus.Failed | TestStatus.Error =>
           val output = state.pendingOutput.getOrElse(suiteKey, Nil)
-          TestFailure(project, suite, test, message, None, output, FailureCategory.TestFailed) :: state.failures
+          TestFailure(project, suite, test, message, None, output, FailureCategory.TestFailed, location) :: state.failures
         case TestStatus.Timeout =>
           val output = state.pendingOutput.getOrElse(suiteKey, Nil)
-          TestFailure(project, suite, test, message, None, output, FailureCategory.Timeout) :: state.failures
+          TestFailure(project, suite, test, message, None, output, FailureCategory.Timeout, location) :: state.failures
         case TestStatus.Cancelled =>
           val output = state.pendingOutput.getOrElse(suiteKey, Nil)
-          TestFailure(project, suite, test, message, None, output, FailureCategory.Cancelled) :: state.failures
+          TestFailure(project, suite, test, message, None, output, FailureCategory.Cancelled, location) :: state.failures
         case TestStatus.AssumptionFailed => state.failures // not a failure
         case _                           => state.failures
       }
@@ -282,7 +282,9 @@ object BuildStateReducer {
               message = Some(msg),
               throwable = None,
               output = state.pendingOutput.getOrElse(key, Nil),
-              category = FailureCategory.ProcessError
+              category = FailureCategory.ProcessError,
+              // synthesised from a suite-level failure, so there is no throwable to recover a frame from
+              location = None
             )
           )
         case _ => Nil
@@ -340,7 +342,9 @@ object BuildStateReducer {
         message = Some(s"Suite idle timeout after ${timeoutMs / 1000}s"),
         throwable = threadDumpInfo.flatMap(_.singleThreadStack),
         output = threadDumpInfo.flatMap(_.dumpFile).map(p => s"Thread dump: $p").toList,
-        category = FailureCategory.Timeout
+        category = FailureCategory.Timeout,
+        // a jstack dump of a hung suite, not a thrown exception — no failing frame to point at
+        location = None
       )
       state.copy(
         suitesCompleted = state.suitesCompleted + 1,
@@ -369,7 +373,9 @@ object BuildStateReducer {
         message = Some(desc),
         throwable = None,
         output = output,
-        category = FailureCategory.ProcessError
+        category = FailureCategory.ProcessError,
+        // the forked JVM died; whatever it was doing never produced a throwable
+        location = None
       )
       state.copy(
         suitesCompleted = if (alreadyCounted) state.suitesCompleted else state.suitesCompleted + 1,
@@ -390,7 +396,9 @@ object BuildStateReducer {
         message = Some(message),
         throwable = details,
         output = Nil,
-        category = FailureCategory.BuildError
+        category = FailureCategory.BuildError,
+        // build-level error, not attributable to a line in any suite
+        location = None
       )
       state.copy(
         testsFailed = state.testsFailed + 1,

--- a/bleep-core/src/scala/bleep/testing/FancyBuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/FancyBuildDisplay.scala
@@ -412,7 +412,7 @@ object FancyBuildDisplay {
         val key = TestKey(project, suite, test)
         state.runningTests.put(key, RunningTest(project, suite, test, Instant.ofEpochMilli(timestamp))): Unit
 
-      case BuildEvent.TestFinished(project, suite, test, status, _, _, _, _) =>
+      case BuildEvent.TestFinished(project, suite, test, status, _, _, _, _, _) =>
         val key = TestKey(project, suite, test)
         state.runningTests.remove(key): Unit
 

--- a/bleep-core/src/scala/bleep/testing/FancyBuildDisplay.scala
+++ b/bleep-core/src/scala/bleep/testing/FancyBuildDisplay.scala
@@ -1204,7 +1204,7 @@ object FancyBuildDisplay {
           )
         )
         errors.foreach { diag =>
-          val pathLine = diag.path match {
+          val pathLine = diag.displayPath match {
             case Some(p) =>
               Spans.from(Span.styled(s"    $p", s(Palette.textDim)))
             case None =>
@@ -1219,7 +1219,7 @@ object FancyBuildDisplay {
       }
 
       warnings.foreach { diag =>
-        val pathLine = diag.path match {
+        val pathLine = diag.displayPath match {
           case Some(p) =>
             Spans.from(Span.styled(s"    $p", s(Palette.textDim)))
           case None =>

--- a/bleep-core/src/scala/bleep/testing/JUnitXmlReport.scala
+++ b/bleep-core/src/scala/bleep/testing/JUnitXmlReport.scala
@@ -197,7 +197,7 @@ class JUnitXmlCollector {
       val key = SuiteKey(project, suite)
       activeSuites(key) = SuiteState(project, suite, Instant.ofEpochMilli(timestamp), Nil, Nil, Nil)
 
-    case BuildEvent.TestFinished(project, suite, test, status, durationMs, message, throwable, _) =>
+    case BuildEvent.TestFinished(project, suite, test, status, durationMs, message, throwable, _, _) =>
       val key = SuiteKey(project, suite)
       val tc = TestCaseResult(
         name = test.value,

--- a/bleep-core/src/scala/bleep/testing/TestProtocol.scala
+++ b/bleep-core/src/scala/bleep/testing/TestProtocol.scala
@@ -73,7 +73,10 @@ object TestProtocol {
         status: String, // passed, failed, error, skipped, ignored, cancelled, pending
         durationMs: Long,
         message: Option[String],
-        throwable: Option[String]
+        throwable: Option[String],
+        // Where in the suite the failure was raised, when the forked runner could recover it from the throwable.
+        // Absent for passing tests, for failures thrown outside the suite class, and from runners that do not report it.
+        location: Option[bleep.bsp.protocol.BleepBspProtocol.SourceLocation]
     ) extends TestResponse
 
     /** A test suite has completed. `outcome` is reconstructed from the flat wire fields (the Java forked runner emits a `kind` discriminator plus counts) into

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/ForkedTestRunner.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/ForkedTestRunner.java
@@ -318,10 +318,12 @@ public class ForkedTestRunner {
 
               String throwableStr = null;
               String message = null;
+              StackTraceElement location = null;
               if (event.throwable() != null && event.throwable().isDefined()) {
                 Throwable t = event.throwable().get();
                 message = t.getMessage();
                 throwableStr = stackTraceToString(t);
+                location = failureLocation(t, className);
               }
 
               // Extract test name from selector if available
@@ -337,7 +339,15 @@ public class ForkedTestRunner {
 
               send(
                   TestProtocol.encodeTestFinished(
-                      className, testName, status, event.duration(), message, throwableStr));
+                      className,
+                      testName,
+                      status,
+                      event.duration(),
+                      message,
+                      throwableStr,
+                      location == null ? null : location.getClassName(),
+                      location == null ? null : location.getFileName(),
+                      location == null ? 0 : location.getLineNumber()));
             }
           };
 
@@ -547,6 +557,33 @@ public class ForkedTestRunner {
     StringWriter sw = new StringWriter();
     t.printStackTrace(new PrintWriter(sw));
     return sw.toString();
+  }
+
+  /**
+   * The first stack frame belonging to the suite class itself, which is where the failing assertion
+   * lives for every framework we support — the frames above it are inside the assertion library.
+   *
+   * <p>Deliberately not "the first frame with a line number": that points at someone else's source,
+   * and an annotation on the wrong file is worse than no annotation. Returns null when the
+   * throwable has no frame in the suite, which is normal for a failure thrown from a helper or a
+   * fixture.
+   *
+   * <p>Inner and anonymous classes ({@code MyTest$$anon$1}) still belong to the suite, so match on
+   * the {@code $} boundary rather than equality alone. Causes are walked because assertion
+   * libraries routinely wrap.
+   */
+  private static StackTraceElement failureLocation(Throwable t, String suiteClass) {
+    for (Throwable current = t; current != null; current = current.getCause()) {
+      for (StackTraceElement frame : current.getStackTrace()) {
+        String cn = frame.getClassName();
+        boolean inSuite = cn.equals(suiteClass) || cn.startsWith(suiteClass + "$");
+        if (inSuite && frame.getFileName() != null && frame.getLineNumber() > 0) {
+          return frame;
+        }
+      }
+      if (current.getCause() == current) break; // self-referential cause, seen in the wild
+    }
+    return null;
   }
 
   /**

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/TestProtocol.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/TestProtocol.java
@@ -43,8 +43,27 @@ public final class TestProtocol {
         + "}}";
   }
 
+  /** For runners that cannot recover a source location, such as the JUnit Platform bridge. */
   public static String encodeTestFinished(
       String suite, String test, String status, long durationMs, String message, String throwable) {
+    return encodeTestFinished(suite, test, status, durationMs, message, throwable, null, null, 0);
+  }
+
+  /**
+   * {@code locationClass} / {@code locationFile} / {@code locationLine} describe the frame where
+   * the failure was raised inside the suite. All three are omitted together — the reader treats a
+   * partial location as no location, since half of one cannot point anywhere.
+   */
+  public static String encodeTestFinished(
+      String suite,
+      String test,
+      String status,
+      long durationMs,
+      String message,
+      String throwable,
+      String locationClass,
+      String locationFile,
+      int locationLine) {
     StringBuilder sb = new StringBuilder();
     sb.append("{\"type\":\"TestFinished\",\"data\":{");
     sb.append("\"suite\":").append(jsonString(suite));
@@ -56,6 +75,13 @@ public final class TestProtocol {
     }
     if (throwable != null) {
       sb.append(",\"throwable\":").append(jsonString(throwable));
+    }
+    if (locationClass != null && locationFile != null && locationLine > 0) {
+      sb.append(",\"location\":{");
+      sb.append("\"declaringClass\":").append(jsonString(locationClass));
+      sb.append(",\"file\":").append(jsonString(locationFile));
+      sb.append(",\"line\":").append(locationLine);
+      sb.append("}");
     }
     sb.append("}}");
     return sb.toString();

--- a/bleep-tests/src/scala/bleep/GithubActionsTest.scala
+++ b/bleep-tests/src/scala/bleep/GithubActionsTest.scala
@@ -1,0 +1,78 @@
+package bleep
+
+import bleep.bsp.protocol.{BleepBspProtocol, DiagnosticSeverity}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Path}
+
+class GithubActionsTest extends AnyFunSuite with Matchers {
+
+  private def diag(path: Option[String], line: Option[Int], column: Option[Int]): BleepBspProtocol.Diagnostic =
+    BleepBspProtocol.Diagnostic(DiagnosticSeverity.Error, "boom", None, path, line, column)
+
+  test("detects the runner from GITHUB_ACTIONS, and stays silent everywhere else") {
+    GithubActions.fromEnv(Map("GITHUB_ACTIONS" -> "true")).annotationsEnabled shouldBe true
+    // A local shell that merely has the variable set to something else is not a runner.
+    GithubActions.fromEnv(Map("GITHUB_ACTIONS" -> "false")).annotationsEnabled shouldBe false
+    GithubActions.fromEnv(Map.empty).annotationsEnabled shouldBe false
+    GithubActions.disabled.annotationsEnabled shouldBe false
+  }
+
+  test("step summary file is only picked up when the runner actually provided one") {
+    GithubActions.fromEnv(Map("GITHUB_STEP_SUMMARY" -> "")).stepSummaryFile shouldBe None
+    GithubActions.fromEnv(Map.empty).stepSummaryFile shouldBe None
+    GithubActions.fromEnv(Map("GITHUB_STEP_SUMMARY" -> "/tmp/summary.md")).stepSummaryFile shouldBe Some(Path.of("/tmp/summary.md"))
+  }
+
+  test("workflow command data escapes what would otherwise truncate the message") {
+    // A raw newline ends the command, so a multi-line compiler message would lose everything after the first line.
+    GithubActions.escapeData("a\nb") shouldBe "a%0Ab"
+    GithubActions.escapeData("a\r\nb") shouldBe "a%0D%0Ab"
+    // '%' first, or the escapes of the other characters would themselves get re-escaped.
+    GithubActions.escapeData("100%") shouldBe "100%25"
+    GithubActions.escapeData("%0A") shouldBe "%250A"
+  }
+
+  test("property values additionally escape the k=v,k=v delimiters") {
+    // Windows paths carry a drive colon, which would otherwise terminate the property list.
+    GithubActions.escapeProperty("C:/foo/Bar.scala") shouldBe "C%3A/foo/Bar.scala"
+    GithubActions.escapeProperty("a,b") shouldBe "a%2Cb"
+  }
+
+  test("annotation paths are repo-relative, and files outside the build get none") {
+    val build = Files.createTempDirectory("gha-build")
+    val inside = build.resolve("bleep-core/src/scala/bleep/Foo.scala")
+
+    GithubActions.relativize(build, inside.toString) shouldBe Some("bleep-core/src/scala/bleep/Foo.scala")
+
+    // An absolute path outside the workspace cannot attach to a line in the diff. Better to drop the position than to
+    // point the annotation at a file the PR does not contain.
+    GithubActions.relativize(build, Files.createTempDirectory("gha-other").resolve("Other.scala").toString) shouldBe None
+  }
+
+  test("annotation budget is spent worst-first") {
+    val positionedError = diag(Some("/x/A.scala"), Some(1), Some(1))
+    val unpositionedError = diag(None, None, None)
+    val warning = positionedError.copy(severity = DiagnosticSeverity.Warning)
+
+    // errors before warnings, and within a severity, diagnostics that can actually appear inline first
+    List(warning, unpositionedError, positionedError).sortBy(GithubActions.rank) shouldBe
+      List(positionedError, unpositionedError, warning)
+  }
+
+  test("displayPath reassembles only the parts the compiler reported") {
+    diag(Some("/x/A.scala"), Some(12), Some(5)).displayPath shouldBe Some("/x/A.scala:12:5")
+    diag(Some("/x/A.scala"), Some(12), None).displayPath shouldBe Some("/x/A.scala:12")
+    diag(Some("/x/A.scala"), None, None).displayPath shouldBe Some("/x/A.scala")
+    diag(None, None, None).displayPath shouldBe None
+  }
+
+  test("appendStepSummary accumulates across calls") {
+    val file = Files.createTempFile("summary", ".md")
+    val gha = GithubActions(annotationsEnabled = false, stepSummaryFile = Some(file))
+    gha.appendStepSummary("## one")
+    gha.appendStepSummary("## two\n")
+    Files.readString(file) shouldBe "## one\n## two\n"
+  }
+}


### PR DESCRIPTION
A failing CI run currently means opening the job log and reading. This makes bleep emit workflow-command annotations, so the error lands on the offending line in the PR diff, plus a markdown summary on the job page.

Complements #627: that made CI *collect* diagnostics, this makes CI *show* them.

## 1. Diagnostic positions become structural — and one live bug

`Diagnostic` flattened position into a single `file:line:col` string, which every consumer then took apart again. The compiler hands us `line`/`column` as integers to begin with (`CompilerError`), so the flattening bought nothing and cost correctness:

```scala
// BuildDiff.diagKey, before
val file = p.substring(0, p.indexOf(':'))
```

On `C:\proj\src\Foo.scala:12:5` that returns `"C"`. **Every diagnostic on Windows shared one dedup key**, so a fixed error in one file cancelled out a new error in another — on every Windows build, silently. Regression test uses a real drive-letter path.

`path` is now the file alone with `line`/`column` beside it; `displayPath` formats the human-readable location for the two TUI sites that want it. MCP emits the position as structured fields rather than a string agents have to re-parse.

This is a wire-protocol change between the client and bleep-bsp, which the version invariant already requires to match.

## 2. Test failures carry a source location

`ForkedTestRunner` held the real `Throwable` and flattened it with `stackTraceToString`, discarding `getFileName`/`getLineNumber` — the only structured position the sbt test interface ever offers, since `Event` has none of its own.

The location is now recovered where the throwable still exists, from the first frame belonging to the suite class. That frame is the failing assertion for every framework we run — ScalaTest, munit, utest — with no framework-specific code and no reflection. Inner and anonymous classes count as the suite, and causes are walked because assertion libraries wrap.

Deliberately **not** "the first frame with a line number": that lands inside the assertion library, and an annotation on someone else's source is worse than none. Absent is a normal answer — helpers and fixtures, the JS/Native/Kotlin runners (no JVM throwable), timeouts, cancellations and process errors all carry `None`, each with a comment at the construction site saying why.

The new field is `Option`, which circe's derived decoder treats as absent-tolerant, so an older runner talking to a newer client still decodes.

## 3. Paths resolved from zinc, not guessed

The forked runner can only report what the JVM knows: a class name, a **bare** file name and a line. That bare name comes from the class file's `SourceFile` attribute, which by specification holds a file name and never a path — so reconstructing a path by searching source roots is guesswork that breaks on files whose name differs from their class, on several roots sharing a relative path, and on generated sources.

Zinc already recorded the answer at compile time. `Relations.definesClass` maps a class to its defining source, and bleep writes analysis through portable mappers, so the id reads back as `${BASE}/bleep-tests/src/.../Foo.scala` — already the repo-relative form an annotation wants, with no machine-specific prefix entering the protocol.

Verifying against bleep's own analysis rather than a hand-built `Relations` caught the part that would have been a silent bug: **zinc records only top-level class names**, so `definesClass("bleep.GithubActionsTest$$anon$1")` is empty while `definesClass("bleep.GithubActionsTest")` resolves. Anonymous classes are exactly where assertion failures are raised, so without truncating at the first `$` nearly every ScalaTest failure would have quietly resolved to nothing.

Resolution happens server-side where the analysis lives, and goes through `AnalysisCache`: a suite reports one location per failing test, so fifty failures in one project would otherwise deserialise the same multi-megabyte analysis fifty times. `TestRunner` takes a `String => Option[String]` rather than the analysis machinery, so it stays a process runner.

## Emitter

`GithubActions`: `::error file=,line=,col=` on stdout, markdown appended to `$GITHUB_STEP_SUMMARY`. Both are plain-text protocols, so no dependency and nothing to configure. Detection is `GITHUB_ACTIONS=true`, the same signal `@actions/core` uses; a run outside Actions emits neither.

The fiddly parts have tests, because each is silent when wrong — a raw newline ends a workflow command, so an unescaped multi-line compiler message would lose everything after its first line; property values additionally escape the `k=v,k=v` delimiters; paths must be repo-relative or GitHub attaches the annotation to nothing; and the annotation budget is spent worst-first.

## Tests

`GithubActionsTest` 8, `BuildDiffTest` 60 (incl. the Windows regression), `BuildStateReducerTest` 10, `ZincSourceLookupTest` 2 — the last reads a real `analysis.zip`, since a hand-built `Relations` would only re-encode my assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)