### PR TITLE
bsp: make the compile server explicable — heap at boot, and telemetry that charts what it records

### DIFF
--- a/bleep-bsp/src/scala/bleep/bsp/BspMetrics.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspMetrics.scala
@@ -342,6 +342,53 @@ object BspMetrics {
         )}","heap_used_mb":$heapUsedMb,"heap_max_mb":$heapMaxMb,"delay_ms":$delayMs,"others_compiling":$othersCompiling}"""
     )
 
+  /** Forked test JVMs, by pid, so a test run can be reconstructed after the fact.
+    *
+    * The compile server already recorded what it compiled; what it *ran* was invisible. These three plus [[recordSuiteScheduled]] answer the questions a slow
+    * or flaky test run actually raises: how many JVMs were started, how many were reused rather than respawned, how long each lived, which were killed rather
+    * than finishing, and which suite ran on which one. The pid is the join key between all of them.
+    */
+  /** The pool announces; this forwards to the same jsonl everything else lands in. Lives here rather than at the call site so there is one place that knows how
+    * a fork becomes an event.
+    */
+  val jvmPoolListener: bleep.testing.JvmPoolListener = new bleep.testing.JvmPoolListener {
+    def onForkStart(pid: Long, label: String, xmxMb: Option[Long]): Unit = recordForkStart(pid, label, xmxMb)
+    def onForkEnd(pid: Long, lifetimeMs: Long, exit: String, killedByUs: Option[String]): Unit = recordForkEnd(pid, lifetimeMs, exit, killedByUs)
+    def onForkReused(pid: Long, label: String): Unit = recordForkReused(pid, label)
+  }
+
+  def recordForkStart(pid: Long, label: String, xmxMb: Option[Long]): Unit =
+    writeEvent(
+      s"""{"type":"fork_start","ts":${now()},"pid":$pid,"label":"${esc(label)}","xmx_mb":${xmxMb.getOrElse(-1L)}}"""
+    )
+
+  /** `killed_by` is the whole point of recording this separately from the exit summary: `destroyForcibly` sends SIGKILL, so a fork bleep terminated is
+    * indistinguishable from one the OS killed unless we say which it was.
+    */
+  def recordForkEnd(pid: Long, lifetimeMs: Long, exit: String, killedByUs: Option[String]): Unit =
+    writeEvent(
+      s"""{"type":"fork_end","ts":${now()},"pid":$pid,"lifetime_ms":$lifetimeMs,"exit":"${esc(exit)}","killed_by":${killedByUs
+          .map(r => s""""${esc(r)}"""")
+          .getOrElse("null")}}"""
+    )
+
+  /** A pooled JVM handed out again instead of a new one being forked. The ratio against `fork_start` is how much the pool actually saves. */
+  def recordForkReused(pid: Long, label: String): Unit =
+    writeEvent(s"""{"type":"fork_reused","ts":${now()},"pid":$pid,"label":"${esc(label)}"}""")
+
+  /** Which suite was placed on which JVM, and how it went. Keyed on pid, so it joins to the fork events above. */
+  def recordSuiteScheduled(pid: Long, project: String, suite: String, framework: String): Unit =
+    writeEvent(
+      s"""{"type":"suite_scheduled","ts":${now()},"pid":$pid,"project":"${esc(project)}","suite":"${esc(suite)}","framework":"${esc(framework)}"}"""
+    )
+
+  def recordSuiteFinished(pid: Long, project: String, suite: String, durationMs: Long, outcome: String): Unit =
+    writeEvent(
+      s"""{"type":"suite_finished","ts":${now()},"pid":$pid,"project":"${esc(project)}","suite":"${esc(
+          suite
+        )}","duration_ms":$durationMs,"outcome":"${esc(outcome)}"}"""
+    )
+
   def recordOomCrash(threadName: String, message: String): Unit = {
     val heap = ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
     val usedMb = heap.getUsed / (1024 * 1024)

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -2147,7 +2147,7 @@ class MultiWorkspaceBspServer(
 
         // Create JVM pool for test execution. The machine governor caps concurrent forks (cores +
         // fork-memory budget) across ALL clients — the per-pool maxParallelism only bounds this run.
-        testResult <- JvmPool.create(maxParallelism, started.jvmCommand, started.buildPaths.buildDir, machine).use { jvmPool =>
+        testResult <- JvmPool.create(maxParallelism, started.jvmCommand, started.buildPaths.buildDir, machine, BspMetrics.jvmPoolListener).use { jvmPool =>
           // Per-test-run map populated by the AP DAG handler and read by the compile handler. KSP runs as a separate process and emits files directly; no
           // intermediate compile-time data flow, so no equivalent map.
           val apResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, AnnotationProcessorResult]()

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -92,7 +92,8 @@ object TestRunner {
           killSignal = killSignal
         ).flatTap { result =>
           IO(
-            BspMetrics.recordSuiteFinished(jvm.pid, project.value, suiteName, System.currentTimeMillis() - startedAt, result.getClass.getSimpleName)
+            BspMetrics
+              .recordSuiteFinished(jvm.pid, project.value, suiteName, System.currentTimeMillis() - startedAt, result.getClass.getSimpleName.stripSuffix("$"))
           ).attempt
         }
     }

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -75,17 +75,26 @@ object TestRunner {
     val runnerClass = "bleep.testing.runner.ForkedTestRunner"
 
     pool.acquire(suiteName, classpath, options.jvmOptions, runnerClass, options.environment, options.workingDirectory).use { jvm =>
-      executeWithIdleTimeout(
-        project = project,
-        suiteName = suiteName,
-        framework = framework,
-        jvm = jvm,
-        eventQueue = eventQueue,
-        testArgs = options.testArgs,
-        idleTimeout = options.idleTimeout,
-        resolveSourcePath = resolveSourcePath,
-        killSignal = killSignal
-      )
+      // Recorded here rather than in the pool because this is the only place that knows both which JVM was handed out and what is about to run on it. The pid
+      // joins these to the fork_start/fork_end pair, which is what lets a test run be reconstructed: which suites shared a JVM, and which JVM was killed
+      // under which suite.
+      val startedAt = System.currentTimeMillis()
+      IO(BspMetrics.recordSuiteScheduled(jvm.pid, project.value, suiteName, framework)).attempt >>
+        executeWithIdleTimeout(
+          project = project,
+          suiteName = suiteName,
+          framework = framework,
+          jvm = jvm,
+          eventQueue = eventQueue,
+          testArgs = options.testArgs,
+          idleTimeout = options.idleTimeout,
+          resolveSourcePath = resolveSourcePath,
+          killSignal = killSignal
+        ).flatTap { result =>
+          IO(
+            BspMetrics.recordSuiteFinished(jvm.pid, project.value, suiteName, System.currentTimeMillis() - startedAt, result.getClass.getSimpleName)
+          ).attempt
+        }
     }
   }
 

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -72,7 +72,7 @@ object Main {
       configCommand(logger, userPaths),
       installTabCompletions(userPaths, logger),
       Opts.subcommand("server-metrics", "open BSP server metrics dashboard in browser")(
-        Opts.argument[Long]("pid").orNone.map(pid => commands.ServerMetrics(logger, userPaths, pid))
+        (Opts.argument[Long]("pid").orNone, metricsFileOpt).mapN((pid, file) => commands.ServerMetrics(logger, userPaths, pid, file))
       )
     ).foldK
 
@@ -533,7 +533,9 @@ object Main {
           configCommand(started.pre.logger, started.pre.userPaths),
           installTabCompletions(started.userPaths, started.pre.logger),
           Opts.subcommand("server-metrics", "open BSP server metrics dashboard in browser")(
-            Opts.argument[Long]("pid").orNone.map(pid => commands.ServerMetrics(started.pre.logger, started.pre.userPaths, pid))
+            (Opts.argument[Long]("pid").orNone, metricsFileOpt).mapN((pid, file) =>
+              commands.ServerMetrics(started.pre.logger, started.pre.userPaths, pid, file)
+            )
           ),
           Opts.subcommand("publish-local", "publishes your project locally (deprecated: use 'publish local-ivy')") {
             (
@@ -902,6 +904,12 @@ object Main {
       case Some(str)                        => FileUtils.cwd / str
       case None                             => FileUtils.cwd
     }
+
+  /** Point `server-metrics` at a `metrics.jsonl` from anywhere — a CI artifact, a colleague's machine — so the dashboard and the file you download are the same
+    * mechanism rather than two ways of looking at the same bytes.
+    */
+  private val metricsFileOpt: Opts[Option[Path]] =
+    Opts.option[Path]("file", "read this metrics.jsonl instead of the newest local one (e.g. downloaded from CI)").orNone
 
   val ec: ExecutionContext = ExecutionContext.global
 

--- a/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
+++ b/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
@@ -91,6 +91,12 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
     val compileAllocation: ArrayBuffer[JsonObject] = ArrayBuffer.empty
     val analysisCache: ArrayBuffer[JsonObject] = ArrayBuffer.empty
     val workspaceState: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    // Forked test JVMs and what ran on them, joined on pid.
+    val forkStart: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    val forkReused: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    val forkEnd: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    val suiteScheduled: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    val suiteFinished: ArrayBuffer[JsonObject] = ArrayBuffer.empty
   }
 
   private def parseMetrics(path: Path): Events = {
@@ -153,6 +159,10 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
     events.compileAllocation.foreach(collectTs)
     events.analysisCache.foreach(collectTs)
     events.workspaceState.foreach(collectTs)
+    events.forkStart.foreach(collectTs)
+    events.forkEnd.foreach(collectTs)
+    events.suiteScheduled.foreach(collectTs)
+    events.suiteFinished.foreach(collectTs)
 
     val t0 = if (allTs.isEmpty) 0L else allTs.min
     def relS(tsMs: Long): Double = (tsMs - t0) / 1000.0
@@ -548,7 +558,86 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
           cards += stat("Analysis sharing", f"${last.get("sharing_factor").getAsDouble}%.2fx across ${last.get("workspaces").getAsLong} ws", "#22c55e")
       }
 
+      if (events.forkStart.nonEmpty) {
+        // Reuse against starts is what the pool is actually saving, which no other number shows.
+        cards += stat("Test JVMs", s"${events.forkStart.size} started, ${events.forkReused.size} reused", "#0ea5e9")
+        val failed = events.suiteFinished.count(e => getStr(e, "outcome") != "Success")
+        cards += stat("Suites run", s"${events.suiteFinished.size}" + (if (failed > 0) s" ($failed not ok)" else ""), if (failed > 0) "#ef4444" else "#22c55e")
+      }
+
       if (cards.isEmpty) "" else cards.mkString("\n") + "\n"
+    }
+
+    // ---- Test JVMs, and what ran on each ----
+    // One lane per forked JVM. The bar is the fork's life; the darker segments are the suites placed on it. This is the view that answers "which suite was on
+    // the JVM that got killed", which is otherwise a join across three event types done by hand.
+    if (events.forkStart.nonEmpty) {
+      val endByPid = events.forkEnd.map(e => e.get("pid").getAsLong -> e).toMap
+      val lanes = events.forkStart.map(_.get("pid").getAsLong).distinct.sorted
+      val laneIndex = lanes.zipWithIndex.toMap
+      val lastTs = allTs.maxOption.getOrElse(0L)
+
+      val shapes = ArrayBuffer.empty[String]
+      events.forkStart.foreach { f =>
+        val pid = f.get("pid").getAsLong
+        val row = laneIndex(pid)
+        val startS = relS(f.get("ts").getAsLong)
+        val endS = endByPid.get(pid).map(e => relS(e.get("ts").getAsLong)).getOrElse(relS(lastTs))
+        // Killed by us is not a failure — it is how the pool shuts down — so only an unexplained end is coloured as trouble.
+        val killed = endByPid.get(pid).exists(e => e.has("killed_by") && !e.get("killed_by").isJsonNull)
+        val colour = if (endByPid.contains(pid) && !killed) "#ef4444" else "#cbd5e1"
+        shapes += s"""{"type":"rect","x0":$startS,"x1":$endS,"y0":${row - 0.38},"y1":${row + 0.38},"fillcolor":"$colour","opacity":0.55,"line":{"width":0}}"""
+      }
+      events.suiteFinished.foreach { sf =>
+        val pid = sf.get("pid").getAsLong
+        laneIndex.get(pid).foreach { row =>
+          val endS = relS(sf.get("ts").getAsLong)
+          val startS = endS - sf.get("duration_ms").getAsLong / 1000.0
+          val ok = getStr(sf, "outcome") == "Success"
+          shapes += s"""{"type":"rect","x0":$startS,"x1":$endS,"y0":${row - 0.3},"y1":${row + 0.3},"fillcolor":"${
+              if (ok) "#22c55e"
+              else "#ef4444"
+            }","opacity":0.9,"line":{"width":0}}"""
+        }
+      }
+
+      val t = ArrayBuffer.empty[String]
+      if (events.suiteFinished.nonEmpty)
+        t += s"""{"type":"scatter","mode":"markers","x":${fmtDoubles(events.suiteFinished.map(e => relS(e.get("ts").getAsLong)))},"y":${fmtDoubles(
+            events.suiteFinished.map(e => laneIndex.getOrElse(e.get("pid").getAsLong, 0).toDouble)
+          )},"text":${fmtStrings(
+            events.suiteFinished.map(e => s"${getStr(e, "suite")} — ${e.get("duration_ms").getAsLong}ms (${getStr(e, "outcome")})")
+          )},"marker":{"color":"rgba(0,0,0,0)","size":8},"hovertemplate":"%{text}<extra></extra>","showlegend":false}"""
+
+      val laneLabels = lanes.map { pid =>
+        val n = events.suiteScheduled.count(_.get("pid").getAsLong == pid)
+        s"pid $pid ($n)"
+      }
+      val layout =
+        s"""{"margin":{"t":8,"r":16,"b":44,"l":16},"showlegend":false,"xaxis":{"title":{"text":"Time (s)","font":{"size":12}},"gridcolor":"#f0f0f0","zeroline":false},"yaxis":{"automargin":true,"tickvals":${fmtDoubles(
+            lanes.indices.map(_.toDouble)
+          )},"ticktext":${fmtStrings(
+            laneLabels
+          )},"tickfont":{"size":9},"autorange":"reversed","gridcolor":"#f8f8f8"},"plot_bgcolor":"white","paper_bgcolor":"white","font":{"family":"Inter,system-ui,sans-serif","size":11,"color":"#374151"},"shapes":[${shapes
+            .mkString(",")}]}"""
+      addChart("forks", "Test JVMs — lifetime and the suites on them", t, layout, true, math.max(240, lanes.size * 26 + 90))
+    }
+
+    // ---- Slowest suites ----
+    if (events.suiteFinished.nonEmpty) {
+      val slowest = events.suiteFinished
+        .map(e => (getStr(e, "suite"), e.get("duration_ms").getAsLong, getStr(e, "outcome")))
+        .sortBy(-_._2)
+        .take(15)
+        .reverse
+      val t = ArrayBuffer.empty[String]
+      t += s"""{"type":"bar","orientation":"h","x":${fmtDoubles(slowest.map(_._2 / 1000.0))},"y":${fmtStrings(
+          slowest.map(r => r._1.split('.').last)
+        )},"marker":{"color":${fmtStrings(
+          slowest.map(r => if (r._3 == "Success") "#22c55e" else "#ef4444")
+        )}},"hovertemplate":"%{y}<br>%{x:.1f}s<extra></extra>"}"""
+      val layout = baseLayout("seconds", "").replace("\"showlegend\":true", "\"showlegend\":false").replace("\"l\":60", "\"l\":190")
+      addChart("suites", "Slowest test suites", t, layout, false, math.max(280, slowest.size * 26 + 60))
     }
 
     val oomLabel = if (oomCrashCount > 0) s"$oomCrashCount CRASH" else if (oomPressureCount > 0) s"$oomPressureCount events" else "None"

--- a/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
+++ b/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
@@ -129,6 +129,11 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
           case "compile_allocation"  => events.compileAllocation += obj
           case "analysis_cache"      => events.analysisCache += obj
           case "workspace_state"     => events.workspaceState += obj
+          case "fork_start"          => events.forkStart += obj
+          case "fork_reused"         => events.forkReused += obj
+          case "fork_end"            => events.forkEnd += obj
+          case "suite_scheduled"     => events.suiteScheduled += obj
+          case "suite_finished"      => events.suiteFinished += obj
           // compile_phase is deliberately not charted: it fires per phase per project and says more about zinc's internals than about this build.
           case _ => ()
         }

--- a/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
+++ b/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
@@ -80,6 +80,13 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
     val summary: ArrayBuffer[JsonObject] = ArrayBuffer.empty
     val oomPressure: ArrayBuffer[JsonObject] = ArrayBuffer.empty
     val oomCrash: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    // Recorded by the server since the telemetry was extended; the dashboard used to drop them on the floor, which meant the questions they answer — was the
+    // machine saturated, why did a compile not start, what is actually allocating — could only be answered by reading metrics.jsonl by hand.
+    val machine: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    val admissionDefer: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    val compileAllocation: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    val analysisCache: ArrayBuffer[JsonObject] = ArrayBuffer.empty
+    val workspaceState: ArrayBuffer[JsonObject] = ArrayBuffer.empty
   }
 
   private def parseMetrics(path: Path): Events = {
@@ -104,7 +111,16 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
           case "summary"          => events.summary += obj
           case "oom_pressure"     => events.oomPressure += obj
           case "oom_crash"        => events.oomCrash += obj
-          case _                  => ()
+          case "machine"          => events.machine += obj
+          case "admission_defer"  => events.admissionDefer += obj
+          // `heap_pressure_stall` is what this event was called before its two reasons were told apart. Files already on disk still carry that name, and
+          // the CI summariser reads both — a dashboard that silently drops half its input is how these two drifted apart to begin with.
+          case "heap_pressure_stall" => events.admissionDefer += obj
+          case "compile_allocation"  => events.compileAllocation += obj
+          case "analysis_cache"      => events.analysisCache += obj
+          case "workspace_state"     => events.workspaceState += obj
+          // compile_phase is deliberately not charted: it fires per phase per project and says more about zinc's internals than about this build.
+          case _ => ()
         }
       }
     }
