### PR TITLE
test-runner: a class whose @AfterClass throws was reported green

### DIFF
--- a/bleep-bsp-tests/src/scala/bleep/analysis/EdgeCaseIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/EdgeCaseIntegrationTest.scala
@@ -882,19 +882,29 @@ class EdgeCaseIntegrationTest extends AnyFunSuite with Matchers with TimeLimits 
   // Helpers
   // ==========================================================================
 
+  /** The callbacks arrive on the runner's reader threads — stdout and stderr drain independently — so every append is synchronized and every read takes a
+    * snapshot under the same lock. Unguarded `mutable.Buffer` appends raced inside `ensureSize` and threw `ArrayIndexOutOfBoundsException: arraycopy` out of a
+    * test that had nothing to do with concurrency.
+    */
   class RecordingTestEventHandler extends TestRunnerTypes.TestEventHandler {
-    val testStarts = mutable.Buffer[(String, String)]()
-    val testFinishes = mutable.Buffer[(String, String, TestStatus, Long, Option[String])]()
-    val suiteStarts = mutable.Buffer[String]()
-    val suiteFinishes = mutable.Buffer[(String, Int, Int, Int)]()
-    val outputs = mutable.Buffer[(String, String, OutputChannel)]()
+    private val testStartsBuffer = mutable.Buffer[(String, String)]()
+    private val testFinishesBuffer = mutable.Buffer[(String, String, TestStatus, Long, Option[String])]()
+    private val suiteStartsBuffer = mutable.Buffer[String]()
+    private val suiteFinishesBuffer = mutable.Buffer[(String, Int, Int, Int)]()
+    private val outputsBuffer = mutable.Buffer[(String, String, OutputChannel)]()
 
-    def onTestStarted(suite: String, test: String): Unit = testStarts += ((suite, test))
+    def testStarts: List[(String, String)] = synchronized(testStartsBuffer.toList)
+    def testFinishes: List[(String, String, TestStatus, Long, Option[String])] = synchronized(testFinishesBuffer.toList)
+    def suiteStarts: List[String] = synchronized(suiteStartsBuffer.toList)
+    def suiteFinishes: List[(String, Int, Int, Int)] = synchronized(suiteFinishesBuffer.toList)
+    def outputs: List[(String, String, OutputChannel)] = synchronized(outputsBuffer.toList)
+
+    def onTestStarted(suite: String, test: String): Unit = synchronized(testStartsBuffer += ((suite, test)))
     def onTestFinished(suite: String, test: String, status: TestStatus, durationMs: Long, message: Option[String]): Unit =
-      testFinishes += ((suite, test, status, durationMs, message))
-    def onSuiteStarted(suite: String): Unit = suiteStarts += suite
-    def onSuiteFinished(suite: String, passed: Int, failed: Int, skipped: Int): Unit = suiteFinishes += ((suite, passed, failed, skipped))
-    def onOutput(suite: String, line: String, channel: OutputChannel): Unit = outputs += ((suite, line, channel))
+      synchronized(testFinishesBuffer += ((suite, test, status, durationMs, message)))
+    def onSuiteStarted(suite: String): Unit = synchronized(suiteStartsBuffer += suite)
+    def onSuiteFinished(suite: String, passed: Int, failed: Int, skipped: Int): Unit = synchronized(suiteFinishesBuffer += ((suite, passed, failed, skipped)))
+    def onOutput(suite: String, line: String, channel: OutputChannel): Unit = synchronized(outputsBuffer += ((suite, line, channel)))
   }
 
   // ==========================================================================

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ForkedTestRunnerFrameworkTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ForkedTestRunnerFrameworkTest.scala
@@ -30,6 +30,7 @@ class ForkedTestRunnerFrameworkTest extends AnyFunSuite with Matchers with RunAn
       passed: Int,
       failed: Int,
       skipped: Int,
+      outcome: String,
       testResults: List[(String, String)], // (testName, status)
       protocolLines: List[String],
       errors: List[String]
@@ -72,6 +73,7 @@ class ForkedTestRunnerFrameworkTest extends AnyFunSuite with Matchers with RunAn
       var suitePassed = 0
       var suiteFailed = 0
       var suiteSkipped = 0
