### PR TITLE
ci: fail when the generated doc snippets drift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,20 @@ jobs:
         # exercised now that the native-image matrix skips them.
         run: ./bleep-cli.sh --dev test
 
+      # `IntegrationTestHarness.commitSnippets` WRITES these files as a side effect of the tests above.
+      # It never compares them, so nothing failed while they drifted: the runner's checkout was updated
+      # and then thrown away. They had been stale since $version moved to 1.0.0-M11, and since the docs
+      # site is published from exactly these files, the site was showing a version nobody could install.
+      #
+      # No `if: always()`: on a test failure the snippets are legitimately half-written, and a second red
+      # step would only obscure the first.
+      - name: Snippets match what the tests generate
+        run: |
+          if ! git diff --exit-code -- docs-snippets-from-tests; then
+            echo "::error::docs-snippets-from-tests is stale. Run the tests locally and commit the result."
+            exit 1
+          fi
+
       # Always, including on failure and step timeout — a run that went wrong is the one whose telemetry
       # is worth having. CI is also the only environment with a realistic shape: 4 cores and 16GB,
       # where memory bounds actually bind. A developer machine cannot reproduce that.

--- a/bleep-tests/src/scala/bleep/IntegrationTestHarness.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationTestHarness.scala
@@ -20,8 +20,9 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
   *      the docs site's `<Snippet path="..." />` can include the same files the tests run against.
   *   3. Bootstraps `Started` in-process and runs assertions.
   *
-  * The snippets directory is git-tracked. CI can assert no diff (`git diff --exit-code docs-snippets-from-tests`) to catch drift between what tests exercise
-  * and what the site renders.
+  * The snippets directory is git-tracked, and [[commitSnippets]] only ever writes it — it does not compare, so a stale snippet fails nothing here. The `Build`
+  * workflow runs `git diff --exit-code docs-snippets-from-tests` after the suite to catch that; without it the drift is invisible, because CI updates the
+  * runner's checkout and then discards it. They had gone stale once already, and the site publishes these files, so it rendered a version nobody could install.
   */
 abstract class IntegrationTestHarness extends AnyFunSuite {
   protected val userPaths: UserPaths = UserPaths.fromAppDirs


### PR DESCRIPTION
`IntegrationTestHarness.commitSnippets` **writes** `docs-snippets-from-tests` as a side effect of the integration tests. It never compares, so a stale snippet failed nothing — CI updated the runner's checkout and then discarded it.

They had been stale for a while: `$version` still said `1.0.0-M10` across all nineteen, and the Kotlin snippet still named kotlin `2.3.21` against `model.Versions`' `2.4.10`. The docs site is published from exactly these files, so it was rendering a version nobody could install. (Regenerated separately in 499993d5.)

The harness scaladoc had already proposed this check — *"CI can assert no diff (`git diff --exit-code docs-snippets-from-tests`)"* — and it was never wired up, which made the doc read as though the drift was covered. This wires it up and corrects the scaladoc to describe what CI actually does.

No `if: always()`: on a test failure the snippets are legitimately half-written, and a second red step would only obscure the first.

Verified it fires — editing a snippet's `$version` makes the step exit non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)