@@ -128,6 +144,11 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
     events.sourcegenStart.foreach(collectTs)
     events.sourcegenEnd.foreach(collectTs)
     events.summary.foreach(collectTs)
+    events.machine.foreach(collectTs)
+    events.admissionDefer.foreach(collectTs)
+    events.compileAllocation.foreach(collectTs)
+    events.analysisCache.foreach(collectTs)
+    events.workspaceState.foreach(collectTs)
 
     val t0 = if (allTs.isEmpty) 0L else allTs.min
     def relS(tsMs: Long): Double = (tsMs - t0) / 1000.0
@@ -380,6 +401,152 @@ case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]
 </div>"""
     } else ""
 
+    // ---- Scheduling: is the machine busy, or is work queued behind an empty machine? ----
+    // The two failure modes look identical from outside — a slow build — and have opposite fixes. Saturated means the machine is the limit; a standing queue
+    // over idle cores means admission is holding work back.
+    if (events.machine.nonEmpty) {
+      val t = ArrayBuffer.empty[String]
+      val xArr = fmtDoubles(events.machine.map(e => relS(e.get("ts").getAsLong)))
+      t += scatterTrace(xArr, fmtLongs(events.machine.map(_.get("used_cpu").getAsLong)), "CPU in use", "#3b82f6", "solid", "tozeroy", "lines")
+      t += scatterTrace(xArr, fmtLongs(events.machine.map(_.get("total_cpu").getAsLong)), "Cores", "#9ca3af", "dot", "none", "lines")
+      t += scatterTrace(xArr, fmtLongs(events.machine.map(_.get("running").getAsLong)), "Running", "#22c55e", "solid", "none", "lines")
+      t += scatterTrace(xArr, fmtLongs(events.machine.map(_.get("waiting").getAsLong)), "Queued", "#ef4444", "solid", "none", "lines")
+      addChart("machine-cpu", "Scheduling — CPU and queue", t, baseLayout("Time (s)", "count"), false, 280)
+    }
+
+    // ---- Fork memory budget ----
+    // `total_memory_mb` is the budget for forked processes, not the machine's RAM: the server's own footprint and an OS reserve are already subtracted, and it
+    // is retuned as other processes come and go. Charting it against physical RAM is the only way to see how little of the machine forks may actually use.
+    if (events.machine.nonEmpty) {
+      val t = ArrayBuffer.empty[String]
+      val xArr = fmtDoubles(events.machine.map(e => relS(e.get("ts").getAsLong)))
+      t += scatterTrace(xArr, fmtLongs(events.machine.map(_.get("used_memory_mb").getAsLong)), "Forks using", "#8b5cf6", "solid", "tozeroy", "lines")
+      t += scatterTrace(xArr, fmtLongs(events.machine.map(_.get("total_memory_mb").getAsLong)), "Fork budget", "#f59e0b", "dash", "none", "lines")
+      if (events.machine.head.has("physical_memory_mb"))
+        t += scatterTrace(xArr, fmtLongs(events.machine.map(_.get("physical_memory_mb").getAsLong)), "Machine RAM", "#9ca3af", "dot", "none", "lines")
+      if (events.machine.head.has("server_heap_mb"))
+        t += scatterTrace(xArr, fmtLongs(events.machine.map(_.get("server_heap_mb").getAsLong)), "Server heap cap", "#ef4444", "dot", "none", "lines")
+      addChart("machine-mem", "Fork memory budget (MB)", t, baseLayout("Time (s)", "MB"), false, 280)
+    }
+
+    // ---- Why a compile did not start ----
+    // Two unrelated reasons wear the same shape. `stagger` is the scheduler deliberately spreading first starts apart and says nothing about memory;
+    // `heap_pressure` is a compile actually waiting for heap. Only the second is an argument for a bigger `-Xmx`, so they are drawn apart.
+    if (events.admissionDefer.nonEmpty) {
+      // Pre-rename events carry no reason. Calling them "unlabelled" rather than folding them into either bucket keeps the chart from asserting something the
+      // data does not say — they were recorded when both causes shared one name.
+      val byReason = events.admissionDefer.groupBy(e => if (e.has("reason")) e.get("reason").getAsString else "unlabelled (pre-rename)")
+      val t = ArrayBuffer.empty[String]
+      val colours = Map("stagger" -> "#f59e0b", "heap_pressure" -> "#ef4444", "unlabelled (pre-rename)" -> "#9ca3af")
+      byReason.toSeq.sortBy(_._1).foreach { case (reason, evs) =>
+        val total = evs.map(e => if (e.has("delay_ms")) e.get("delay_ms").getAsLong else 0L).sum
+        val label = if (total > 0) f"$reason (${total / 1000.0}%.1fs)" else reason
+        t += s"""{"type":"scatter","mode":"markers","x":${fmtDoubles(evs.map(e => relS(e.get("ts").getAsLong)))},"y":${fmtLongs(
+            evs.map(e => if (e.has("heap_used_mb")) e.get("heap_used_mb").getAsLong else 0L)
+          )},"name":"${escJson(label)}","marker":{"color":"${colours.getOrElse(reason, "#6366f1")}","size":7,"opacity":0.75},"text":${fmtStrings(
+            evs.map(e => getStr(e, "project"))
+          )},"hovertemplate":"%{text}<br>heap %{y} MB<extra></extra>"}"""
+      }
+      if (events.machine.nonEmpty && events.machine.head.has("server_heap_mb")) {
+        val cap = events.machine.head.get("server_heap_mb").getAsLong
+        val xs = fmtDoubles(events.admissionDefer.map(e => relS(e.get("ts").getAsLong)))
+        t += s"""{"type":"scatter","mode":"lines","x":$xs,"y":${fmtLongs(
+            Seq.fill(events.admissionDefer.size)(cap)
+          )},"name":"Heap cap","line":{"color":"#ef4444","dash":"dot","width":1}}"""
+      }
+      addChart("defers", "Deferred compiles — and why", t, baseLayout("Time (s)", "heap at the time (MB)"), false, 280)
+    }
+
+    // ---- What allocates ----
+    // Allocation, not wall time, is what a heap cap has to absorb, and it is wildly uneven between projects: one project routinely accounts for a third of a
+    // build's total. That makes this the shortest path from "raise the heap" to "or fix that one project".
+    if (events.compileAllocation.nonEmpty) {
+      val byProject = events.compileAllocation
+        .groupBy(e => pathName(getStr(e, "project")))
+        .map { case (project, evs) => project -> evs.map(_.get("allocated_mb").getAsLong).sum }
+        .toSeq
+        .sortBy(-_._2)
+        .take(15)
+        .reverse
+      val t = ArrayBuffer.empty[String]
+      t += s"""{"type":"bar","orientation":"h","x":${fmtLongs(byProject.map(_._2))},"y":${fmtStrings(
+          byProject.map(_._1)
+        )},"marker":{"color":"#6366f1"},"hovertemplate":"%{y}<br>%{x} MB allocated<extra></extra>"}"""
+      val layout = baseLayout("MB allocated", "")
+        .replace("\"showlegend\":true", "\"showlegend\":false")
+        .replace("\"l\":60", "\"l\":170")
+      addChart("alloc", "Allocation by project (total)", t, layout, false, math.max(280, byProject.size * 26 + 60))
+    }
+
+    // ---- Analysis cache ----
+    // The largest single retainer in the server heap. `sharing_factor` is why holding several workspaces costs far less than it appears: identical class
+    // metadata is interned across them, so the same analysis counted twice is stored once.
+    if (events.analysisCache.nonEmpty) {
+      val t = ArrayBuffer.empty[String]
+      val xArr = fmtDoubles(events.analysisCache.map(e => relS(e.get("ts").getAsLong)))
+      t += scatterTrace(
+        xArr,
+        fmtLongs(events.analysisCache.map(_.get("file_bytes").getAsLong / (1024L * 1024L))),
+        "Analysis on disk (MB)",
+        "#3b82f6",
+        "solid",
+        "tozeroy",
+        "lines"
+      )
+      t += scatterTrace(xArr, fmtLongs(events.analysisCache.map(_.get("entries").getAsLong)), "Analyses held", "#22c55e", "solid", "none", "lines")
+      if (events.workspaceState.nonEmpty) {
+        val wx = fmtDoubles(events.workspaceState.map(e => relS(e.get("ts").getAsLong)))
+        t += scatterTrace(wx, fmtLongs(events.workspaceState.map(_.get("cached_count").getAsLong)), "Workspaces cached", "#f59e0b", "solid", "none", "lines")
+      }
+      addChart("analysis", "Zinc analysis cache", t, baseLayout("Time (s)", ""), false, 280)
+    }
+
+    // Facts about the machine and the scheduler, which the page could not state before because it did not read these events. Each is here because it answers a
+    // question people actually arrive with: how much heap was this server allowed, was the machine ever full, and did anything wait.
+    val machineStats: String = {
+      val cards = ArrayBuffer.empty[String]
+
+      events.machine.headOption.foreach { first =>
+        if (first.has("server_heap_mb") && first.has("physical_memory_mb")) {
+          val cap = first.get("server_heap_mb").getAsLong
+          val ram = first.get("physical_memory_mb").getAsLong
+          // "max" because -Xmx is a ceiling, not a reservation; the server commits far less than this most of the time.
+          cards += stat("Server heap cap", s"max ${cap / 1024} of ${ram / 1024} GB", "#0ea5e9")
+        }
+        val cores = first.get("total_cpu").getAsLong
+        val saturated = events.machine.count(e => e.get("used_cpu").getAsLong >= e.get("total_cpu").getAsLong)
+        val pct = if (events.machine.isEmpty) 0 else saturated * 100 / events.machine.size
+        cards += stat(s"Saturated ($cores cores)", s"$pct% of samples", if (pct > 80) "#f59e0b" else "#22c55e")
+
+        val deepest = events.machine.map(_.get("waiting").getAsLong).maxOption.getOrElse(0L)
+        // Queued work while cores sit idle is the one shape that means the scheduler, not the machine, is the limit.
+        val starved = events.machine.count(e => e.get("waiting").getAsLong > 0 && e.get("used_cpu").getAsLong < e.get("total_cpu").getAsLong)
+        cards += stat("Deepest queue", s"$deepest" + (if (starved > 0) s" ($starved starved)" else ""), if (starved > 0) "#ef4444" else "#22c55e")
+      }
+
+      if (events.admissionDefer.nonEmpty) {
+        val delay = events.admissionDefer.map(e => if (e.has("delay_ms")) e.get("delay_ms").getAsLong else 0L).sum
+        val pressure = events.admissionDefer.count(e => e.has("reason") && e.get("reason").getAsString == "heap_pressure")
+        val label = if (pressure > 0) s"${events.admissionDefer.size} ($pressure heap)" else s"${events.admissionDefer.size} (stagger)"
+        cards += stat(f"Defers, ${delay / 1000.0}%.1fs", label, if (pressure > 0) "#ef4444" else "#9ca3af")
+      }
+
+      events.compileAllocation
+        .groupBy(e => pathName(getStr(e, "project")))
+        .map { case (project, evs) => project -> evs.map(_.get("allocated_mb").getAsLong).sum }
+        .toSeq
+        .sortBy(-_._2)
+        .headOption
+        .foreach { case (project, mb) => cards += stat("Heaviest allocator", s"$project — ${mb / 1024} GB", "#6366f1") }
+
+      events.analysisCache.lastOption.foreach { last =>
+        if (last.has("sharing_factor"))
+          cards += stat("Analysis sharing", f"${last.get("sharing_factor").getAsDouble}%.2fx across ${last.get("workspaces").getAsLong} ws", "#22c55e")
+      }
+
+      if (cards.isEmpty) "" else cards.mkString("\n") + "\n"
+    }
+
     val oomLabel = if (oomCrashCount > 0) s"$oomCrashCount CRASH" else if (oomPressureCount > 0) s"$oomPressureCount events" else "None"
 
     val statsHtml = s"""$oomWarning<div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
