### PR TITLE
ci: verify the hang bound instead of assuming it, and widen the Windows kill

### DIFF
--- a/.github/scripts/hang-tree.sh
+++ b/.github/scripts/hang-tree.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# A process tree that hangs, shaped like the hang `run-bounded.sh` exists to bound. Used only by the `bound-check` job.
+#
+# The shape is the whole point. A tree of bash `sleep`s would be reaped by the POSIX process-group kill on every
+# platform, so such a test would pass while the real thing kept failing — which is exactly the trap this is here to
+# avoid. What actually hung was `bleep` spawning a BSP daemon which forked test JVMs: those are GRANDCHILDREN, they are
+# native Windows processes outside any POSIX process group, and they had inherited the step's stdout. Both properties
+# have to be present or the test proves nothing.
+#
+#   - grandchild, not child: killing the direct child is what the first version of the bound did, and the hang came back.
+#   - a real Windows process: `start /B` detaches one that MSYS knows nothing about.
+#
+# It also writes to stdout before blocking, so a run that produces no output tells you the harness itself failed to
+# start rather than that the bound worked.
+set -uo pipefail
+
+echo "hang-tree: starting"
+
+if [ -n "${WINDIR:-}" ]; then
+  # Detached native grandchild. `ping -n` is the portable Windows sleep: no PowerShell startup cost, present on every
+  # runner image, and it shows up in `tasklist` under a name the check can look for.
+  cmd //c "start /B ping -n 3000 127.0.0.1 > NUL" || true
+  echo "hang-tree: spawned detached grandchild, now blocking"
+  ping -n 3000 127.0.0.1 >/dev/null
+else
+  # POSIX equivalent, so the job can run on Linux too and prove the bound is not Windows-only behaviour.
+  sleep 3000 &
+  echo "hang-tree: spawned background grandchild, now blocking"
+  sleep 3000
+fi

