### PR TITLE
docs: generated snippets pinned a version no commit could ever hold

### DIFF
--- a/bleep-site/scripts/extract-snippets.js
+++ b/bleep-site/scripts/extract-snippets.js
@@ -184,11 +184,21 @@ async function main() {
     }
   }
 
+  // These files are checked in with BLEEP_LATEST_VERSION where a version belongs, so that cutting a
+  // release tag does not change them and the drift check stays meaningful. Nothing else resolves it
+  // for them: the remark plugin that handles the token in hand-written docs walks markdown, and these
+  // reach the page as <Snippet path="..." /> props instead. Left alone, every generated bleep.yaml on
+  // the site would tell readers to depend on "BLEEP_LATEST_VERSION".
+  const { latestBleepVersion } = await import("./latest-version.mjs");
+  const { VERSION_PLACEHOLDER } = await import("./remark-bleep-version.mjs");
+  const version = latestBleepVersion();
+
   // docs-snippets-from-tests files: full content only. Same json key (relative
   // path) so <Snippet path="..." /> can fetch them by raw path.
   for (const file of buildFiles) {
     try {
-      const content = fs.readFileSync(file, "utf8");
+      const raw = fs.readFileSync(file, "utf8");
+      const content = raw.split(VERSION_PLACEHOLDER).join(version);
       const relativePath = path.relative(ROOT_DIR, file);
       allSnippets[relativePath] = {
         name: relativePath,

--- a/bleep-tests/src/scala/bleep/IntegrationTestHarness.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationTestHarness.scala
@@ -94,6 +94,22 @@ abstract class IntegrationTestHarness extends AnyFunSuite {
     }
 }
 
+object Workspace {
+
+  /** What generated snippets write instead of a bleep version, resolved to the newest `v*` tag when the site is built.
+    *
+    * These files are checked in and a CI step diffs them against what the tests produce, so whatever goes in here has to be identical on every commit. A
+    * resolved version cannot be: it comes from dynver, so cutting `v1.0.0-M12` changes it, and the tag build is the first build that can possibly know the new
+    * value. Every release therefore failed the drift check against snippets that no earlier commit could have contained, and between releases the committed
+    * files went on advertising the previous version until someone regenerated them by hand.
+    *
+    * The token is shared with hand-written docs, which have used it all along. Its definition lives in `bleep-site/scripts/remark-bleep-version.mjs`
+    * (`VERSION_PLACEHOLDER`); `extract-snippets.js` substitutes it for these files, because the remark plugin only walks markdown and these reach the page as
+    * `<Snippet path="..." />` props. Change it in one place and the other two have to follow.
+    */
+  val VersionPlaceholder: String = "BLEEP_LATEST_VERSION"
+}
+
 /** A test workspace: a temp directory + a bleep.yaml + source files + an attached `Started`/`Commands` pair when [[start]] is called.
   *
   * Methods that take a `snippet` name mirror the file content into `<snippetsRoot>/<snippet>` so the docs site can include the same content via
@@ -212,7 +228,7 @@ class Workspace(
   /** Read a file written by [[bleepNew]] (or any other workspace setup) and tag it as a snippet. The content is mirrored to `<snippetsRoot>/<snippet>` when the
     * test body completes.
     *
-    * For bleep.yaml content the in-test `$version: dev` is rewritten to the latest release tag so docs are copy-pasteable. Same trick as [[snippetWithPrelude]]
+    * For bleep.yaml content the in-test `$version: dev` is rewritten to [[VersionPlaceholder]] so docs are copy-pasteable. Same trick as [[snippetWithPrelude]]
     * uses for the manually-authored prelude path.
     */
   def attachSnippet(relPath: String, snippet: String): Unit = {
@@ -222,10 +238,8 @@ class Workspace(
     taggedSnippets.update(snippet, content)
   }
 
-  private def normalizeDevVersionForDocs(yaml: String): String = {
-    val release = model.BleepVersion.current.value.takeWhile(_ != '+')
-    yaml.replaceFirst("(?m)^\\$version: dev$", s"\\$$version: $release")
-  }
+  private def normalizeDevVersionForDocs(yaml: String): String =
+    yaml.replaceFirst("(?m)^\\$version: dev$", s"\\$$version: ${Workspace.VersionPlaceholder}")
 
   /** Mirror `userYaml` (with the published `$schema` / `$version` / `jvm` prelude) to `<snippetsRoot>/<snippet>` without affecting the workspace bleep.yaml.
     * Use this when the in-test bleep.yaml needs different values than what the docs should show — e.g. a localhost test port versus a documented Artifactory
@@ -253,13 +267,12 @@ class Workspace(
   }
 
   /** When the user wants to show the full bleep.yaml (with schema + version + jvm) we reconstruct it. The test body's yaml prelude uses `$version: dev`; for
-    * the site we substitute the most recent release tag so docs are copy-pasteable. Dynver appends `+<commits>-<sha>-SNAPSHOT` after the tag — strip it.
+    * the site we substitute [[VersionPlaceholder]] so docs are copy-pasteable.
     */
   private def snippetWithPrelude(userYaml: String): String = {
-    val release = model.BleepVersion.current.value.takeWhile(_ != '+')
     val publishedPrelude =
       s"""$$schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-         |$$version: $release
+         |$$version: ${Workspace.VersionPlaceholder}
          |jvm:
          |  name: ${model.Jvm.graalvm.name}
          |""".stripMargin

--- a/docs-snippets-from-tests/artifactory/bleep.yaml
+++ b/docs-snippets-from-tests/artifactory/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 resolvers:

--- a/docs-snippets-from-tests/cross-building-kotlin/bleep.yaml
+++ b/docs-snippets-from-tests/cross-building-kotlin/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/cross-building-scala/bleep.yaml
+++ b/docs-snippets-from-tests/cross-building-scala/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/first-script-java/bleep.yaml
+++ b/docs-snippets-from-tests/first-script-java/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/first-script-kotlin/bleep.yaml
+++ b/docs-snippets-from-tests/first-script-kotlin/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/first-script-scala/bleep.yaml
+++ b/docs-snippets-from-tests/first-script-scala/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/per-cross-customization/bleep.yaml
+++ b/docs-snippets-from-tests/per-cross-customization/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/proguard-publish-java/bleep.yaml
+++ b/docs-snippets-from-tests/proguard-publish-java/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/proguard-publish-kotlin/bleep.yaml
+++ b/docs-snippets-from-tests/proguard-publish-kotlin/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/proguard-publish-scala/bleep.yaml
+++ b/docs-snippets-from-tests/proguard-publish-scala/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/publish-to-maven/bleep.yaml
+++ b/docs-snippets-from-tests/publish-to-maven/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/sourcegen-java/bleep.yaml
+++ b/docs-snippets-from-tests/sourcegen-java/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/sourcegen-kotlin/bleep.yaml
+++ b/docs-snippets-from-tests/sourcegen-kotlin/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/sourcegen-scala/bleep.yaml
+++ b/docs-snippets-from-tests/sourcegen-scala/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/spring-boot-myapp/bleep.yaml
+++ b/docs-snippets-from-tests/spring-boot-myapp/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/test-projects/bleep.yaml
+++ b/docs-snippets-from-tests/test-projects/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/your-first-kotlin-project/bleep.yaml
+++ b/docs-snippets-from-tests/your-first-kotlin-project/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/your-first-project/bleep.yaml
+++ b/docs-snippets-from-tests/your-first-project/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:

--- a/docs-snippets-from-tests/your-first-scala-project/bleep.yaml
+++ b/docs-snippets-from-tests/your-first-scala-project/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 1.0.0-M11
+$version: BLEEP_LATEST_VERSION
 jvm:
   name: graalvm-community:25.0.1
 projects:


### PR DESCRIPTION
## What broke

Cutting `v1.0.0-M12` failed its own release build, so nothing was published.

The failing step is `Snippets match what the tests generate`, which diffs the checked-in `docs-snippets-from-tests` against what the integration tests produce. The tests wrote `BleepVersion.current` into every `$version:` line, and that value comes from dynver — so **the tag itself changes it**. The tag build is the first build that can possibly know the new version, and it diffs against snippets written before the tag existed.

No commit could ever have contained the right value. Every release was going to fail here, and `release` needs `build`, so the publish never ran.

## The quieter half

The same root cause was already costing us between releases. The committed snippets kept advertising the previous version, and the site is published from exactly these files — so the docs told readers to depend on a version that was no longer current, until someone regenerated them by hand. `build.yml` already carries a comment about this having happened once.

## The fix

Snippets now write `BLEEP_LATEST_VERSION` — the token hand-written docs have used all along — so the files are identical on every commit and the drift check becomes meaningful instead of a countdown to the next release.

The remark plugin that resolves that token only walks markdown, and these snippets reach the page as `<Snippet path="..." />` props, so `extract-snippets.js` substitutes it when baking `snippets.json`. Without that half, the site would render the literal `BLEEP_LATEST_VERSION` to readers.

## Verification

- Both generator paths re-run locally (`YourFirstProjectIT` for `attachSnippet`, `PublishToHttpMavenRepoIT` for `attachSnippetYaml`) and reproduce the committed files exactly.
- Substitution checked end to end: newest tag resolves to `1.0.0-M12`, rendered line is `$version: 1.0.0-M12`, and no file leaks the raw token.
- The other 19 snippet files are covered by the drift check itself in CI, which is its job.

Once this is green and merged, `v1.0.0-M12` gets retagged onto the merge commit so the release can actually publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)