+      var suiteOutcome = ""
 
       lines.foreach { line =>
         if (line.contains("\"type\":\"TestFinished\"")) {
@@ -83,6 +85,7 @@ class ForkedTestRunnerFrameworkTest extends AnyFunSuite with Matchers with RunAn
           suitePassed = extractJsonIntField(line, "passed")
           suiteFailed = extractJsonIntField(line, "failed")
           suiteSkipped = extractJsonIntField(line, "skipped")
+          suiteOutcome = extractJsonField(line, "outcome")
         }
         if (line.contains("\"type\":\"Error\"")) {
           errors += extractJsonField(line, "message")
@@ -93,6 +96,7 @@ class ForkedTestRunnerFrameworkTest extends AnyFunSuite with Matchers with RunAn
         passed = suitePassed,
         failed = suiteFailed,
         skipped = suiteSkipped,
+        outcome = suiteOutcome,
         testResults = testResults.toList,
         protocolLines = lines,
         errors = errors.toList
@@ -925,6 +929,442 @@ class ForkedTestRunnerFrameworkTest extends AnyFunSuite with Matchers with RunAn
       result.failed shouldBe 1
       result.testResults.count(_._2 == "passed") shouldBe 1
       result.testResults.count(t => t._2 == "failed" || t._2 == "error") shouldBe 1
+    } finally deleteRecursively(outputDir)
+  }
+
+  // ============================================================================
+  // Container-level lifecycle failures (JUnit Platform)
+  //
+  // @AfterClass/@AfterAll and friends are reported by the platform against the *container*, not
+  // against any test. The listener used to drop every non-test identifier, so a class whose
+  // teardown asserted was reported green with exit 0.
+  // ============================================================================
+
+  val junit4AfterClassFailure = SourceFile(
+    Path.of("example/Junit4AfterClassFailureTest.java"),
+    """package example;
+      |
+      |import org.junit.AfterClass;
+      |import org.junit.Test;
+      |import static org.junit.Assert.*;
+      |
+      |public class Junit4AfterClassFailureTest {
+      |    @Test
+      |    public void passingTest() {
+      |        assertEquals(2, 1 + 1);
+      |    }
+      |
+      |    @AfterClass
+      |    public static void afterAll() {
+      |        throw new AssertionError("deliberate @AfterClass failure");
+      |    }
+      |}
+      |""".stripMargin
+  )
+
+  val junit4ParameterizedAfterClassFailure = SourceFile(
+    Path.of("example/Junit4ParameterizedAfterClassTest.java"),
+    """package example;
+      |
+      |import java.util.Arrays;
+      |import java.util.List;
+      |import org.junit.AfterClass;
+      |import org.junit.Test;
+      |import org.junit.runner.RunWith;
+      |import org.junit.runners.Parameterized;
+      |
+      |@RunWith(Parameterized.class)
+      |public class Junit4ParameterizedAfterClassTest {
+      |    @Parameterized.Parameters(name = "{0}")
+      |    public static List<Object[]> params() {
+      |        return Arrays.asList(new Object[] {"a"}, new Object[] {"b"});
+      |    }
+      |
+      |    @Parameterized.Parameter(0)
+      |    public String name;
+      |
+      |    @Test
+      |    public void passes() {}
+      |
+      |    @AfterClass
+      |    public static void afterAll() {
+      |        throw new AssertionError("deliberate @AfterClass failure");
+      |    }
+      |}
+      |""".stripMargin
+  )
+
+  val junit5AfterAllFailure = SourceFile(
+    Path.of("example/Junit5AfterAllFailureTest.java"),
+    """package example;
+      |
+      |import org.junit.jupiter.api.AfterAll;
+      |import org.junit.jupiter.api.Test;
+      |import static org.junit.jupiter.api.Assertions.*;
+      |
+      |public class Junit5AfterAllFailureTest {
+      |    @Test
+      |    public void passingTest() {
+      |        assertEquals(2, 1 + 1);
+      |    }
+      |
+      |    @AfterAll
+      |    public static void afterAll() {
+      |        fail("deliberate @AfterAll failure");
+      |    }
+      |}
+      |""".stripMargin
+  )
+
+  val junit5BeforeAllFailure = SourceFile(
+    Path.of("example/Junit5BeforeAllFailureTest.java"),
+    """package example;
+      |
+      |import org.junit.jupiter.api.BeforeAll;
+      |import org.junit.jupiter.api.Test;
+      |import static org.junit.jupiter.api.Assertions.*;
+      |
+      |public class Junit5BeforeAllFailureTest {
+      |    @BeforeAll
+      |    public static void beforeAll() {
+      |        fail("deliberate @BeforeAll failure");
+      |    }
+      |
+      |    @Test
+      |    public void neverRuns() {
+      |        assertEquals(2, 1 + 1);
+      |    }
+      |}
+      |""".stripMargin
+  )
+
+  val junit5DisabledClass = SourceFile(
+    Path.of("example/Junit5DisabledClassTest.java"),
+    """package example;
+      |
+      |import org.junit.jupiter.api.Disabled;
+      |import org.junit.jupiter.api.Test;
+      |import static org.junit.jupiter.api.Assertions.*;
+      |
+      |@Disabled("not today")
+      |public class Junit5DisabledClassTest {
+      |    @Test
+      |    public void neverRuns() {
+      |        assertEquals(2, 1 + 1);
+      |    }
+      |}
+      |""".stripMargin
+  )
+
+  test("JUnit 4: @AfterClass failure is reported against the class") {
+    val outputDir = createTempDir("junit4-afterclass-")
+    try {
+      compileJava(Seq(junit4AfterClassFailure), CompilerTestLibraries.junitLibrary, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++ CompilerTestLibraries.jupiterInterfaceLibrary ++ CompilerTestLibraries.junitLibrary
+      val result = runSuiteViaProtocol(cp, "example.Junit4AfterClassFailureTest", "JUnit")
+
+      info(s"Test results: ${result.testResults}")
+      result.passed shouldBe 1
+      result.failed shouldBe 1
+      result.outcome shouldBe "executed"
+      val failures = result.testResults.filter(_._2 == "failed")
+      failures.size shouldBe 1
+      failures.head._1 should include("class-level")
+      result.protocolLines.mkString("\n") should include("deliberate @AfterClass failure")
+    } finally deleteRecursively(outputDir)
+  }
+
+  test("JUnit 4: @AfterClass failure in a @Parameterized class is reported against the class") {
+    val outputDir = createTempDir("junit4-param-afterclass-")
+    try {
+      compileJava(Seq(junit4ParameterizedAfterClassFailure), CompilerTestLibraries.junitLibrary, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++ CompilerTestLibraries.jupiterInterfaceLibrary ++ CompilerTestLibraries.junitLibrary
+      val result = runSuiteViaProtocol(cp, "example.Junit4ParameterizedAfterClassTest", "JUnit")
+
+      info(s"Test results: ${result.testResults}")
+      result.passed shouldBe 2
+      result.failed shouldBe 1
+      result.outcome shouldBe "executed"
+      result.testResults.count(_._2 == "failed") shouldBe 1
+    } finally deleteRecursively(outputDir)
+  }
+
+  test("JUnit 5: @AfterAll failure is reported against the class") {
+    val outputDir = createTempDir("junit5-afterall-")
+    try {
+      compileJava(Seq(junit5AfterAllFailure), CompilerTestLibraries.junit5Library, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++ CompilerTestLibraries.jupiterInterfaceLibrary ++ CompilerTestLibraries.junit5Library
+      val result = runSuiteViaProtocol(cp, "example.Junit5AfterAllFailureTest", "JUnit Jupiter")
+
+      info(s"Test results: ${result.testResults}")
+      result.passed shouldBe 1
+      result.failed shouldBe 1
+      result.outcome shouldBe "executed"
+      val failures = result.testResults.filter(_._2 == "failed")
+      failures.size shouldBe 1
+      failures.head._1 should include("class-level")
+      result.protocolLines.mkString("\n") should include("deliberate @AfterAll failure")
+    } finally deleteRecursively(outputDir)
+  }
+
+  test("JUnit 5: @BeforeAll failure is reported as a failure, not an empty suite") {
+    val outputDir = createTempDir("junit5-beforeall-")
+    try {
+      compileJava(Seq(junit5BeforeAllFailure), CompilerTestLibraries.junit5Library, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++ CompilerTestLibraries.jupiterInterfaceLibrary ++ CompilerTestLibraries.junit5Library
+      val result = runSuiteViaProtocol(cp, "example.Junit5BeforeAllFailureTest", "JUnit Jupiter")
+
+      info(s"Test results: ${result.testResults}")
+      result.passed shouldBe 0
+      result.failed shouldBe 1
+      result.outcome shouldBe "executed"
+      result.protocolLines.mkString("\n") should include("deliberate @BeforeAll failure")
+    } finally deleteRecursively(outputDir)
+  }
+
+  test("JUnit 5: a @Disabled class is skipped, not an empty suite") {
+    val outputDir = createTempDir("junit5-disabled-")
+    try {
+      compileJava(Seq(junit5DisabledClass), CompilerTestLibraries.junit5Library, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++ CompilerTestLibraries.jupiterInterfaceLibrary ++ CompilerTestLibraries.junit5Library
+      val result = runSuiteViaProtocol(cp, "example.Junit5DisabledClassTest", "JUnit Jupiter")
+
+      info(s"Test results: ${result.testResults}")
+      result.passed shouldBe 0
+      result.failed shouldBe 0
+      result.skipped shouldBe 1
+      result.outcome shouldBe "executed"
+    } finally deleteRecursively(outputDir)
+  }
+
+  val junit4EmptyParams = SourceFile(
+    Path.of("example/Junit4EmptyParamsTest.java"),
+    """package example;
+      |
+      |import java.util.Collections;
+      |import java.util.List;
+      |import org.junit.Test;
+      |import org.junit.runner.RunWith;
+      |import org.junit.runners.Parameterized;
+      |
+      |@RunWith(Parameterized.class)
+      |public class Junit4EmptyParamsTest {
+      |    @Parameterized.Parameters(name = "{0}")
+      |    public static List<Object[]> params() {
+      |        return Collections.emptyList();
+      |    }
+      |
+      |    @Parameterized.Parameter(0)
+      |    public String name;
+      |
+      |    @Test
+      |    public void passes() {}
+      |}
+      |""".stripMargin
+  )
+
+  test("JUnit 4: a class with an empty @Parameters list is empty, not one passed test") {
+    val outputDir = createTempDir("junit4-emptyparams-")
+    try {
+      compileJava(Seq(junit4EmptyParams), CompilerTestLibraries.junitLibrary, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++ CompilerTestLibraries.jupiterInterfaceLibrary ++ CompilerTestLibraries.junitLibrary
+      val result = runSuiteViaProtocol(cp, "example.Junit4EmptyParamsTest", "JUnit")
+
+      info(s"Test results: ${result.testResults}")
+      result.passed shouldBe 0
+      result.failed shouldBe 0
+      result.outcome shouldBe "empty"
+      result.testResults shouldBe empty
+    } finally deleteRecursively(outputDir)
+  }
+
+  // ============================================================================
+  // Class-level teardown failures on the sbt-testing path
+  //
+  // Same question as the JUnit Platform bridge above, asked of every framework that goes through
+  // sbt's test-interface instead: when the failure belongs to the class rather than to any one
+  // test, does it reach us at all?
+  // ============================================================================
+
+  val scalaTestAfterAllFailure = SourceFile(
+    Path.of("AfterAllFailingScalaTest.scala"),
+    """package example
+      |
+      |import org.scalatest.BeforeAndAfterAll
+      |import org.scalatest.funsuite.AnyFunSuite
+      |
+      |class AfterAllFailingScalaTest extends AnyFunSuite with BeforeAndAfterAll {
+      |  test("passing test") {
+      |    assert(1 + 1 == 2)
+      |  }
+      |  override def afterAll(): Unit =
+      |    throw new AssertionError("deliberate afterAll failure")
+      |}
+      |""".stripMargin
+  )
+
+  val munitAfterAllFailure = SourceFile(
+    Path.of("AfterAllFailingMUnitTest.scala"),
+    """package example
+      |
+      |class AfterAllFailingMUnitTest extends munit.FunSuite {
+      |  test("passing test") {
+      |    assertEquals(1 + 1, 2)
+      |  }
+      |  override def afterAll(): Unit =
+      |    throw new AssertionError("deliberate afterAll failure")
+      |}
+      |""".stripMargin
+  )
+
+  val utestAfterAllFailure = SourceFile(
+    Path.of("AfterAllFailingUTest.scala"),
+    """package example
+      |
+      |import utest._
+      |
+      |object AfterAllFailingUTest extends TestSuite {
+      |  val tests = Tests {
+      |    test("passing test") {
+      |      assert(1 + 1 == 2)
+      |    }
+      |  }
+      |  // java.lang.AssertionError spelled out: `import utest._` shadows it with utest.AssertionError
+      |  override def utestAfterAll(): Unit =
+      |    throw new java.lang.AssertionError("deliberate utestAfterAll failure")
+      |}
+      |""".stripMargin
+  )
+
+  val kotestAfterSpecFailure = SourceFile(
+    Path.of("example/AfterSpecFailingKotest.kt"),
+    """package example
+      |
+      |import io.kotest.core.spec.style.FunSpec
+      |import io.kotest.matchers.shouldBe
+      |
+      |class AfterSpecFailingKotest : FunSpec({
+      |    test("addition works") {
+      |        (1 + 1) shouldBe 2
+      |    }
+      |    afterSpec {
+      |        throw AssertionError("deliberate afterSpec failure")
+      |    }
+      |})
+      |""".stripMargin
+  )
+
+  val testngAfterClassFailure = SourceFile(
+    Path.of("example/TestNGAfterClassFailureTest.java"),
+    """package example;
+      |
+      |import org.testng.annotations.AfterClass;
+      |import org.testng.annotations.Test;
+      |import static org.testng.Assert.*;
+      |
+      |public class TestNGAfterClassFailureTest {
+      |    @Test
+      |    public void passingTest() {
+      |        assertEquals(1 + 1, 2);
+      |    }
+      |
+      |    @AfterClass
+      |    public void afterAll() {
+      |        throw new AssertionError("deliberate @AfterClass failure");
+      |    }
+      |}
+      |""".stripMargin
+  )
+
+  test("ScalaTest: afterAll failure is not swallowed") {
+    val outputDir = createTempDir("scalatest-afterall-")
+    try {
+      val compileClasspath = CompilerTestLibraries.scalaLibrary ++ CompilerTestLibraries.scalaTestLibrary
+      compileScala(Seq(scalaTestAfterAllFailure), compileClasspath, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++
+        CompilerTestLibraries.scalaTestLibrary ++ CompilerTestLibraries.scalaLibrary ++ CompilerTestLibraries.testInterfaceLibrary
+      val result = runSuiteViaProtocol(cp, "example.AfterAllFailingScalaTest", "ScalaTest")
+
+      info(s"outcome=${result.outcome} passed=${result.passed} failed=${result.failed} results=${result.testResults}")
+      withClue(result.protocolLines.mkString("\n")) {
+        (result.failed > 0 || result.outcome == "errored") shouldBe true
+      }
+    } finally deleteRecursively(outputDir)
+  }
+
+  test("MUnit: afterAll failure is not swallowed") {
+    val outputDir = createTempDir("munit-afterall-")
+    try {
+      val compileClasspath = CompilerTestLibraries.scalaLibrary ++ CompilerTestLibraries.munitLibrary
+      compileScala(Seq(munitAfterAllFailure), compileClasspath, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++
+        CompilerTestLibraries.munitLibrary ++ CompilerTestLibraries.scalaLibrary ++ CompilerTestLibraries.testInterfaceLibrary
+      val result = runSuiteViaProtocol(cp, "example.AfterAllFailingMUnitTest", "MUnit")
+
+      info(s"outcome=${result.outcome} passed=${result.passed} failed=${result.failed} results=${result.testResults}")
+      withClue(result.protocolLines.mkString("\n")) {
+        (result.failed > 0 || result.outcome == "errored") shouldBe true
+      }
+    } finally deleteRecursively(outputDir)
+  }
+
+  test("utest: utestAfterAll failure is not swallowed") {
+    val outputDir = createTempDir("utest-afterall-")
+    try {
+      val compileClasspath = CompilerTestLibraries.scalaLibrary ++ CompilerTestLibraries.utestLibrary
+      compileScala(Seq(utestAfterAllFailure), compileClasspath, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++
+        CompilerTestLibraries.utestLibrary ++ CompilerTestLibraries.scalaLibrary ++ CompilerTestLibraries.testInterfaceLibrary
+      val result = runSuiteViaProtocol(cp, "example.AfterAllFailingUTest", "utest")
+
+      info(s"outcome=${result.outcome} passed=${result.passed} failed=${result.failed} results=${result.testResults}")
+      withClue(result.protocolLines.mkString("\n")) {
+        (result.failed > 0 || result.outcome == "errored") shouldBe true
+      }
+    } finally deleteRecursively(outputDir)
+  }
+
+  test("Kotest: afterSpec failure is not swallowed") {
+    val outputDir = createTempDir("kotest-afterspec-")
+    try {
+      val compileClasspath = CompilerTestLibraries.kotlinLibrary ++ CompilerTestLibraries.kotestLibrary
+      compileKotlin(Seq(kotestAfterSpecFailure), compileClasspath, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++
+        CompilerTestLibraries.jupiterInterfaceLibrary ++ CompilerTestLibraries.kotestLibrary ++ CompilerTestLibraries.kotlinLibrary
+      val result = runSuiteViaProtocol(cp, "example.AfterSpecFailingKotest", "Kotest")
+
+      info(s"outcome=${result.outcome} passed=${result.passed} failed=${result.failed} results=${result.testResults}")
+      withClue(result.protocolLines.mkString("\n")) {
+        (result.failed > 0 || result.outcome == "errored") shouldBe true
+      }
+    } finally deleteRecursively(outputDir)
+  }
+
+  // TestNG is the one framework where a class-level teardown failure never reaches us, and the
+  // limitation is not ours to fix here: the sbt-testing bridge bleep discovers on the user's
+  // classpath, `mill.testng.TestNGListener`, implements `org.testng.ITestListener` and nothing
+  // else. TestNG routes @BeforeClass/@AfterClass failures to `IConfigurationListener` instead, so
+  // the bridge emits no event for them — TestNG prints "Configuration Failures: 1" and we are told
+  // only about the passing test. This test pins that behaviour rather than pretending it is fine;
+  // when a bridge that implements IConfigurationListener shows up, it fails and we come back.
+  //
+  // A @BeforeClass failure is less severe: TestNG skips the dependent tests, and skips do go
+  // through ITestListener, so the suite at least does not look green.
+  test("TestNG: @AfterClass failure is invisible — the mill bridge reports no configuration events") {
+    val outputDir = createTempDir("testng-afterclass-")
+    try {
+      compileJava(Seq(testngAfterClassFailure), CompilerTestLibraries.testngLibrary, outputDir)
+      val cp = Seq(outputDir, testRunnerPath) ++
+        CompilerTestLibraries.testngBridgeLibrary ++ CompilerTestLibraries.testngLibrary ++ CompilerTestLibraries.testInterfaceLibrary
+      val result = runSuiteViaProtocol(cp, "example.TestNGAfterClassFailureTest", "TestNG")
+
+      info(s"outcome=${result.outcome} passed=${result.passed} failed=${result.failed} results=${result.testResults}")
+      withClue(result.protocolLines.mkString("\n")) {
+        result.passed shouldBe 1
+        result.failed shouldBe 0
+        // TestNG itself knows; it just has no way to tell the bridge.
+        result.protocolLines.mkString("\n") should include("Configuration Failures: 1")
+      }
     } finally deleteRecursively(outputDir)
   }
 }

--- a/bleep-test-runner/src/main/java/bleep/testing/runner/JUnitPlatformRunner.java
+++ b/bleep-test-runner/src/main/java/bleep/testing/runner/JUnitPlatformRunner.java
@@ -101,7 +101,7 @@ class JUnitPlatformRunner {
 
               @Override
               public void executionStarted(TestIdentifier testIdentifier) {
-                if (testIdentifier.isTest()) {
+                if (testIdentifier.isTest() && !isChildlessVintageClass(testIdentifier)) {
                   String testName = testIdentifier.getDisplayName();
                   send(TestProtocol.encodeTestStarted(currentSuite, testName));
                 }
@@ -110,7 +110,16 @@ class JUnitPlatformRunner {
               @Override
               public void executionFinished(
                   TestIdentifier testIdentifier, TestExecutionResult result) {
-                if (!testIdentifier.isTest()) return;
+                if (!testIdentifier.isTest()) {
+                  // A container fails on its own whenever the failure is not attributable to any
+                  // one test: @AfterClass/@AfterAll/@BeforeClass/@BeforeAll throwing, a class-level
+                  // rule, a @Parameters method blowing up, an engine dying. Dropping these reported
+                  // a suite whose teardown asserted as green, with exit 0.
+                  if (result.getStatus() == TestExecutionResult.Status.FAILED) {
+                    reportContainerFailure(testIdentifier, result);
+                  }
+                  return;
+                }
 
                 String testName = testIdentifier.getDisplayName();
                 long durationMs = 0; // JUnit Platform doesn't provide per-test duration in listener
@@ -121,6 +130,18 @@ class JUnitPlatformRunner {
 
                 switch (result.getStatus()) {
                   case SUCCESSFUL:
+                    if (isChildlessVintageClass(testIdentifier)) {
+                      // Count nothing, so the suite finishes with zero events and is reported as
+                      // Empty rather than as one green test. See isChildlessVintageClass.
+                      send(
+                          TestProtocol.encodeLog(
+                              "warn",
+                              currentSuite
+                                  + " has no runnable tests — JUnit 4 reported the class itself as"
+                                  + " a leaf. An empty @Parameters list or @SuiteClasses({}) does"
+                                  + " this."));
+                      return;
+                    }
                     status = "passed";
                     passed[0]++;
                     break;
@@ -158,9 +179,65 @@ class JUnitPlatformRunner {
                         currentSuite, testName, status, durationMs, message, throwableStr));
               }
 
+              /**
+               * True when the platform handed us the requested class itself as a leaf "test".
+               *
+               * <p>JUnit 4's {@code Description.isTest()} means only "I have no children", so a
+               * class that produced no runnable tests — an empty {@code @Parameters} list,
+               * {@code @SuiteClasses({})} — arrives through the vintage engine as a single leaf
+               * whose unique id ends in {@code [runner:<the class we asked for>]} instead of the
+               * usual {@code [test:method(class)]}. Reporting it as one passed test made a suite
+               * that ran nothing look exactly like a green one.
+               */
+              private boolean isChildlessVintageClass(TestIdentifier testIdentifier) {
+                return testIdentifier.getUniqueId().endsWith("[runner:" + currentSuite + "]");
+              }
+
+              /**
+               * Surface a failed container as a synthetic failed test, so it lands in the counts,
+               * in the failures section, and in the exit code like any other failure.
+               */
+              private void reportContainerFailure(
+                  TestIdentifier testIdentifier, TestExecutionResult result) {
+                String testName = containerTestName(testIdentifier);
+                String message = null;
+                String throwableStr = null;
+                if (result.getThrowable().isPresent()) {
+                  Throwable t = result.getThrowable().get();
+                  message = t.getMessage();
+                  throwableStr = stackTraceToString(t);
+                }
+                failed[0]++;
+
+                try {
+                  capturedOut.flush();
+                  capturedErr.flush();
+                } catch (Exception e) {
+                  // Ignore
+                }
+
+                // Started/finished as a pair: the reader counts started tests, and a finish without
+                // a start leaves its running-test bookkeeping short.
+                send(TestProtocol.encodeTestStarted(currentSuite, testName));
+                send(
+                    TestProtocol.encodeTestFinished(
+                        currentSuite, testName, "failed", 0, message, throwableStr));
+              }
+
               @Override
               public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-                if (!testIdentifier.isTest()) return;
+                if (!testIdentifier.isTest()) {
+                  // A skipped container (@Disabled/@Ignore on the class) reports nothing for the
+                  // tests underneath it, so without this the suite finishes having emitted zero
+                  // events and is reported as an empty — i.e. failed — suite.
+                  if (!testIdentifier.getParentId().isPresent()) return;
+                  String containerName = containerTestName(testIdentifier);
+                  skipped[0]++;
+                  send(
+                      TestProtocol.encodeTestFinished(
+                          currentSuite, containerName, "skipped", 0, reason, null));
+                  return;
+                }
                 String testName = testIdentifier.getDisplayName();
                 skipped[0]++;
                 send(
@@ -235,6 +312,16 @@ class JUnitPlatformRunner {
   private void send(String message) {
     protocolOut.println(message);
     protocolOut.flush();
+  }
+
+  /**
+   * A name for a container reported as if it were a test. Roots are engine descriptors ("JUnit
+   * Vintage"); everything below them is a class, a {@code @Nested} class, or a parameterized group,
+   * all of which fail for class-lifecycle reasons.
+   */
+  private static String containerTestName(TestIdentifier testIdentifier) {
+    String suffix = testIdentifier.getParentId().isPresent() ? " (class-level)" : " (engine-level)";
+    return testIdentifier.getDisplayName() + suffix;
   }
 
   private static String stackTraceToString(Throwable t) {


### PR DESCRIPTION
A JUnit 4 `@RunWith(Parameterized.class)` class whose `@AfterClass` throws `AssertionError` is reported by `bleep test` as **PASSED**, exit 0, with the exception nowhere in the output — not as a failure, not as a warning, not in the failures section.

```
📗 PASSED ai.datoria.dfmt.test.AfterClassProbeTest: 2 passed, 0 failed, 0 skipped (348 ms)
📗   Tests: 2 passed, 0 failed
```

`JUnitPlatformRunner`'s listener dropped every identifier with `isTest() == false`:

```java
public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult result) {
  if (!testIdentifier.isTest()) return;   // <-- container failures dropped here
```

Everything the platform attributes to a container rather than to a test went out that line: `@AfterClass`, `@BeforeClass`, `@AfterAll`, `@BeforeAll`, a failing class-level rule, a dying engine. JUnit 4 reaches this runner too, not just JUnit 5 — `isJUnitPlatformFramework` matches the framework name `"JUnit"`, so vintage suites inherit the same listener.

A failed container now becomes a failed test named `<container> (class-level)` (or `(engine-level)` for an engine root), carrying the message and stack trace, so it lands in the counts, in the failures section and in the exit code like any other failure. `@BeforeAll` previously surfaced as an *empty* suite — red, but for the wrong reason and with no stack trace.

## Two neighbours of the same early return

**A skipped container reported nothing.** `executionSkipped` had the identical guard. A `@Disabled`/`@Ignore`d class reports nothing for the tests underneath it, so the suite finished having emitted zero events — and a suite with zero events is reported `Empty`, which is to say **failed**. It now counts as skipped.

**A class with no runnable tests looked green.** JUnit 4's `Description.isTest()` means only "I have no children", so a class that produced nothing to run — an empty `@Parameters` list, `@SuiteClasses({})` — arrives through vintage as a single leaf and was counted as one passed test. The probe confirms it verbatim:

```
Child: Junit4EmptyParamsTest isTest=true [TEST]
```

Such a leaf is identifiable by a unique id ending in `[runner:<the class we asked for>]` rather than the usual `[test:method(class)]`. It no longer counts, so the suite falls through to `SuiteOutcome.Empty` with a warning naming the cause.

## Every other framework, probed

Each was given a class-level teardown that throws:

| framework | probe | verdict |
|---|---|---|
| JUnit 4 (vintage) | `@AfterClass` | was swallowed → **fixed** |
| JUnit 5 | `@AfterAll` / `@BeforeAll` | was swallowed → **fixed** |
| Kotest | `afterSpec` | already reported (platform path; now also gets a class-level line) |
| ScalaTest | `afterAll` | already reported as `error` on the suite |
| MUnit | `afterAll` | already reported as failed test `afterAll(…)` |
| utest | `utestAfterAll` | already reported as `#utestAfterAll` |
| TestNG | `@AfterClass` | **invisible — not ours to fix** |

TestNG is characterized rather than fixed. `mill.testng.TestNGListener` — the sbt-testing bridge bleep discovers on the user's classpath, not one it ships or injects — implements `org.testng.ITestListener` and nothing else, while TestNG routes `@BeforeClass`/`@AfterClass` failures to `IConfigurationListener`. TestNG prints `Configuration Failures: 1` and the bridge emits no event for it. That test pins today's behaviour and asserts TestNG's own summary line, so it goes red the day a bridge with `IConfigurationListener` shows up. (`@BeforeClass` is less severe: TestNG skips the dependent tests, and skips do go through `ITestListener`, so the suite at least does not look green.)

## Tests

11 new tests in `ForkedTestRunnerFrameworkTest`, plus an `outcome` field on `SuiteRunResult` — nothing had been asserting on the `SuiteDone` discriminator from a real forked JVM before. Verified as regression tests by stashing the Java change: all 5 JUnit ones fail without it.

- `bleep test bleep-bsp-tests --only ForkedTestRunnerFrameworkTest` — 32 passed
- `RunAndTestIntegrationTest`, `JvmTestRunnerIntegrationTest`, `BuildStateReducerTest`, `SuiteFinishedCodecTest`, `EdgeCaseIntegrationTest`, `PlatformTestRunnerIntegrationTest` — 90 passed
- `bleep test bleep-tests --only YourFirstProjectIT --only YourFirstKotlinProjectIT --only YourFirstScalaProjectIT --only KotlinIT --only TestFilterIT` — 18 passed

This ships in the test runner, so a reporter's workaround can only be dropped after `bleep sourcegen && bleep publish local-ivy` and a client/server/test-runner triple that all carry the same version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
