### PR TITLE
feat: --max-time, so a stuck build ends itself and says why

### DIFF
--- a/.github/scripts/collect-bsp-diagnostics.sh
+++ b/.github/scripts/collect-bsp-diagnostics.sh
@@ -47,6 +47,22 @@ if [ -n "${LOCALAPPDATA:-}" ]; then
   fi
 fi
 
+# The `--max-time` thread dump, if bleep bounded itself on this run. Collected FIRST, and before the early exit
+# below: it lives in the workspace rather than the server's socket dir, and it is the one artifact that exists
+# precisely when the run went wrong. A run with no socket dirs at all is exactly when you would still want it.
+dumps=(.bleep/builds/*/max-time-thread-dump.txt)
+if [ ${#dumps[@]} -gt 0 ]; then
+  mkdir -p "$out"
+  for f in "${dumps[@]}"; do
+    variant=$(basename "$(dirname "$f")")
+    cp "$f" "$out/max-time-thread-dump-$variant.txt"
+    echo "collected max-time thread dump for variant '$variant' ($(wc -c <"$f" | tr -d ' ') bytes)"
+    echo "::warning::bleep exceeded --max-time on this run; thread dump is in the bsp-diagnostics artifact"
+  done
+else
+  echo "no --max-time thread dump (the build was not bounded out)"
+fi
+
 echo "compile-server socket dirs:"
 dirs=()
 for root in "${roots[@]}"; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,10 @@ jobs:
         timeout-minutes: 22
         # No tag exclusions: this is the canonical full-suite gate, and the only place the platform linkers are
         # exercised now that the native-image matrix skips them.
-        run: ./bleep-cli.sh --dev test
+        # `--max-time` sized just under the step's 22-minute cap, so bleep gives up on itself before GitHub reaps it.
+        # That difference is the whole point: bleep exiting on its own ends the step cleanly and leaves the telemetry
+        # steps below alive, where a GitHub-side reap destroys them along with the runner.
+        run: ./bleep-cli.sh --dev test --max-time 20m
 
       # `IntegrationTestHarness.commitSnippets` WRITES these files as a side effect of the tests above.
       # It never compares them, so nothing failed while they drifted: the runner's checkout was updated
@@ -400,7 +403,15 @@ jobs:
         # lands at 42 and leaves the job cap as the last line rather than the first one to fire.
         timeout-minutes: 25
         run: |
-          bash .github/scripts/run-bounded.sh 1200 ./${{ matrix.file_name }} --dev test --no-color jvm3 --exclude-tag slow
+          # Two bounds, deliberately ordered 19m < 20m. `--max-time` is bleep bounding itself: it cancels the build,
+          # writes a thread dump of the client AND the compile server to `.bleep/builds/*/max-time-thread-dump.txt`,
+          # and exits non-zero — so the step ends normally and the telemetry steps below still run. `run-bounded.sh`
+          # stays as the outer backstop for the case `--max-time` structurally cannot cover, which is the client being
+          # unable to act at all.
+          #
+          # 19m rather than a tighter number on purpose: it sits just under the bound that is already enforced here, so
+          # this can only convert an existing kill into a clean exit. It cannot fail a run that passes today.
+          bash .github/scripts/run-bounded.sh 1200 ./${{ matrix.file_name }} --dev test --no-color jvm3 --exclude-tag slow --max-time 19m
           bash .github/scripts/run-bounded.sh 120 ./${{ matrix.file_name }} selftest
 
       # Same telemetry as the `build` job. This matrix is the only place Windows and macOS run, so without

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -11,6 +11,7 @@ import ryddig.Logger
 
 import java.nio.file.{Path, Paths}
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Properties, Success, Try}
 
 object Main {
@@ -179,18 +180,32 @@ object Main {
 
     val cancel = Opts.flag("cancel", "cancel any running build before starting").orFalse
 
+    /** Wall-clock ceiling for the build, e.g. `--max-time 15m`.
+      *
+      * Off unless asked for. A default here would eventually kill somebody's legitimately long clean build, and there is no value that is right for both a
+      * laptop and a cold CI runner — which is the same reason it is a per-invocation flag rather than a setting on the shared compile server, where whichever
+      * client happened to spawn the daemon would silently impose its choice on everyone else.
+      */
+    val maxTime: Opts[Option[FiniteDuration]] =
+      Opts
+        .option[String]("max-time", "give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing")
+        .mapValidated(str => Validated.fromEither(internal.MaxTime.parse(str).left.map(NonEmptyList.one)))
+        .orNone
+
     val commonBuildOpts: Opts[commands.CommonBuildOpts] = (
       (
         Opts.flag("no-tui", "disable TUI, show summary only (for CI/agents)").orFalse,
         Opts.flag("quiet", "alias for --no-tui", "q").orFalse
       ).mapN(_ || _),
       Opts.flag("flamegraph", "generate execution trace (open in chrome://tracing or ui.perfetto.dev)").orFalse,
-      cancel
-    ).mapN { case (noTui, flamegraph, cancel) =>
+      cancel,
+      maxTime
+    ).mapN { case (noTui, flamegraph, cancel, maxTime) =>
       commands.CommonBuildOpts(
         displayMode = commands.DisplayMode.fromFlags(noTui),
         flamegraph = flamegraph,
-        cancel = cancel
+        cancel = cancel,
+        maxTime = maxTime
       )
     }
 
@@ -343,12 +358,13 @@ object Main {
               ).mapN(_ || _),
               Opts.flag("diff-watch", "watch mode with per-project diffs between cycles").orFalse,
               Opts.flag("flamegraph", "generate execution trace (open in chrome://tracing or ui.perfetto.dev)").orFalse,
-              cancel
-            ).mapN { case (watch, projectNames, noTui, diffWatch, flamegraph, cancel) =>
+              cancel,
+              maxTime
+            ).mapN { case (watch, projectNames, noTui, diffWatch, flamegraph, cancel, maxTime) =>
               val (effectiveWatch, effectiveDisplayMode) =
                 if (diffWatch) (true, commands.DisplayMode.DiffWatch)
                 else (watch, commands.DisplayMode.fromFlags(noTui))
-              commands.ReactiveBsp.compile(effectiveWatch, projectNames, effectiveDisplayMode, flamegraph, cancel)
+              commands.ReactiveBsp.compile(effectiveWatch, projectNames, effectiveDisplayMode, flamegraph, cancel, maxTime)
             }
           ),
           Opts.subcommand("link", "link JS or Native projects (Scala.js / Scala Native / Kotlin/JS / Kotlin/Native), produces .js or a native executable")(
@@ -367,8 +383,9 @@ object Main {
                 Opts.flag("quiet", "alias for --no-tui", "q").orFalse
               ).mapN(_ || _),
               Opts.flag("flamegraph", "generate execution trace (open in chrome://tracing or ui.perfetto.dev)").orFalse,
-              cancel
-            ).mapN { case (watch, projectNames, release, sourceMaps, minify, moduleKind, lto, optimize, debugInfo, noTui, flamegraph, cancel) =>
+              cancel,
+              maxTime
+            ).mapN { case (watch, projectNames, release, sourceMaps, minify, moduleKind, lto, optimize, debugInfo, noTui, flamegraph, cancel, maxTime) =>
               val linkOptions = commands.LinkOptions(
                 releaseMode = release,
                 sourceMaps = sourceMaps,
@@ -378,7 +395,7 @@ object Main {
                 optimize = optimize,
                 debugInfo = debugInfo
               )
-              commands.ReactiveBsp.link(watch, projectNames, commands.DisplayMode.fromFlags(noTui), linkOptions, flamegraph, cancel)
+              commands.ReactiveBsp.link(watch, projectNames, commands.DisplayMode.fromFlags(noTui), linkOptions, flamegraph, cancel, maxTime)
             }
           ),
           Opts.subcommand("sourcegen", "run source generators for projects")(
@@ -403,26 +420,44 @@ object Main {
               excludeTag,
               Opts.flag("flamegraph", "generate execution trace (open in chrome://tracing or ui.perfetto.dev)").orFalse,
               cancel,
-              Opts.option[String]("junit-report", "write JUnit XML reports to this directory").orNone
-            ).mapN { case (watch, projectNames, noTui, diffWatch, jvmOpts, testArgs, only, exclude, onlyTag, excludeTag, flamegraph, cancel, junitReportDir) =>
-              val (effectiveWatch, effectiveDisplayMode) =
-                if (diffWatch) (true, commands.DisplayMode.DiffWatch)
-                else (watch, commands.DisplayMode.fromFlags(noTui))
-              commands.ReactiveBsp.test(
-                watch = effectiveWatch,
-                projects = projectNames,
-                displayMode = effectiveDisplayMode,
-                jvmOptions = jvmOpts.toList,
-                testArgs = testArgs.toList,
-                only = only.map(_.toList).getOrElse(Nil),
-                exclude = exclude.map(_.toList).getOrElse(Nil),
-                includeTags = onlyTag.map(_.toList).getOrElse(Nil),
-                excludeTags = excludeTag.map(_.toList).getOrElse(Nil),
-                flamegraph = flamegraph,
-                cancel = cancel,
-                junitReportDir = junitReportDir.map(java.nio.file.Paths.get(_)),
-                clientEnv = bleep.bsp.protocol.BleepBspProtocol.ClientEnv.current()
-              )
+              Opts.option[String]("junit-report", "write JUnit XML reports to this directory").orNone,
+              maxTime
+            ).mapN {
+              case (
+                    watch,
+                    projectNames,
+                    noTui,
+                    diffWatch,
+                    jvmOpts,
+                    testArgs,
+                    only,
+                    exclude,
+                    onlyTag,
+                    excludeTag,
+                    flamegraph,
+                    cancel,
+                    junitReportDir,
+                    maxTime
+                  ) =>
+                val (effectiveWatch, effectiveDisplayMode) =
+                  if (diffWatch) (true, commands.DisplayMode.DiffWatch)
+                  else (watch, commands.DisplayMode.fromFlags(noTui))
+                commands.ReactiveBsp.test(
+                  watch = effectiveWatch,
+                  projects = projectNames,
+                  displayMode = effectiveDisplayMode,
+                  jvmOptions = jvmOpts.toList,
+                  testArgs = testArgs.toList,
+                  only = only.map(_.toList).getOrElse(Nil),
+                  exclude = exclude.map(_.toList).getOrElse(Nil),
+                  includeTags = onlyTag.map(_.toList).getOrElse(Nil),
+                  excludeTags = excludeTag.map(_.toList).getOrElse(Nil),
+                  flamegraph = flamegraph,
+                  cancel = cancel,
+                  junitReportDir = junitReportDir.map(java.nio.file.Paths.get(_)),
+                  clientEnv = bleep.bsp.protocol.BleepBspProtocol.ClientEnv.current(),
+                  maxTime = maxTime
+                )
             }
           ),
           Opts.subcommand("list-tests", "list tests in projects")(

--- a/bleep-core/src/scala/bleep/Commands.scala
+++ b/bleep-core/src/scala/bleep/Commands.scala
@@ -11,14 +11,16 @@ class Commands(started: Started) {
     commands.CommonBuildOpts(
       displayMode = commands.DisplayMode.NoTui,
       flamegraph = false,
-      cancel = false
+      cancel = false,
+      // Scripts are not bounded: a script is somebody's own program, and bleep has no basis for deciding how long it may take.
+      maxTime = None
     )
 
   def clean(projects: List[model.CrossProjectName]): Unit =
     force(commands.Clean(projects.toArray))
 
   def compile(projects: List[model.CrossProjectName], watch: Boolean = false): Unit =
-    force(commands.ReactiveBsp.compile(watch, projects.toArray, commands.DisplayMode.NoTui, flamegraph = false, cancel = false))
+    force(commands.ReactiveBsp.compile(watch, projects.toArray, commands.DisplayMode.NoTui, flamegraph = false, cancel = false, maxTime = None))
 
   def run(
       project: model.CrossProjectName,
@@ -51,7 +53,8 @@ class Commands(started: Started) {
         flamegraph = false,
         cancel = false,
         junitReportDir = None,
-        clientEnv = bleep.bsp.protocol.BleepBspProtocol.ClientEnv.current()
+        clientEnv = bleep.bsp.protocol.BleepBspProtocol.ClientEnv.current(),
+        maxTime = None
       )
     )
 

--- a/bleep-core/src/scala/bleep/commands/CommonBuildOpts.scala
+++ b/bleep-core/src/scala/bleep/commands/CommonBuildOpts.scala
@@ -9,5 +9,7 @@ package commands
 case class CommonBuildOpts(
     displayMode: DisplayMode,
     flamegraph: Boolean,
-    cancel: Boolean
+    cancel: Boolean,
+    /** Wall-clock ceiling for the build this command triggers, from `--max-time`. `None` means unbounded. */
+    maxTime: Option[scala.concurrent.duration.FiniteDuration]
 )

--- a/bleep-core/src/scala/bleep/commands/Dist.scala
+++ b/bleep-core/src/scala/bleep/commands/Dist.scala
@@ -27,7 +27,8 @@ case class Dist(watch: Boolean, options: Dist.Options, buildOpts: CommonBuildOpt
           projects = Array(options.project),
           displayMode = buildOpts.displayMode,
           flamegraph = buildOpts.flamegraph,
-          cancel = buildOpts.cancel
+          cancel = buildOpts.cancel,
+          maxTime = buildOpts.maxTime
         )
         .run(started)
       mainClass <- options.overrideMain match {

--- a/bleep-core/src/scala/bleep/commands/Publish.scala
+++ b/bleep-core/src/scala/bleep/commands/Publish.scala
@@ -211,7 +211,8 @@ case class Publish(watch: Boolean, options: Publish.Options, buildOpts: CommonBu
           projects = projects,
           displayMode = buildOpts.displayMode,
           flamegraph = buildOpts.flamegraph,
-          cancel = buildOpts.cancel
+          cancel = buildOpts.cancel,
+          maxTime = buildOpts.maxTime
         )
         .run(started)
       version <- resolveVersion()

--- a/bleep-core/src/scala/bleep/commands/PublishLocal.scala
+++ b/bleep-core/src/scala/bleep/commands/PublishLocal.scala
@@ -44,7 +44,8 @@ case class PublishLocal(watch: Boolean, options: PublishLocal.Options, buildOpts
         projects = options.projects,
         displayMode = buildOpts.displayMode,
         flamegraph = buildOpts.flamegraph,
-        cancel = buildOpts.cancel
+        cancel = buildOpts.cancel,
+        maxTime = buildOpts.maxTime
       )
       .run(started)
       .map { case () =>

--- a/bleep-core/src/scala/bleep/commands/PublishSonatype.scala
+++ b/bleep-core/src/scala/bleep/commands/PublishSonatype.scala
@@ -33,7 +33,8 @@ case class PublishSonatype(options: PublishSonatype.Options, buildOpts: CommonBu
         projects = projects,
         displayMode = buildOpts.displayMode,
         flamegraph = buildOpts.flamegraph,
-        cancel = buildOpts.cancel
+        cancel = buildOpts.cancel,
+        maxTime = buildOpts.maxTime
       )
       .run(started)
       .map { case () =>

--- a/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
+++ b/bleep-core/src/scala/bleep/commands/ReactiveBsp.scala
@@ -12,6 +12,7 @@ import cats.effect.unsafe.implicits.global
 import ch.epfl.scala.bsp4j
 
 import java.nio.file.Path
+import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
@@ -45,7 +46,11 @@ case class ReactiveBsp(
       * `sys.env` read at the send site so tests can inject values that are provably not in the running JVM's own environment — the only way to prove the value
       * travelled over BSP rather than being inherited by the fork.
       */
-    clientEnv: Map[String, String]
+    clientEnv: Map[String, String],
+    /** Wall-clock ceiling for one run of this command, from `--max-time`. `None` means unbounded, which is the default: a bound nobody asked for would kill
+      * somebody's legitimately long build. Applied per run, so in `--watch` each cycle gets the full budget.
+      */
+    maxTime: Option[FiniteDuration]
 ) extends BleepBuildCommand {
 
   /** Persists across watch cycles for per-project diff (only used in DiffWatch mode) */
@@ -59,6 +64,21 @@ case class ReactiveBsp(
   override def run(started: Started): Either[BleepException, Unit] =
     if (watch) WatchMode.run(started, s => TransitiveProjects(s.build, projects))(runOnce)
     else runOnce(started)
+
+  /** The bound for one run, or `None` when `--max-time` was not given.
+    *
+    * `serverPids` is what makes the dump worth having: the compile server is not a descendant of this process, so nothing else would find it, and it is usually
+    * the half that is actually stuck. `jvmBinDirs` supplies a `jstack` — this client is a native image and has no JDK of its own.
+    */
+  private def maxTimeFor(started: Started, serverPids: List[Long]): Option[bleep.internal.MaxTime] =
+    maxTime.map { duration =>
+      bleep.internal.MaxTime(
+        duration = duration,
+        dumpTo = started.buildPaths.workspaceVariantDir / "max-time-thread-dump.txt",
+        jvmBinDirs = List(started.jvmCommand.getParent),
+        serverPids = serverPids
+      )
+    }
 
   private def runOnce(started: Started): Either[BleepException, Unit] = {
     // For `bleep test --only-tag slow`, prune projects whose `testTags` declare none of the requested tags before BSP dispatch.
@@ -197,7 +217,8 @@ case class ReactiveBsp(
     } yield summary
 
     try {
-      val summary = program.unsafeRunSync()
+      // No separate daemon in this mode, so there is no server pid to dump — the work is happening on these threads.
+      val summary = bleep.internal.MaxTime.bound(maxTimeFor(started, serverPids = Nil), program).unsafeRunSync()
       resultFromSummary(summary)
     } catch {
       case ex: Exception =>
@@ -476,7 +497,8 @@ case class ReactiveBsp(
     var errorOpt: Option[Throwable] = None
 
     try {
-      val summary = program.unsafeRunSync()
+      val serverPids = bleep.bsp.BspServerOperations.readPid(config.address.socketDir.resolve("pid")).unsafeRunSync().toList
+      val summary = bleep.internal.MaxTime.bound(maxTimeFor(started, serverPids), program).unsafeRunSync()
       summaryOpt = Some(summary)
       resultFromSummary(summary)
     } catch {
@@ -965,7 +987,8 @@ object ReactiveBsp {
       projects: Array[model.CrossProjectName],
       displayMode: DisplayMode,
       flamegraph: Boolean,
-      cancel: Boolean
+      cancel: Boolean,
+      maxTime: Option[FiniteDuration]
   ): ReactiveBsp = ReactiveBsp(
     watch = watch,
     projects = projects,
@@ -981,7 +1004,8 @@ object ReactiveBsp {
     flamegraph = flamegraph,
     cancel = cancel,
     junitReportDir = None,
-    clientEnv = Map.empty
+    clientEnv = Map.empty,
+    maxTime = maxTime
   )
 
   /** Create test-bsp command */
@@ -998,7 +1022,8 @@ object ReactiveBsp {
       flamegraph: Boolean,
       cancel: Boolean,
       junitReportDir: Option[Path],
-      clientEnv: Map[String, String]
+      clientEnv: Map[String, String],
+      maxTime: Option[FiniteDuration]
   ): ReactiveBsp = ReactiveBsp(
     watch = watch,
     projects = projects,
@@ -1014,7 +1039,8 @@ object ReactiveBsp {
     flamegraph = flamegraph,
     cancel = cancel,
     junitReportDir = junitReportDir,
-    clientEnv = clientEnv
+    clientEnv = clientEnv,
+    maxTime = maxTime
   )
 
   /** Create link-bsp command */
@@ -1024,7 +1050,8 @@ object ReactiveBsp {
       displayMode: DisplayMode,
       options: LinkOptions,
       flamegraph: Boolean,
-      cancel: Boolean
+      cancel: Boolean,
+      maxTime: Option[FiniteDuration]
   ): ReactiveBsp = ReactiveBsp(
     watch = watch,
     projects = projects,
@@ -1040,6 +1067,7 @@ object ReactiveBsp {
     flamegraph = flamegraph,
     cancel = cancel,
     junitReportDir = None,
-    clientEnv = Map.empty
+    clientEnv = Map.empty,
+    maxTime = maxTime
   )
 }

--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -68,7 +68,8 @@ case class Run(
         projects = Array(project),
         displayMode = buildOpts.displayMode,
         flamegraph = buildOpts.flamegraph,
-        cancel = buildOpts.cancel
+        cancel = buildOpts.cancel,
+        maxTime = buildOpts.maxTime
       )
       .run(started)
 
@@ -80,7 +81,8 @@ case class Run(
         displayMode = buildOpts.displayMode,
         options = LinkOptions.Debug,
         flamegraph = buildOpts.flamegraph,
-        cancel = buildOpts.cancel
+        cancel = buildOpts.cancel,
+        maxTime = buildOpts.maxTime
       )
       .run(started)
 

--- a/bleep-core/src/scala/bleep/commands/Script.scala
+++ b/bleep-core/src/scala/bleep/commands/Script.scala
@@ -10,7 +10,7 @@ case class Script(name: model.ScriptName, args: List[String], watch: Boolean) ex
 
 object Script {
   private val scriptBuildOpts: CommonBuildOpts =
-    CommonBuildOpts(DisplayMode.NoTui, flamegraph = false, cancel = false)
+    CommonBuildOpts(DisplayMode.NoTui, flamegraph = false, cancel = false, maxTime = None)
 
   def run(started: Started, scriptDefs: Seq[model.ScriptDef], args: List[String], watch: Boolean): Either[BleepException, Unit] =
     traverseish.runAll(scriptDefs) { case model.ScriptDef.Main(project, main, _) =>

--- a/bleep-core/src/scala/bleep/internal/MaxTime.scala
+++ b/bleep-core/src/scala/bleep/internal/MaxTime.scala
@@ -1,0 +1,103 @@
+package bleep
+package internal
+
+import cats.effect.IO
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.file.{Files, Path}
+import scala.concurrent.duration.*
+
+/** How long a build operation may take before bleep cancels it and says why.
+  *
+  * @param duration
+  *   wall-clock ceiling for the operation
+  * @param dumpTo
+  *   where the thread dump goes when the ceiling is hit. A file rather than the log, because the point is to survive the process exiting — in CI the
+  *   interesting run is the one whose console output nobody kept.
+  * @param jvmBinDirs
+  *   JVM `bin` directories to find `jstack` in. The client is a native image with no JDK of its own, so without this it can only dump its own threads — see
+  *   [[ChildProcessDiagnostics.dumpAll]].
+  * @param serverPids
+  *   compile servers to dump alongside this process. They are not descendants of the client, so nothing else finds them, and they are usually the half doing
+  *   the work that got stuck.
+  */
+case class MaxTime(
+    duration: FiniteDuration,
+    dumpTo: Path,
+    jvmBinDirs: List[Path],
+    serverPids: List[Long]
+)
+
+object MaxTime {
+
+  /** Run `program`, giving up after [[MaxTime.duration]].
+    *
+    * The ladder, in order:
+    *
+    *   1. cancel — cancelling the fiber cancels the outstanding BSP future, which makes lsp4j send `$/cancelRequest`. The server has that in its
+    *      `immediatelyHandled` set, so it lands even while a compile is running in a background fiber.
+    *   1. diagnose — dump this process's threads plus the compile server's to [[MaxTime.dumpTo]].
+    *   1. fail — a [[BleepException]], so the command exits non-zero through the normal path.
+    *
+    * It deliberately stops there. Killing the compile server would be collateral for a daemon serving other workspaces, and buys nothing for the case this
+    * exists for: the client exiting is already enough to end a CI step and let the telemetry steps run.
+    *
+    * `timeoutAndForget`, not `timeout`. `timeout` cancels the fiber and then WAITS for its finalizers to complete, so against a fiber wedged in uninterruptible
+    * blocking — exactly what is worth bounding — it does not bound anything at all. Measured, not reasoned: swapping this one call to `timeout` makes
+    * `MaxTimeTest`'s uncancellable case run to completion and return SUCCESS well past its deadline, rather than merely being late. `timeoutAndForget` abandons
+    * the fiber and moves on. The abandoned fiber cannot delay exit either: `Main` calls `System.exit` unconditionally.
+    */
+  def bound[A](maxTime: Option[MaxTime], program: IO[A]): IO[A] =
+    maxTime match {
+      case None     => program
+      case Some(mt) =>
+        program.timeoutAndForget(mt.duration).handleErrorWith {
+          case _: java.util.concurrent.TimeoutException =>
+            IO.blocking(writeDump(mt)).flatMap(note => IO.raiseError(new BleepException.Text(message(mt, note))))
+          case other => IO.raiseError(other)
+        }
+    }
+
+  private val Syntax = """^(\d+)(s|m|h)$""".r
+
+  /** Parse `90s`, `15m`, `1h`.
+    *
+    * Deliberately narrow. A bare number is rejected because `--max-time 30` reads as seconds to one person and minutes to the next, and a bound that silently
+    * means something other than what was typed is worse than one that refuses to start.
+    */
+  def parse(str: String): Either[String, FiniteDuration] =
+    str.trim match {
+      case Syntax(amount, unit) =>
+        val n = amount.toLong
+        if (n <= 0) Left(s"--max-time must be greater than zero, got '$str'")
+        else
+          Right(unit match {
+            case "s" => n.seconds
+            case "m" => n.minutes
+            case "h" => n.hours
+            case _   => sys.error(s"unreachable unit '$unit'")
+          })
+      case other => Left(s"--max-time must look like 90s, 15m or 1h, got '$other'")
+    }
+
+  /** Rendered into the failure message rather than thrown.
+    *
+    * Not error-swallowing: both facts reach the user in one message. Letting a failure in the *diagnostics* replace the timeout that triggered them would
+    * report the less useful of the two problems, and lose the one the user actually hit.
+    */
+  private def writeDump(mt: MaxTime): String =
+    try {
+      val bytes = new ByteArrayOutputStream()
+      val out = new PrintStream(bytes, true, "UTF-8")
+      ChildProcessDiagnostics.dumpAll(out, mt.jvmBinDirs, mt.serverPids)
+      out.flush()
+      Option(mt.dumpTo.getParent).foreach(Files.createDirectories(_))
+      Files.write(mt.dumpTo, bytes.toByteArray)
+      s"thread dump written to ${mt.dumpTo}"
+    } catch {
+      case th: Throwable => s"additionally, the thread dump could not be written to ${mt.dumpTo}: $th"
+    }
+
+  private def message(mt: MaxTime, dumpNote: String): String =
+    s"Gave up after --max-time ${mt.duration}: cancelled the build and stopped waiting. $dumpNote"
+}

--- a/bleep-tests/src/scala/bleep/MaxTimeTest.scala
+++ b/bleep-tests/src/scala/bleep/MaxTimeTest.scala
@@ -1,0 +1,111 @@
+package bleep
+
+import bleep.internal.MaxTime
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.file.{Files, Path}
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.duration.*
+
+/** The in-process analogue of the `bound-check` CI job.
+  *
+  * A bound nobody exercises is a bound that silently does not work — the `run-bounded.sh` timeout was in place for three consecutive Windows hangs before
+  * anyone checked whether it fired. So every rung of the ladder is asserted here against a program that really does hang, rather than assumed from the shape of
+  * the code.
+  */
+class MaxTimeTest extends AnyFunSuite {
+
+  private def tempDump(name: String): Path =
+    Files.createTempDirectory("max-time-test").resolve(name)
+
+  private def maxTimeOf(duration: FiniteDuration, dumpTo: Path): MaxTime =
+    MaxTime(duration = duration, dumpTo = dumpTo, jvmBinDirs = Nil, serverPids = Nil)
+
+  test("a program that finishes in time is untouched") {
+    val dump = tempDump("unused.txt")
+    val result = MaxTime.bound(Some(maxTimeOf(30.seconds, dump)), IO.pure(42)).unsafeRunSync()
+    assert(result == 42)
+    assert(!Files.exists(dump), "nothing should be dumped when the program finished")
+  }
+
+  test("no max-time means no bound") {
+    val result = MaxTime.bound(None, IO.pure("ok")).unsafeRunSync()
+    assert(result == "ok")
+  }
+
+  test("a hanging program fails, and says how long it waited") {
+    val dump = tempDump("dump.txt")
+    val th = intercept[BleepException.Text](MaxTime.bound(Some(maxTimeOf(200.millis, dump)), IO.never[Int]).unsafeRunSync())
+    assert(th.message.contains("--max-time"), s"message should name the flag that fired: ${th.message}")
+    assert(th.message.contains("200 milliseconds"), s"message should name the duration: ${th.message}")
+  }
+
+  test("a hanging program leaves a thread dump behind") {
+    val dump = tempDump("dump.txt")
+    intercept[BleepException.Text](MaxTime.bound(Some(maxTimeOf(200.millis, dump)), IO.never[Int]).unsafeRunSync())
+    assert(Files.exists(dump), "the dump is the whole point — it has to outlive the process")
+    val content = Files.readString(dump)
+    assert(content.contains("Thread Dump"), s"expected a thread dump, got: ${content.take(200)}")
+    // Proves it dumped THIS process rather than writing an empty shell. The test thread is necessarily in there.
+    assert(content.contains("--- This JVM"), s"expected this JVM's threads, got: ${content.take(200)}")
+    // Not just a header: the dump is only worth writing if it carries frames. This test's own thread must be in there.
+    assert(content.contains("MaxTimeTest"), "the dump should contain this test's own stack frames")
+  }
+
+  test("cancellation actually reaches the program, it is not merely abandoned") {
+    // The rung that matters most and is easiest to get silently wrong: `timeoutAndForget` must still CANCEL the fiber,
+    // because that cancellation is what makes lsp4j send `$/cancelRequest` to the compile server.
+    val cancelled = new AtomicBoolean(false)
+    val started = new CountDownLatch(1)
+    val dump = tempDump("dump.txt")
+    val program = IO.never[Int].onCancel(IO { cancelled.set(true); () }).guarantee(IO(started.countDown()))
+    intercept[BleepException.Text](MaxTime.bound(Some(maxTimeOf(200.millis, dump)), program).unsafeRunSync())
+    assert(started.await(5, java.util.concurrent.TimeUnit.SECONDS), "the program's finalizers should have run")
+    assert(cancelled.get(), "the fiber must be cancelled, not just dropped")
+  }
+
+  test("an uncancellable hang does not hang the bound itself") {
+    // Why `timeoutAndForget` rather than `timeout`. `timeout` waits for the cancelled fiber's finalizers, so a fiber
+    // wedged in uninterruptible blocking would make the timeout hang on exactly the hang it exists to catch.
+    // 2s of uninterruptible sleep against a 200ms bound: with `timeout` this test would take 2s, with
+    // `timeoutAndForget` it returns immediately.
+    val dump = tempDump("dump.txt")
+    val stuck = IO.uncancelable(_ => IO.blocking(Thread.sleep(2000)))
+    val startedAt = System.nanoTime()
+    intercept[BleepException.Text](MaxTime.bound(Some(maxTimeOf(200.millis, dump)), stuck).unsafeRunSync())
+    val elapsed = (System.nanoTime() - startedAt) / 1000000L
+    assert(elapsed < 1500, s"the bound waited $elapsed ms for an uncancellable fiber — it should have abandoned it")
+  }
+
+  test("parses the durations the help text promises") {
+    assert(MaxTime.parse("90s") == Right(90.seconds))
+    assert(MaxTime.parse("15m") == Right(15.minutes))
+    assert(MaxTime.parse("1h") == Right(1.hour))
+    assert(MaxTime.parse("  15m  ") == Right(15.minutes), "surrounding whitespace should not matter")
+  }
+
+  test("rejects anything whose meaning would have to be guessed") {
+    // A bare number is the important one: `--max-time 30` reads as seconds to one person and minutes to the next, and
+    // guessing wrong means a bound that silently is not the one that was asked for.
+    List("30", "", "15 m", "1.5h", "15M", "-5m", "0m", "forever", "1d").foreach { bad =>
+      assert(MaxTime.parse(bad).isLeft, s"'$bad' should be rejected rather than interpreted")
+    }
+  }
+
+  test("the rejection says what a good value looks like") {
+    val err = MaxTime.parse("30").left.getOrElse(fail("should have been rejected"))
+    assert(err.contains("15m"), s"the error should show a valid example, got: $err")
+  }
+
+  test("a failing dump reports both problems rather than replacing one with the other") {
+    // dumpTo points at a path whose parent is a FILE, so the write cannot succeed.
+    val file = Files.createTempFile("max-time-not-a-dir", ".txt")
+    val dump = file.resolve("dump.txt")
+    val th = intercept[BleepException.Text](MaxTime.bound(Some(maxTimeOf(200.millis, dump)), IO.never[Int]).unsafeRunSync())
+    assert(th.message.contains("--max-time"), s"the timeout must still be reported: ${th.message}")
+    assert(th.message.contains("could not be written"), s"the dump failure must also be reported: ${th.message}")
+  }
+}

--- a/bleep-tests/src/scala/bleep/TestEnvPropagationIT.scala
+++ b/bleep-tests/src/scala/bleep/TestEnvPropagationIT.scala
@@ -66,7 +66,8 @@ class TestEnvPropagationIT extends IntegrationTestHarness {
         flamegraph = false,
         cancel = false,
         junitReportDir = None,
-        clientEnv = clientEnv
+        clientEnv = clientEnv,
+        maxTime = None
       )
       .run(started)
 

--- a/docs/reference/cli/compile.mdx
+++ b/docs/reference/cli/compile.mdx
@@ -32,4 +32,5 @@ bleep compile <project name...> [flags]
 | `--diff-watch` | watch mode with per-project diffs between cycles |
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
+| `--max-time <string>` | give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing |
 

--- a/docs/reference/cli/dist.mdx
+++ b/docs/reference/cli/dist.mdx
@@ -33,4 +33,5 @@ bleep dist <project name exact> <path> [flags]
 | `--quiet, -q` | alias for --no-tui |
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
+| `--max-time <string>` | give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing |
 

--- a/docs/reference/cli/link.mdx
+++ b/docs/reference/cli/link.mdx
@@ -42,4 +42,5 @@ bleep link <project name...> [flags]
 | `--quiet, -q` | alias for --no-tui |
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
+| `--max-time <string>` | give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing |
 

--- a/docs/reference/cli/publish-local.mdx
+++ b/docs/reference/cli/publish-local.mdx
@@ -34,4 +34,5 @@ bleep publish-local <project name...> [flags]
 | `--quiet, -q` | alias for --no-tui |
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
+| `--max-time <string>` | give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing |
 

--- a/docs/reference/cli/publish/local-ivy.mdx
+++ b/docs/reference/cli/publish/local-ivy.mdx
@@ -33,5 +33,6 @@ bleep publish local-ivy <project name...> [flags]
 | `--quiet, -q` | alias for --no-tui |
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
+| `--max-time <string>` | give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing |
 | `--to <path>` | write the ivy layout here instead of ~/.ivy2/local |
 

--- a/docs/reference/cli/publish/sonatype.mdx
+++ b/docs/reference/cli/publish/sonatype.mdx
@@ -32,4 +32,5 @@ bleep publish sonatype <project name...> [flags]
 | `--quiet, -q` | alias for --no-tui |
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
+| `--max-time <string>` | give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing |
 

--- a/docs/reference/cli/run.mdx
+++ b/docs/reference/cli/run.mdx
@@ -33,4 +33,5 @@ bleep run <project or script name> <arguments...> [flags]
 | `--quiet, -q` | alias for --no-tui |
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
+| `--max-time <string>` | give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing |
 

--- a/docs/reference/cli/test.mdx
+++ b/docs/reference/cli/test.mdx
@@ -40,4 +40,5 @@ bleep test <project name...> [flags]
 | `--flamegraph` | generate execution trace (open in chrome://tracing or ui.perfetto.dev) |
 | `--cancel` | cancel any running build before starting |
 | `--junit-report <string>` | write JUnit XML reports to this directory |
+| `--max-time <string>` | give up after this long, e.g. 90s / 15m / 1h, and dump thread state before failing |
 


### PR DESCRIPTION
## Why

Three Windows CI hangs produced no diagnostics. The cause turned out not to be a missing timeout — on the **fourth** occurrence the 1200s `run-bounded.sh` bound, the step's `timeout-minutes: 25`, and the job's `45` were all in place, and **all three failed to end the step**:

```
step  Test binary after build   17:20:17 -> null     (47m, never completed)
job   started 17:12:45  destroyed 18:07:45           (55m00s = 45m cap + 10m grace)
logs  BlobNotFound                                   (never uploaded)
telemetry steps  null                                (destroyed with the runner)
```

GitHub waits for the step's output *pipes*, not for the process. Raising caps cannot fix that, which is why three of them didn't. And the `if: always()` telemetry steps are steps — the hung step never yields the runner, so they never run.

## What

bleep bounds itself instead:

```bash
bleep test --max-time 15m
```

On expiry it cancels the build, writes a thread dump of the client **and** the compile server, and exits non-zero. The step then ends normally and the telemetry steps run — diagnostics travel the path that already exists.

**Where it deliberately stops:** it does not kill the compile server. The client exiting is already enough to end a CI step, and killing a daemon serving other workspaces is collateral nobody asked for.

## `timeoutAndForget`, not `timeout`

Measured, not reasoned. `timeout` cancels the fiber then *waits for its finalizers*, so against an uncancellable hang it does not bound anything. Swapping this one call makes `MaxTimeTest`'s uncancellable case run to completion and return **SUCCESS past its deadline** — not merely late.

## Two silent bugs in `ChildProcessDiagnostics`

Both made the dump useless exactly where it was needed:

- `findJstack` looked only under `java.home`, and only for `jstack`. The client is a native image with no JDK of its own, so it could never dump a child at all — and with no `.exe` candidate it found nothing on **Windows** even in the server, the platform where the hangs happen.
- `dumpAll` walked only `descendants()`. A shared compile server is nobody's descendant, so the dump omitted precisely the process doing the stuck work. Verified fixed against a daemon from an earlier run: client pid 73467 dumped server pid 73300, which is not its descendant.

## Risk

Off unless asked for — no duration is right for both a laptop and a cold CI runner. That is also why it is per-invocation rather than a setting on the shared server, where whichever client spawned the daemon would impose its choice on everyone else. `--max-time 30` is rejected rather than guessed.

CI sets it **just under** the bound already enforced (19m vs `run-bounded.sh`'s 20m), so it can only convert an existing kill into a clean exit — **it cannot fail a run that passes today**. `run-bounded.sh` stays as the outer backstop for what this structurally cannot cover: the client unable to act at all.

## Tests

`MaxTimeTest` is the in-process analogue of the `bound-check` job, for the reason that job exists — every rung is asserted against a program that really hangs, including that cancellation *reaches* the program rather than merely abandoning it, and that a failing dump reports both problems instead of replacing one with the other.

Verified end-to-end against a real compile: bound fires, message names the duration, 17KB dump written containing 53 server threads via jstack.

Also regenerates the CLI docs, which were stale for `max-cached-workspaces` from an earlier merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)