--- a/.github/scripts/run-bounded.sh
+++ b/.github/scripts/run-bounded.sh
@@ -68,14 +68,21 @@ kill_tree() {
     if [ -n "$winpid" ]; then
       taskkill //F //T //PID "$winpid" >/dev/null 2>&1 || true
     fi
-    # Belt and braces, because every part of the targeted path above can fail silently: /proc/<pid>/winpid may not
-    # exist for the child shape we got, and `taskkill //T` only walks the tree it can see. Both failures are masked by
-    # `|| true`, which is how a bound that looked correct let a 45-minute hang through three times.
+    # Belt and braces, and on Windows it is not optional: the `bound-check` job proved the targeted kill above does NOT
+    # reach a DETACHED grandchild. `start /B` leaves the intermediate `cmd` to exit, so by the time we look there is no
+    # live parent link to walk — `taskkill //T` cannot see it, and both that and the winpid translation fail silently
+    # behind `|| true`. That is how a 20-minute bound produced a 55-minute teardown three times: the survivor also held
+    # the step's stdout, and GitHub waits for the pipes, not for us.
     #
-    # By image name, so nothing has to be translated or walked. Safe here specifically: this runs on a CI runner at the
-    # moment we have already decided the tree is unsalvageable, and the only steps after it read files. It would not be
-    # safe on a developer machine, which is why it lives behind the timeout branch and not in normal teardown.
-    for image in java.exe bleep.exe; do
+    # By image name, because a descendant walk cannot find what has no living ancestor. Safe here specifically: this
+    # runs on a CI runner at the moment we have already decided the tree is unsalvageable, and the only steps after it
+    # read files. It would not be safe on a developer machine, which is why it lives behind the timeout branch.
+    #
+    # Configurable, so the images swept are the ones the bounded command can actually spawn — a hardcoded list is a
+    # guess that fails quietly when it is wrong, which is the whole failure mode being fixed here.
+    # node.exe belongs in the default alongside the JVMs: the Scala.js suites fork node, and a forked node inherits the
+    # step's stdout exactly like a test JVM does. It cannot hold the pipe open if it is not running.
+    for image in ${BOUND_KILL_IMAGES:-java.exe bleep.exe node.exe}; do
       taskkill //F //T //IM "$image" >/dev/null 2>&1 || true
     done
   fi

--- a/.github/scripts/run-bounded.sh
+++ b/.github/scripts/run-bounded.sh
@@ -68,6 +68,16 @@ kill_tree() {
     if [ -n "$winpid" ]; then
       taskkill //F //T //PID "$winpid" >/dev/null 2>&1 || true
     fi
+    # Belt and braces, because every part of the targeted path above can fail silently: /proc/<pid>/winpid may not
+    # exist for the child shape we got, and `taskkill //T` only walks the tree it can see. Both failures are masked by
+    # `|| true`, which is how a bound that looked correct let a 45-minute hang through three times.
+    #
+    # By image name, so nothing has to be translated or walked. Safe here specifically: this runs on a CI runner at the
+    # moment we have already decided the tree is unsalvageable, and the only steps after it read files. It would not be
+    # safe on a developer machine, which is why it lives behind the timeout branch and not in normal teardown.
+    for image in java.exe bleep.exe; do
+      taskkill //F //T //IM "$image" >/dev/null 2>&1 || true
+    done
   fi
   kill -9 -- "-$child_pid" 2>/dev/null || true
   kill -9 "$child_pid" 2>/dev/null || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,11 @@ jobs:
 
       - name: A hang fails the step, and ends it
         shell: bash
+        env:
+          # The images this harness can spawn, standing in for java.exe/bleep.exe in the real step. Passed explicitly
+          # because the sweep must name what the bounded command actually starts; a hardcoded list is a guess, and this
+          # job exists to stop guesses shipping.
+          BOUND_KILL_IMAGES: ping.exe
         run: |
           start=$SECONDS
           set +e
@@ -219,9 +224,19 @@ jobs:
               exit 1
             fi
           else
-            if pgrep -f "sleep 3000" >/dev/null 2>&1; then
+            # `pgrep -x sleep` then filter on args, NOT `pgrep -f "sleep 3000"`. The -f form matches any process whose
+            # command line merely CONTAINS the pattern — including this step's own ancestry, which mentions it in the
+            # check itself. That false-positived locally and would have reported a survivor that did not exist. Matching
+            # comm exactly means no shell can satisfy it.
+            survivors=""
+            for pid in $(pgrep -x sleep 2>/dev/null || true); do
+              case "$(ps -o args= -p "$pid" 2>/dev/null)" in
+                *3000*) survivors="$survivors $pid" ;;
+              esac
+            done
+            if [ -n "$survivors" ]; then
               echo "::error title=Survivor::a sleep outlived the kill — the process tree was not reaped"
-              pgrep -af "sleep 3000" || true
+              ps -o pid,ppid,pgid,args -p ${survivors# } || true
               exit 1
             fi
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,76 @@ jobs:
                 "schema.json": [ "**/bleep.yaml" ]
             }
 
+  # `run-bounded.sh` is the only thing standing between a hung test step and a destroyed runner, and nothing exercised
+  # it. It failed three times — runs 30697246865, 30752489661 and 31268861301 — each time reaching the job's ceiling at
+  # 55m00s, which tears down the `if: always()` telemetry steps and leaves no artifact and no retrievable log. The one
+  # hang worth reading is the one that reports nothing.
+  #
+  # Every fix so far was reasoned and shipped unverified, which is why the same signature came back twice. This job is
+  # the verification: hang deliberately, and assert the bound does what the surrounding steps depend on it doing.
+  #
+  # Both arches: the mechanism is meant to be one code path, and running it on Linux too keeps a Windows-only
+  # regression from hiding behind "it works locally".
+  bound-check:
+    name: run-bounded.sh bounds a hang on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    # Generously above the 30s bound under test, and far below the native-image job's 45: if this job is ever itself
+    # reaped by its own ceiling, that IS the failure being tested for, and it should look different from a hang.
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: A hang fails the step, and ends it
+        shell: bash
+        run: |
+          start=$SECONDS
+          set +e
+          bash .github/scripts/run-bounded.sh 30 bash .github/scripts/hang-tree.sh
+          rc=$?
+          set -e
+          elapsed=$((SECONDS - start))
+          echo "exit=$rc elapsed=${elapsed}s"
+
+          # 124 is what the bound reports on expiry, matching timeout(1).
+          if [ "$rc" != "124" ]; then
+            echo "::error title=Bound did not fire::expected exit 124 after ~30s, got $rc"
+            exit 1
+          fi
+
+          # The assertion that matters, and the one no previous fix checked. Killing the child is necessary but not
+          # sufficient: GitHub waits for the step's output pipes to close, so a surviving grandchild holding stdout keeps
+          # the step alive even though the bound "fired". That is precisely how a 20-minute bound became a 55-minute
+          # teardown. If we got here at all the pipes closed; this pins how long that took.
+          if [ "$elapsed" -ge 120 ]; then
+            echo "::error title=Bound fired but the step did not end::took ${elapsed}s for a 30s bound"
+            exit 1
+          fi
+
+      - name: Nothing survived the kill
+        if: always()
+        shell: bash
+        # Requirement 1 from the script's header: the whole tree dies, not just the direct child. Checked after the fact
+        # rather than trusted, because both the winpid translation and `taskkill //T` fail silently behind `|| true`.
+        run: |
+          if [ -n "${WINDIR:-}" ]; then
+            if tasklist //FI "IMAGENAME eq PING.EXE" 2>/dev/null | grep -qi "ping.exe"; then
+              echo "::error title=Survivor::ping.exe outlived the kill — the process tree was not reaped"
+              tasklist //FI "IMAGENAME eq PING.EXE" 2>/dev/null || true
+              exit 1
+            fi
+          else
+            if pgrep -f "sleep 3000" >/dev/null 2>&1; then
+              echo "::error title=Survivor::a sleep outlived the kill — the process tree was not reaped"
+              pgrep -af "sleep 3000" || true
+              exit 1
+            fi
+          fi
+          echo "no survivors"
+
   build-intellij-plugin:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
`run-bounded.sh` is the only thing between a hung test step and a destroyed runner, and **nothing exercised it.**

It has failed three times — runs `30697246865`, `30752489661`, `31268861301` — each reaching the job's ceiling at **55m00s**, which tears down the `if: always()` telemetry steps. The result is no artifact and no retrievable log (`BlobNotFound`), so the one hang worth reading is the one that reports nothing. Every fix so far was reasoned and shipped unverified, which is why the same signature came back twice.

### A job that hangs on purpose

`bound-check` runs a deliberate hang and asserts the bound does what the surrounding steps depend on it doing.

**The harness shape is the point.** A tree of bash `sleep`s is reaped by the process-group kill on every platform, so that test would pass while the real thing kept failing. `hang-tree.sh` spawns a detached **native Windows grandchild**, because what actually hung was `bleep` → BSP daemon → forked test JVMs: grandchildren, outside any POSIX process group, holding the step's stdout.

Three assertions:
- exit **124** on expiry
- **the step ended** — elapsed < 120s for a 30s bound. Killing the child is necessary but not sufficient: GitHub waits for the output pipes to close, and a survivor holding stdout is exactly how a 20-minute bound became a 55-minute teardown. No previous fix checked this.
- **nothing outlived the kill**

Runs on `windows-latest` and `ubuntu-latest` so a Windows-only regression can't hide behind "works locally".

### A wider kill on Windows

Every part of the targeted path can fail silently — `/proc/<pid>/winpid` may not exist for the child shape, and `taskkill //T` only walks the tree it can see, both masked by `|| true`. Now also sweeps `java.exe`/`bleep.exe` by image name. Safe *here specifically*: it runs on a CI runner at the point we've already decided the tree is unsalvageable, and the only later steps read files.

### Verified before pushing

Which is the habit that was missing: expiry returns 124, a normal exit passes its own code through (7), no survivors.

Note this does **not** explain the original hang — that evidence was destroyed. It makes the next one diagnosable, which is the prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)