### PR TITLE
bsp: the socket dir was 0700 only by luck, and the luck ran out

### DIFF
--- a/bleep-bsp-tests/src/scala/bleep/bsp/SocketDirPermissionsTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/bsp/SocketDirPermissionsTest.scala
@@ -1,0 +1,72 @@
+package bleep.bsp
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.attribute.PosixFilePermissions
+import java.nio.file.{Files, Path}
+
+/** The socket directory is 0700 or the daemon does not start — at all, and not once.
+  *
+  * libdaemonjvm's `LockFiles.under` throws on any group/other permission bit, and it is the daemon's first act. The client can only see the symptom: a spawn
+  * that exits instantly, a retry, another instant exit, then "BSP server failed to start within 1 minute" with `socket file exists: false`. Since the bleep
+  * version is part of the JVM key, a directory that starts out wrong is never revisited by a binary that would get it right — it stays broken until someone
+  * chmods it by hand. Observed in the field with a default umask of 022, on a directory the client had created a moment earlier.
+  */
+class SocketDirPermissionsTest extends AnyFunSuite with Matchers {
+
+  private val OwnerOnly = PosixFilePermissions.fromString("rwx------")
+
+  private def tempDir(): Path = {
+    val d = Files.createTempDirectory("bleep-socket-perms")
+    d.toFile.deleteOnExit()
+    d
+  }
+
+  private def isPosix(p: Path): Boolean = p.getFileSystem.supportedFileAttributeViews().contains("posix")
+
+  test("a directory that does not exist yet is created 0700") {
+    val dir = tempDir().resolve("socket-dir")
+    BspServerOperations.ensureSocketDir(dir)
+
+    Files.isDirectory(dir) shouldBe true
+    if (isPosix(dir)) Files.getPosixFilePermissions(dir) shouldBe OwnerOnly
+  }
+
+  test("a directory left group/other readable by the umask is repaired, not accepted") {
+    val dir = tempDir().resolve("socket-dir")
+    Files.createDirectories(dir)
+    if (isPosix(dir)) {
+      // What `mkdir(2)` yields under the common umask of 022 — and what the client used to leave behind for the daemon.
+      Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwxr-xr-x")): Unit
+
+      BspServerOperations.ensureSocketDir(dir)
+
+      Files.getPosixFilePermissions(dir) shouldBe OwnerOnly
+    }
+  }
+
+  test("repairing keeps the directory's contents — logs and locks are not collateral") {
+    val dir = tempDir().resolve("socket-dir")
+    Files.createDirectories(dir)
+    val log = dir.resolve("output")
+    Files.write(log, "the crash trace".getBytes("UTF-8")): Unit
+    if (isPosix(dir)) Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwxrwxrwx")): Unit
+
+    BspServerOperations.ensureSocketDir(dir)
+
+    new String(Files.readAllBytes(log), "UTF-8") shouldBe "the crash trace"
+  }
+
+  test("the parent is left alone — only the lock directory itself is constrained") {
+    val parent = tempDir()
+    val dir = parent.resolve("socket-dir")
+    if (isPosix(parent)) {
+      val parentBefore = Files.getPosixFilePermissions(parent)
+
+      BspServerOperations.ensureSocketDir(dir)
+
+      Files.getPosixFilePermissions(parent) shouldBe parentBefore
+    }
+  }
+}

--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -10,13 +10,11 @@ import ryddig.jul.RyddigJulBridge
 import bleep.{MachineMemory, MachineResources}
 
 import java.nio.file.{Files, Path, Paths}
-import java.nio.file.attribute.PosixFilePermissions
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-import scala.util.Properties
 
 /** Daemon entry point for the BSP server.
   *
@@ -609,12 +607,9 @@ object BspServerDaemon {
     logger.info("Parent death monitor started (will exit on stdin EOF)")
   }
 
+  /** The client normally gets here first, so this mostly repairs rather than creates — but the daemon is the process `LockFiles.under` throws in, so it owns
+    * the last word on the permissions it demands.
+    */
   private def ensureSafeDirectoryExists(dir: Path): Unit =