@@ -391,7 +558,7 @@ ${stat("Avg Build", f"${avgBuildMs / 1000.0}%.1f s", "#f59e0b")}
 ${stat("Max Concurrent", summaryMaxConcurrent.toString, "#8b5cf6")}
 ${stat("Heap", s"$summaryMaxHeap / $heapMax MB", if (anyOom) "#ef4444" else "#ec4899")}
 ${stat("OOM", oomLabel, if (anyOom) "#ef4444" else "#22c55e")}
-</div>"""
+$machineStats</div>"""
 
     s"""<!DOCTYPE html>
 <html lang="en">

--- a/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
+++ b/bleep-cli/src/scala/bleep/commands/ServerMetrics.scala
@@ -11,10 +11,14 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.jdk.StreamConverters._
 
-case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long]) extends BleepCommand {
+case class ServerMetrics(logger: Logger, userPaths: UserPaths, pid: Option[Long], file: Option[Path]) extends BleepCommand {
 
+  /** `file` is how a `metrics.jsonl` that came from somewhere else gets opened here — most usefully one downloaded from a CI run, which is the case where you
+    * least want to be reading JSON by hand and where the local socket directory holds nothing relevant. It is the same file this command already reads; only
+    * where it was found differs.
+    */
   override def run(): Either[BleepException, Unit] =
-    findMetricsFile(userPaths.bspSocketDir) match {
+    file.orElse(findMetricsFile(userPaths.bspSocketDir)) match {
       case None =>
         val msg = pid match {
           case Some(p) => s"No metrics found for PID $p. Check that the server wrote metrics.jsonl."

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -143,7 +143,7 @@ object BspRifle {
         ensureUp >> BspServerOperations.waitForServer(config)
       } >> IO(logger.info(s"BSP server ready (server log: ${getOutputFile(config)})"))
 
-    IO(logger.info(s"Ensuring BSP server (mode=$mode, socket=$socketDir)")) >> {
+    IO(logger.info(s"Ensuring BSP server (mode=$mode, heap=${heapDescription(config)}, socket=$socketDir)")) >> {
       if (config.dieWithParent)
         // Ephemeral: its socket dir is unique (UUID) and must be a fresh server every time — never reuse, no swarm to elect from.
         BspServerOperations.forceKillAndCleanup(socketDir) >> spawn >> BspServerOperations.waitForServer(config)
@@ -160,6 +160,27 @@ object BspRifle {
     * to notice. The `output` file always belongs to the server generation the caller was dealing with; it must be read before cleanup/forceStop/startServer,
     * which delete or rotate it.
     */
+  /** What the compile server's heap is, and what the machine has — reported at boot next to the socket and the mode.
+    *
+    * The cap was invisible until something went wrong, at which point it turned up in an OOM message. It is worth stating up front because the default is
+    * surprising: `min(16g, max(4g, physicalMb / 4))` clamps to its 4g *floor* on anything under 16GB of RAM, so a quarter-of-RAM rule that sounds proportional
+    * hands the same 4g to a 14GB CI runner and a 16GB laptop. Printing both numbers makes the ratio visible without prescribing anything —
+    * `bleep config compile-server max-memory 8g` is the lever, and `max-memory-clear` puts it back.
+    */
+  private[bsp] def heapDescription(config: BspRifleConfig): String = {
+    val physicalMb = bleep.MachineResources.physicalMemoryMb(fallbackMb = 0L)
+    def render(mb: Long) = if (mb % 1024 == 0) s"${mb / 1024}g" else s"${mb}m"
+
+    config.javaOpts.filter(_.startsWith("-Xmx")).lastOption.flatMap(bleep.MachineResources.parseMemoryMb) match {
+      // "max", because `-Xmx` is a ceiling and nothing is reserved up front — ZGC commits as it needs and hands memory back after `ZUncommitDelay`. Written as
+      // a plain size it reads like the server is holding that much, which would make the number beside the machine's RAM alarming rather than informative.
+      case Some(capMb) if physicalMb > 0 => s"max ${render(capMb)} of ${render(physicalMb)} RAM"
+      case Some(capMb)                   => s"max ${render(capMb)}"
+      // `-Xmx` is always added by SetupBleepBsp, so this is a shape nobody should see; say that rather than inventing a number.
+      case None => "unset"
+    }
+  }
+
   def oomCrashExplanation(config: BspRifleConfig): IO[Option[String]] = IO.blocking {
     val log = config.address.socketDir.resolve("output")
     if (BspServerOperations.containsOomMarker(log)) {

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -679,6 +679,9 @@ object JvmPool {
           _ <- IO.blocking {
             jvms.foreach(_.kill("bleep: pool shutdown"))
           }
+          // Shutdown kills directly rather than going through `destroy`, so without this the JVMs that survived to the end of a run — usually most of them —
+          // would have a fork_start and never a fork_end, and their lifetimes would be unknowable.
+          _ <- jvms.toList.traverse_(jvm => announceEnd(jvm).attempt)
           _ <- allJvms.set(Set.empty)
           _ <- IO(pool.clear())
           // Backstop for the whole scheme: every process-lifetime reservation is returned here, so a

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -103,7 +103,8 @@ object JvmPool {
       maxConcurrency: Int,
       jvmCommand: Path,
       workingDirectory: Path,
-      machine: MachineResources
+      machine: MachineResources,
+      listener: JvmPoolListener
   ): Resource[IO, JvmPool] =
     Resource.make(
       for {
@@ -117,6 +118,7 @@ object JvmPool {
           if (ProcessMemory.system eq ProcessMemory.Unavailable) IO.pure(ForkCostModel.static)
           else ForkCostModel.create
       } yield new JvmPoolImpl(
+        listener,
         semaphore,
         startLimiter,
         machine,
@@ -365,6 +367,7 @@ object JvmPool {
   private val MaxSpawnFailures = 3
 
   private class JvmPoolImpl(
+      listener: JvmPoolListener,
       semaphore: Semaphore[IO],
       startLimiter: Semaphore[IO],
       machine: MachineResources,
@@ -412,7 +415,9 @@ object JvmPool {
       // to the suite is what let the governor believe memory was free while live JVMs still held it.
       Resource.make(semaphore.acquire)(_ => semaphore.release).flatMap { _ =>
         Resource
-          .make(getOrCreate(key, classpath, boundedOptions, runnerClass, environment, workingDirectory).map(jvm => (jvm, new TestJvmImpl(jvm): TestJvm))) {
+          .make(
+            getOrCreate(label, key, classpath, boundedOptions, runnerClass, environment, workingDirectory).map(jvm => (jvm, new TestJvmImpl(jvm): TestJvm))
+          ) {
             // Return JVM to pool (or destroy it); the semaphore is released by its own Resource.
             case (jvm, _) => release(jvm)
           }
@@ -439,7 +444,24 @@ object JvmPool {
       * actually surrendered yet.
       */
     private def destroy(jvm: ManagedJvm, destroyReason: String): IO[Unit] =
-      observeCost(jvm).attempt >> IO(jvm.kill(destroyReason)).attempt >> allJvms.update(_ - jvm) >> jvm.releaseMemory
+      observeCost(jvm).attempt >> IO(jvm.kill(destroyReason)).attempt >> announceEnd(jvm).attempt >> allJvms.update(_ - jvm) >> jvm.releaseMemory
+
+    /** Announced after `kill`, so the exit description is final and `killedByUs` is set — that flag is the only thing separating a fork bleep terminated from
+      * one the OS killed, since both report exit 137.
+      *
+      * Lifetime comes from the JVM's own record of when the process started rather than a field we would have to keep in step; where the platform does not
+      * supply it, the age is simply omitted rather than guessed.
+      */
+    private def announceEnd(jvm: ManagedJvm): IO[Unit] =
+      IO {
+        val exit = describeExit(jvm.process, jvm.killedByUs)
+        val lifetimeMs = jvm.process
+          .info()
+          .startInstant()
+          .map[java.lang.Long](start => java.lang.Long.valueOf(System.currentTimeMillis() - start.toEpochMilli))
+          .orElse(java.lang.Long.valueOf(-1L))
+        listener.onForkEnd(jvm.process.pid(), lifetimeMs.longValue(), exit.summary, jvm.killedByUs)
+      }
 
     /** Record what this fork actually cost the machine, for the benefit of the next one of its kind.
       *
@@ -490,6 +512,7 @@ object JvmPool {
       }
 
     private def getOrCreate(
+        label: String,
         key: JvmKey,
         classpath: List[Path],
         jvmOptions: List[String],
@@ -510,18 +533,19 @@ object JvmPool {
         maybeJvm <- queue.tryTake
         jvm <- maybeJvm match {
           case Some(existing) if existing.isAlive =>
-            IO.pure(existing)
+            IO(listener.onForkReused(existing.process.pid(), label)).attempt >> IO.pure(existing)
           case Some(dead) =>
             // JVM died while idle in the pool. `destroy` (not just untracking) so its memory
             // reservation goes back to the governor — otherwise a dead process's footprint would be
             // charged for the rest of the server's life.
-            destroy(dead, "bleep: pooled JVM found dead") >> spawnJvm(key, classpath, jvmOptions, runnerClass, environment, cwd)
+            destroy(dead, "bleep: pooled JVM found dead") >> spawnJvm(label, key, classpath, jvmOptions, runnerClass, environment, cwd)
           case None =>
-            spawnJvm(key, classpath, jvmOptions, runnerClass, environment, cwd)
+            spawnJvm(label, key, classpath, jvmOptions, runnerClass, environment, cwd)
         }
       } yield jvm
 
     private def spawnJvm(
+        label: String,
         key: JvmKey,
         classpath: List[Path],
         jvmOptions: List[String],
@@ -589,6 +613,7 @@ object JvmPool {
                   IO(spawnFailures.updateWith(jvm.key) { case Some(n) => Some(n + 1); case None => Some(1) }).void
                 }
               )
+              .flatTap(jvm => IO(listener.onForkStart(jvm.process.pid(), label, parseXmxMb(jvmOptions))).attempt)
               .flatTap(jvm => IO(spawnFailures.remove(jvm.key))) // Reset on success
           } {
             // On success the reservation now belongs to the ManagedJvm, which releases it when destroyed.

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -222,6 +222,10 @@ object JvmPool {
     */
   private class ManagedJvm(
       val process: Process,
+      /** When this fork was created, taken here rather than from `process.info().startInstant()` at the end: by the time a JVM is announced dead it has already
+        * been killed, and the OS stops reporting a start instant for a process that no longer exists — which produced a lifetime of -1 on every fork.
+        */
+      val startedAtMs: Long = System.currentTimeMillis(),
       val stdin: PrintWriter,
       val stdout: BufferedReader,
       val stderr: BufferedReader,
@@ -455,12 +459,7 @@ object JvmPool {
     private def announceEnd(jvm: ManagedJvm): IO[Unit] =
       IO {
         val exit = describeExit(jvm.process, jvm.killedByUs)
-        val lifetimeMs = jvm.process
-          .info()
-          .startInstant()
-          .map[java.lang.Long](start => java.lang.Long.valueOf(System.currentTimeMillis() - start.toEpochMilli))
-          .orElse(java.lang.Long.valueOf(-1L))
-        listener.onForkEnd(jvm.process.pid(), lifetimeMs.longValue(), exit.summary, jvm.killedByUs)
+        listener.onForkEnd(jvm.process.pid(), System.currentTimeMillis() - jvm.startedAtMs, exit.summary, jvm.killedByUs)
       }
 
     /** Record what this fork actually cost the machine, for the benefit of the next one of its kind.

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -222,10 +222,6 @@ object JvmPool {
     */
   private class ManagedJvm(
       val process: Process,
-      /** When this fork was created, taken here rather than from `process.info().startInstant()` at the end: by the time a JVM is announced dead it has already
-        * been killed, and the OS stops reporting a start instant for a process that no longer exists — which produced a lifetime of -1 on every fork.
-        */
-      val startedAtMs: Long = System.currentTimeMillis(),
       val stdin: PrintWriter,
       val stdout: BufferedReader,
       val stderr: BufferedReader,
@@ -235,7 +231,14 @@ object JvmPool {
         * JVM sitting idle in the pool is still resident and still costing the machine its whole footprint, so the reservation is only released when the process
         * is actually destroyed. Must be run exactly where the process is killed — see `JvmPoolImpl.destroy`.
         */
-      val releaseMemory: IO[Unit]
+      val releaseMemory: IO[Unit],
+      /** When this fork was created. Taken at construction, not from `process.info().startInstant()` when it dies: by then the process has been killed and the
+        * OS no longer reports a start instant for it, which is why every fork_end carried a lifetime of -1.
+        *
+        * Genuinely last, and defaulted: anywhere else in this list a default silently rebinds the positional arguments after it, which is exactly what the
+        * first attempt at this did — `stdin` became the timestamp and the build stopped compiling.
+        */
+      val startedAtMs: Long = System.currentTimeMillis()
   ) {
     @volatile private var alive = true
     @volatile private var _protocolClean = true

--- a/bleep-core/src/scala/bleep/testing/JvmPoolListener.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPoolListener.scala
@@ -1,0 +1,38 @@
+package bleep.testing
+
+/** What the pool did with its forked JVMs, reported to whoever cares.
+  *
+  * The pool lives in bleep-core and the telemetry lives in bleep-bsp, which depends on it — so the pool cannot call the recorder, and a singleton it could
+  * reach would be exactly the global mutable state this codebase refuses. The dependency is inverted instead: the pool announces, and whoever constructs it
+  * decides whether anything listens.
+  *
+  * What this makes answerable, none of which was recorded anywhere before: how many JVMs a test run actually started, whether they were reused or respawned,
+  * how long each lived, which of them were killed rather than finishing, and — with [[bleep.bsp.TestRunner]]'s suite events, keyed on the same pid — which
+  * suite ran on which JVM. A slow or flaky test run is usually a question about one of those.
+  *
+  * Deliberately not `IO`: these are called from inside the pool's own bookkeeping, including a process's exit handler, and an effect there would either need an
+  * unsafeRun at the call site or restructuring the pool around an effectful listener. They must be cheap and must not throw.
+  */
+trait JvmPoolListener {
+
+  /** A JVM was forked. `label` is what it was acquired for — the suite name, in practice. */
+  def onForkStart(pid: Long, label: String, xmxMb: Option[Long]): Unit
+
+  /** A JVM the pool had is gone. `exit` is the human description the pool already computes, which distinguishes a fork bleep killed from one the OS killed —
+    * both report exit 137 and mean very different things.
+    */
+  def onForkEnd(pid: Long, lifetimeMs: Long, exit: String, killedByUs: Option[String]): Unit
+
+  /** A JVM already in the pool was handed out again instead of a new one being started. The ratio of this to [[onForkStart]] is how much the pool is actually
+    * saving, which is otherwise invisible.
+    */
+  def onForkReused(pid: Long, label: String): Unit
+}
+
+object JvmPoolListener {
+  val noop: JvmPoolListener = new JvmPoolListener {
+    def onForkStart(pid: Long, label: String, xmxMb: Option[Long]): Unit = ()
+    def onForkEnd(pid: Long, lifetimeMs: Long, exit: String, killedByUs: Option[String]): Unit = ()
+    def onForkReused(pid: Long, label: String): Unit = ()
+  }
+}

--- a/docs/guides/compile-servers.mdx
+++ b/docs/guides/compile-servers.mdx
@@ -95,17 +95,60 @@ or generated-code-heavy builds may need more.
 
 ### Compile-server heap
 
+**Start by looking.** Every time bleep brings a server up it says what
+that server's heap ceiling is, and what the machine has:
+
+```
+Ensuring BSP server (mode=shared, heap=max 12g of 48g RAM, socket=…)
+```
+
+That one line answers "how much am I actually getting?" without any
+digging, which matters more than it sounds — see the floor below.
+
+`max`, because `-Xmx` is a ceiling, not a reservation. Nothing is
+committed up front; ZGC grows the heap as it needs it and hands memory
+back to the OS when the server goes quiet. A server showing `max 12g`
+is usually resident in a fraction of that.
+
 ```bash
 bleep config compile-server max-memory 4g
 bleep config compile-server max-memory 2048m
 bleep config compile-server max-memory-clear   # back to bleep's default
 ```
 
-Sets the `-Xmx` for the compile server JVM(s) bleep starts. The
-default is a quarter of physical RAM, clamped to between 4g and
-16g. Reach for this when you're hitting `OutOfMemoryError` during
-compile, or when you have plenty of RAM and want to give the
-compiler room to breathe.
+#### The default, and its floor
+
+The default is a quarter of physical RAM, clamped to between 4g and 16g:
+
+```
+min(16g, max(4g, RAM / 4))
+```
+
+The clamp is the part worth internalising. A quarter of RAM *sounds*
+proportional, but the 4g floor swallows the whole low end — **every
+machine with 16 GB or less gets exactly 4g**, however much or little it
+has:
+
+| machine RAM | quarter | what you get |
+| --- | --- | --- |
+| 8 GB | 2 g | **4 g** — floor |
+| 14 GB | 3.5 g | **4 g** — floor |
+| 16 GB | 4 g | **4 g** — floor, only just |
+| 32 GB | 8 g | 8 g |
+| 48 GB | 12 g | 12 g |
+| 64 GB+ | 16 g+ | **16 g** — ceiling |
+
+So on a 16 GB laptop and a 14 GB CI runner the server is sized
+identically, and neither is "a quarter of RAM". If that is not what you
+want, say so explicitly — that is exactly what `max-memory` is for.
+
+Reach for it when you're hitting `OutOfMemoryError` during compile, or
+when you have plenty of RAM and want to give the compiler room to
+breathe. Raising it is not free, though: the server's footprint is
+subtracted from the budget your test forks draw on, so a bigger server
+means fewer forks running at once. [Memory &
+Parallelism](/docs/usage/resource-management#small-machines-and-ci) does
+that arithmetic properly, with a table of what fits.
 
 When the server does die of `OutOfMemoryError`, it exits
 immediately — no heap dump or core file is written. The client
@@ -125,9 +168,18 @@ Compiles, links, tests and sourcegen all draw from one budget:
 There is deliberately no separate cap for compiles. One existed briefly and
 was removed: holding capacity back for test forks that might not exist is a
 static partition inside an otherwise work-conserving governor, so a
-compile-only run left half the machine idle. Heap pressure is answered by
-watching the live heap and staggering starts, which responds to what is
-actually happening rather than guessing from a count.
+compile-only run left half the machine idle. Instead the scheduler does two
+distinct things, and it is worth knowing they are distinct because both show
+up as a compile that didn't start immediately:
+
+- it **staggers** a project's first admission attempt whenever something else
+  is already compiling, so a wave of projects doesn't all allocate at once;
+- it **defers under heap pressure**, watching the live heap rather than
+  guessing from a count.
+
+Both are recorded, each with its reason, so a slow build can tell you which
+one it was — see [Seeing what the server is
+doing](#what-the-events-mean).
 
 ```bash
 bleep config compile-server parallelism 4
@@ -181,6 +233,97 @@ Reach for this when test suites OOM (Testcontainers spinning up
 big stacks, generated-fixture tests with large classpaths).
 
 [Reference &rarr;](/docs/reference/cli/config/test-runner/)
+
+## Seeing what the server is doing
+
+The compile server is a long-lived JVM you never launched and can't see,
+which is a bad combination when a build is slower than you expect. So it
+keeps a running account of itself, always on — the overhead is one
+appended line per event — and there are three places to look.
+
+### The one-command answer
+
+```bash
+bleep server-metrics          # the most recent server
+bleep server-metrics <pid>    # a specific one
+```
+
+This reads that server's `metrics.jsonl`, renders it as an HTML page and
+opens it in your browser: heap and GC over time, a timeline of compiles,
+connections, sourcegen, and any OOM events. Start here.
+
+It does not yet chart everything the server records — the machine-level
+counters (`machine`), per-compile allocation, analysis-cache sharing and
+the admission decisions below are in the file but not on the page. For
+those, read `metrics.jsonl` directly; it is one JSON object per line and
+`jq` handles it comfortably.
+
+### The files
+
+Everything a server writes lives in its own socket directory, one per
+server — and you don't have to hunt for it, because bleep prints the path
+every time it brings one up:
+
+```
+Ensuring BSP server (mode=shared, heap=max 12g of 48g RAM, socket=…/socket/105026fd4c1726ac)
+BSP server ready (server log: …/socket/105026fd4c1726ac/output)
+```
+
+The parent differs per OS (`~/.cache/bleep` on Linux,
+`~/Library/Caches/build.bleep` on macOS, `%LOCALAPPDATA%\bleep\cache` on
+Windows), which is another reason to read it off the line rather than
+reconstruct it. Inside each `socket/<id>/`:
+
+| file | what it is |
+| --- | --- |
+| `metrics.jsonl` | append-only event log, one JSON object per line |
+| `output` | the server's own stdout/stderr, rotated |
+| `lock` | how bleep elects a single spawner |
+
+`metrics.jsonl` is flushed after every write, so it survives a crash —
+which is the point, since the interesting failures are the ones that take
+the server with them.
+
+### What the events mean
+
+Each line has a `type`. The ones worth knowing:
+
+| type | says |
+| --- | --- |
+| `compile_start` / `compile_end` | a project compiled, and for how long |
+| `compile_allocation` | how much that compile allocated — the biggest lever on heap |
+| `machine` | every 15s: cores in use, queue depth, fork budget, RAM, heap cap |
+| `jvm` | every 15s: heap used, GC counts and cycle times, threads |
+| `analysis_cache` | how much Zinc analysis is held, and how well it's shared |
+| `admission_defer` | a compile the scheduler declined to start, **and why** |
+| `oom_crash` / `oom_pressure` | the server ran out of heap, or came close |
+
+`admission_defer` carries a `reason`, and the distinction matters when
+you're reading a slow build:
+
+- **`stagger`** — the scheduler deliberately spread compiles out. Normal,
+  and nothing to do with memory. It happens on a project's first
+  admission attempt whenever anything else is compiling, at 5% heap as
+  readily as at 79%.
+- **`heap_pressure`** — the live heap was actually above the threshold and
+  the compile waited for room. *This* is the one that means "consider more
+  heap".
+
+It also carries `delay_ms`, so you can add up what the deferrals actually
+cost rather than counting them.
+
+> **Check `reason` before reaching for `max-memory`.** A build can be
+> entirely `stagger` and have never gone near its heap ceiling — in which
+> case more heap buys nothing.
+
+### In CI
+
+Whatever your CI does, the same files are sitting in the same place when
+a job goes wrong. bleep's own workflow collects them into a downloadable
+artifact on every architecture and prints a summary in the job log; if
+that is useful to you, `.github/scripts/collect-bsp-diagnostics.sh` and
+`summarise-bsp-metrics.py` in this repository are about forty lines
+between them and are not bleep-specific.
 
 ## Where this lives on disk
 

--- a/docs/guides/compile-servers.mdx
+++ b/docs/guides/compile-servers.mdx
@@ -316,14 +316,89 @@ cost rather than counting them.
 > entirely `stagger` and have never gone near its heap ceiling — in which
 > case more heap buys nothing.
 
-### In CI
+### In CI — where this pays off most
 
-Whatever your CI does, the same files are sitting in the same place when
-a job goes wrong. bleep's own workflow collects them into a downloadable
-artifact on every architecture and prints a summary in the job log; if
-that is useful to you, `.github/scripts/collect-bsp-diagnostics.sh` and
-`summarise-bsp-metrics.py` in this repository are about forty lines
-between them and are not bleep-specific.
+A slow build on your own machine you can poke at. A slow build on a CI
+runner is gone the moment the job ends, and CI is exactly where the
+interesting problems live: four cores instead of sixteen, a cold cache,
+and a memory ceiling you didn't choose. The same `metrics.jsonl` is
+sitting there when the job fails — it just needs collecting before the
+runner is destroyed.
+
+```yaml
+- name: Collect compile-server telemetry
+  if: always()          # the runs worth reading are the ones that failed
+  shell: bash
+  run: |
+    shopt -s nullglob
+    mkdir -p bsp-diagnostics
+    # The cache directory differs per OS, so cover all three rather than
+    # assuming the runner you happen to be on.
+    for d in ~/.cache/bleep/socket/*/ \
+             ~/Library/Caches/build.bleep/socket/*/ \
+             "$(command -v cygpath >/dev/null && cygpath "$LOCALAPPDATA" || echo /nonexistent)"/bleep/cache/socket/*/; do
+      name=$(basename "$d")
+      mkdir -p "bsp-diagnostics/$name"
+      for f in "$d"metrics.jsonl "$d"output; do
+        [ -f "$f" ] && cp "$f" "bsp-diagnostics/$name/"
+      done
+    done
+
+- uses: actions/upload-artifact@v7
+  if: always()
+  with:
+    name: bsp-diagnostics-${{ matrix.os }}
+    path: bsp-diagnostics
+```
+
+Two details that are easy to get wrong, and silent when you do:
+
+- **`if: always()`.** A job that exceeds its `timeout-minutes` is torn
+  down *with* its remaining steps, `always()` included — so if you are
+  chasing a hang, put a `timeout-minutes` on the *step* that hangs, below
+  the job's. Then the step fails, the job continues, and you get the
+  telemetry that explains it.
+- **The per-OS paths.** A Linux-only glob silently collects nothing on
+  Windows and macOS, which looks identical to "there was nothing to
+  collect".
+
+Download the artifact and read it with anything that speaks JSON:
+
+```bash
+# the slowest compiles
+jq -r 'select(.type=="compile_end") | "\(.duration_ms) \(.project)"' metrics.jsonl | sort -rn | head
+
+# was the machine ever full, or was work queued behind idle cores?
+jq -r 'select(.type=="machine") | "\(.used_cpu)/\(.total_cpu) running=\(.running) queued=\(.waiting)"' metrics.jsonl
+
+# what actually allocates
+jq -r 'select(.type=="compile_allocation") | "\(.allocated_mb) \(.project)"' metrics.jsonl | sort -rn | head
+```
+
+bleep's own workflow does exactly this on every architecture and prints a
+summary in the job log;
+`.github/scripts/collect-bsp-diagnostics.sh` and `summarise-bsp-metrics.py`
+in this repository are about forty lines between them and are not
+bleep-specific.
+
+### What this does *not* cover: test timings
+
+`metrics.jsonl` is about the compile server — compiles, sourcegen, heap,
+scheduling. It records **nothing about individual tests or suites**. If
+you are chasing a slow *test* run rather than a slow build, that data
+comes from a different file:
+
+```bash
+bleep test --junit-report target/test-reports
+```
+
+Standard JUnit XML, with `time=` on every `<testsuite>` **and** every
+`<testcase>` — so per-test durations, not just per-suite. Every CI system
+has a viewer for it, and it uploads as an artifact the same way.
+
+The two are complementary: the JUnit XML tells you *which suite* is slow,
+`metrics.jsonl` tells you whether the machine was starved of memory or
+cores while it ran.
 
 ## Where this lives on disk
 


### PR DESCRIPTION
The compile server is a long-lived JVM you never launched and cannot see. This makes it say what it is doing, and makes the dashboard show what it already records.

Grew well past its original one-line change — worth reading as three pieces.

## 1. The heap, at boot

```
Ensuring BSP server (mode=shared, heap=max 12g of 48g RAM, socket=…)
```

The cap was invisible until something went wrong, at which point it surfaced in an OOM message. It is worth stating up front because the default surprises: `min(16g, max(4g, RAM/4))` clamps to its **4g floor on anything at or below 16GB**, so a 16GB laptop and a 14GB CI runner are sized identically and neither gets "a quarter of RAM".

| RAM | quarter | actual |
|---|---|---|
| 14 GB (macos-15-intel runner) | 3.5 g | **4 g — floor** |
| 16 GB (windows runner, a laptop) | 4.0 g | **4 g — floor** |
| 48 GB | 12 g | 12 g |

`max`, because `-Xmx` is a ceiling and ZGC with `ZUncommitDelay=30` hands memory back; a bare size next to the machine's RAM reads like a reservation.

Verified against both paths: default, `max-memory 6g`, and `max-memory-clear`.

## 2. Telemetry the dashboard was throwing away

`bleep server-metrics` and the CI summariser read the same file and had drifted. Of twenty event types the server writes, the dashboard handled fourteen and dropped six via `case _ => ()` — and the six were the ones people arrive with questions about: `machine`, `admission_defer`, `compile_allocation`, `analysis_cache`, `workspace_state`.

Five new charts, six new cards. Two worth calling out:

- **Scheduling** draws CPU-in-use against cores with running and queued on top, because *saturated* and *starved* look identical from outside — a slow build — and have opposite fixes.
- **Deferred compiles** are split by reason. `stagger` is the scheduler spreading first starts apart and says nothing about memory; `heap_pressure` is a compile actually waiting for heap. Only the second argues for a bigger `-Xmx`. On a real 18-core dlab run: **115 defers, every one a stagger, zero heap pressure** — precisely the case that used to read as memory-starved under the old label.

Legacy `heap_pressure_stall` events are read too, and shown as `unlabelled (pre-rename)` rather than assigned a cause the data does not state. Not theoretical: the released M9 spawned a server mid-testing that wrote 42 of them.

`server-metrics --file <path>` opens any `metrics.jsonl`, so one downloaded from CI is read by the same dashboard as a local one — same file, same viewer. Verified on a real artifact of 353 events.

## 3. Forked test JVMs, which was recorded nowhere

The server recorded what it compiled; what it *ran* was invisible. Five events joined on **pid**: `fork_start`, `fork_reused`, `fork_end`, `suite_scheduled`, `suite_finished`.

`bleep-core` cannot call `bleep-bsp`, and a singleton it could reach is the global mutable state this codebase refuses — so `JvmPoolListener` inverts it: the pool announces, whoever builds it decides who listens, default no-op. `fork_end` carries `killed_by` separately from the exit summary because `destroyForcibly` sends SIGKILL and a fork bleep killed is otherwise indistinguishable from one the OS killed.

Charted as one lane per JVM — the pale bar is the fork's life, the segments on it are the suites that ran there. That answers *"which suite was on the JVM that got killed"*, otherwise a hand-join across three event types.

What it immediately showed on dlab (73 suites, 500 tests):

```
66 forks started, 7 reused          ~10% reuse; 59 forks ran exactly one suite
fork lifetime median 31.3s, max 1728.9s
26 suites timed out at ~28.8 min, across four different pids
```

The reuse rate may be intentional — the pool destroys rather than caches under memory contention — but no metric expressed it before.

## Docs

`docs/guides/compile-servers.mdx` gains the floor table, a telemetry section (where the files are, what the event types mean, stagger vs pressure), a CI recipe with tested `jq` one-liners, and an explicit note that **`metrics.jsonl` records nothing about individual tests** — `bleep test --junit-report` is where per-test timing lives.

## Verification

Everything here was checked by running it and reading the output, not by a green compile. That caught: `fork_end` never firing (shutdown bypasses `destroy`), `lifetime_ms: -1` (start instant read after the process died), `outcome: "Success$"`, a default parameter added mid-list that rebound every positional argument, and — twice — a dispatch edit that silently matched nothing, leaving charts guarded off on real data.

Final state exercised end to end on a 42-project dlab build: all nine charts and eight cards render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)