-    if (!Files.exists(dir)) {
-      Files.createDirectories(dir)
-      if (!Properties.isWin) {
-        Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------"))
-        ()
-      }
-    }
+    BspServerOperations.ensureSocketDir(dir)
 }

--- a/bleep-core/src/scala/bleep/bsp/BspRifle.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifle.scala
@@ -106,7 +106,9 @@ object BspRifle {
         .make(IO.blocking {
           if (!jvmPermit.tryAcquire()) (Option.empty[java.nio.channels.FileChannel], false) // another fiber/thread here is spawning
           else {
-            Files.createDirectories(socketDir)
+            // 0700, not whatever the umask says: this is the first thing to create the directory, and the daemon refuses to lock one that is group/other
+            // readable (see BspServerOperations.ensureSocketDir).
+            BspServerOperations.ensureSocketDir(socketDir)
             val ch = java.nio.channels.FileChannel.open(spawnLockPath, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)
             val gotFile =
               try ch.tryLock() != null // null → another process holds it

--- a/bleep-core/src/scala/bleep/bsp/BspRifleConfig.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspRifleConfig.scala
@@ -82,7 +82,6 @@ object BspRifleConfig {
     "-Xss4m",
     "-XX:ReservedCodeCacheSize=512m",
     "-XX:+UseZGC",
-    "-XX:+ZGenerational",
     "-XX:ZUncommitDelay=30",
     "-XX:ZCollectionInterval=5",
     "-XX:+UseStringDeduplication",
@@ -107,6 +106,12 @@ object BspRifleConfig {
   /** JVM options that require a minimum JDK version */
   def jdkVersionOpts(jvmMajorVersion: Int): Seq[String] = {
     val opts = Seq.newBuilder[String]
+    // Generational ZGC was opt-in through JDK 23 and is the only mode from 24 on, where the flag was removed. Passing it anyway costs a warning line at the top
+    // of every server log ("Ignoring option ZGenerational; support was removed in 24.0") — noise directly above the stack traces people come to that file to
+    // read. `jvmMajorVersion` is 0 when the JVM name has no parsable version, which reads as "not a JDK we can vouch for": say nothing rather than guess.
+    if (jvmMajorVersion >= 21 && jvmMajorVersion < 24) {
+      opts += "-XX:+ZGenerational"
+    }
     if (jvmMajorVersion >= 22) {
       // The server resolves user paths via `UserPaths.fromAppDirs`, which on Windows/JDK22+ is an FFM downcall to SHGetKnownFolderPath (coursier-paths ships
       // that impl under META-INF/versions/22). Without this the JVM prints "WARNING: A restricted method in java.lang.foreign.Linker has been called" on every

--- a/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
+++ b/bleep-core/src/scala/bleep/bsp/BspServerOperations.scala
@@ -82,7 +82,7 @@ object BspServerOperations {
   def startServer(config: BspRifleConfig, logger: Logger): IO[Process] = IO
     .blocking {
       val socketDir = config.address.socketDir
-      ensureDirectoryExists(socketDir)
+      ensureSocketDir(socketDir)
 
       // Multi-GB heap dumps left behind by older bleep versions (whose servers ran with
       // -XX:+HeapDumpOnOutOfMemoryError) accumulate one per crash until the disk fills.
@@ -554,17 +554,26 @@ object BspServerOperations {
       paths.reverse.foreach(p => Files.deleteIfExists(p): Unit)
     } catch { case _: Exception => () }
 
-  /** Ensure a directory exists with proper permissions */
-  private def ensureDirectoryExists(dir: Path): Unit =
-    if (!Files.exists(dir)) {
-      Files.createDirectories(dir)
-      // Set restrictive permissions on Unix
-      try
-        Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------")): Unit
-      catch {
-        case _: UnsupportedOperationException => () // Windows
-      }
+  /** Create the socket directory if it is missing, and make an existing one 0700.
+    *
+    * libdaemonjvm's `LockFiles.under` — the first thing the daemon does — hard-fails on a socket directory carrying ANY group or other permission bit, and the
+    * client's retry loop just spawns another daemon that dies the same way. The failure is total and permanent for that bleep version (the version is part of
+    * the JVM key, so the directory is never revisited by an older binary that got it right): every spawn ends in "BSP server failed to start within 1 minute",
+    * with `socket file exists: false` forever, and only a manual `chmod 700` unsticks it.
+    *
+    * Which is exactly what a default umask of 022 produced. The permission fix used to be conditional on having just created the directory, but by then the
+    * client had already created it — `BspRifle.ensureRunning` mkdirs the socket dir to put its `.spawn-lock` there, before any of this runs — so `mkdir(2) &
+    * ~umask` decided the permissions and the fix never fired. Repairing unconditionally is what makes 0700 an invariant of the directory rather than a property
+    * of whoever happened to create it first.
+    */
+  def ensureSocketDir(dir: Path): Unit = {
+    Files.createDirectories(dir)
+    // Only the leaf: the parent cache directory is shared with unrelated bleep state and is nobody's lock directory.
+    if (dir.getFileSystem.supportedFileAttributeViews().contains("posix")) {
+      val wanted = PosixFilePermissions.fromString("rwx------")
+      if (Files.getPosixFilePermissions(dir) != wanted) Files.setPosixFilePermissions(dir, wanted): Unit
     }
+  }
 
   // ==========================================================================
   // Zombie Detection


### PR DESCRIPTION
## The failure

```
bleep.compile failed: BSP server failed to start within 1 minute
  socket file exists: false
  output file exists: true
  pid file: 99363
  socket dir: ~/Library/Caches/build.bleep/socket/c8c787357076bd46
```

Every retry did the same thing. The daemon's own log had the answer:

```
java.lang.IllegalArgumentException: .../c8c787357076bd46 has invalid permissions
  GROUP_EXECUTE, GROUP_READ, OTHERS_EXECUTE, OTHERS_READ
    at libdaemonjvm.LockFiles$.under(LockFiles.scala:83)
    at bleep.bsp.BspServerDaemon$.loop$1(BspServerDaemon.scala:110)
```

`LockFiles.under` rejects a lock directory carrying **any** group or other permission bit, and it is the daemon's first act — before it can log anything a client would see. The directory was `drwxr-xr-x`.

## Why it was 0755

Three places create the socket directory. Two set 0700. The third does not, and it is the one that runs first:

| | |
|---|---|
| `BspRifle.ensureRunning` | `Files.createDirectories(socketDir)` — added in #619 to host `.spawn-lock`. Plain mkdir, so `0777 & ~umask` decides. Under the standard umask 022 that is **0755**. |
| `BspServerOperations.ensureDirectoryExists` | set 0700, but guarded by `if (!Files.exists(dir))` → no-op, the client already made it |
| `BspServerDaemon.ensureSafeDirectoryExists` | same guard, same no-op |

So 0700 was a property of whoever created the directory first, and since #619 that is the one caller which didn't enforce it.

This is not a flake. The client retries into the same wall, and the bleep version is part of the JVM key — a directory born wrong is never revisited by a binary that would get it right. It stays broken until someone chmods it by hand. Timestamps from the reported incident: the directory was born at 14:50:38, and the failure is from 14:50.

## The fix

One `BspServerOperations.ensureSocketDir` that creates when missing **and** repairs when not, used by all three call sites. The leaf only — the parent cache directory is shared with unrelated bleep state and is nobody's lock directory.

`SocketDirPermissionsTest` pins it: fresh dir is 0700, a 0755 dir is repaired rather than accepted, repair preserves contents (logs, locks), and the parent is untouched.

## Also

`-XX:+ZGenerational` moves into `jdkVersionOpts`, gated to JDK 21–23. Generational ZGC is the only mode from 24 on, where the flag was removed, and passing it anyway printed `Ignoring option ZGenerational; support was removed in 24.0` at the top of every server log — directly above the stack traces people open that file to read. This changes the JVM key, so the first run after this mints a new socket dir.

## Not in scope

When the spawn times out, the client reports socket/pid/output *existence* but never the daemon's actual error, which sat in `output` the whole time. There is already an `oomHint` for the OOM case; extending it to tail the log on any startup failure would have turned this incident into a one-line answer. Happy to do it separately.

## Verification

`bleep fmt`; `bleep test bleep-bsp-tests` — 9 tests pass across the new suite and `ServerLogRetentionTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)