### PR TITLE
test-runner: testRunnerMaxMemory was a default wearing a ceiling's name

### DIFF
--- a/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepServerAdmin.scala
+++ b/bleep-bsp-protocol/src/scala/bleep/bsp/protocol/BleepServerAdmin.scala
@@ -115,7 +115,8 @@ case class ServerConfigDto(
     parallelism: Int,
     /** As written in config — `"4g"`, `"512m"` — or absent when the computed default applies. */
     compileServerMaxMemory: Option[String],
-    testRunnerMaxMemory: Option[String],
+    /** Default heap for test forks; a project's own `-Xmx` overrides it. Absent when bleep's own default applies. */
+    testRunnerHeap: Option[String],
     maxCachedWorkspaces: Int,
     bspReadTimeoutMillis: Long,
     compileServerIdleTimeoutMillis: Long,

--- a/bleep-bsp-tests/src/scala/bleep/MachineResourcesTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/MachineResourcesTest.scala
@@ -147,11 +147,27 @@ class MachineResourcesTest extends AnyFunSuite with Matchers {
     // The whole point of the redesign. An unstated -Xmx is not "unlimited" — HotSpot hands the fork
     // MaxRAMPercentage=25, a quarter of the machine, which is how ~18 forks came to request 216GB on
     // a 48GB box. Containment is the bound, not the scheduling.
-    MachineResources.withHeapBound(Nil) shouldBe List(s"-Xmx${MachineResources.DefaultForkHeapMb}m")
-    MachineResources.withHeapBound(List("-XX:+UseZGC")) shouldBe List("-XX:+UseZGC", s"-Xmx${MachineResources.DefaultForkHeapMb}m")
+    MachineResources.withHeapBound(Nil, MachineResources.DefaultForkHeapMb) shouldBe List(s"-Xmx${MachineResources.DefaultForkHeapMb}m")
+    MachineResources.withHeapBound(List("-XX:+UseZGC"), MachineResources.DefaultForkHeapMb) shouldBe List(
+      "-XX:+UseZGC",
+      s"-Xmx${MachineResources.DefaultForkHeapMb}m"
+    )
     // A build that stated its own bound keeps it, exactly.
-    MachineResources.withHeapBound(List("-Xmx12g")) shouldBe List("-Xmx12g")
+    MachineResources.withHeapBound(List("-Xmx12g"), MachineResources.DefaultForkHeapMb) shouldBe List("-Xmx12g")
     MachineResources.DefaultForkHeapMb shouldBe 2048L
+  }
+
+  test("the configured default applies only when the build states no -Xmx of its own") {
+    // `testRunnerHeap` is a default, not a ceiling. It used to be prepended to the build's options and
+    // left to JVM last-one-wins, so a fork could be started with two `-Xmx` and neither source told you
+    // which one it ran with. Exactly one comes out of here.
+    val configured = MachineResources.forkHeapMb(Some("512m"))
+    MachineResources.withHeapBound(Nil, configured) shouldBe List("-Xmx512m")
+    // A project asking for MORE than the configured default gets it — the machine is protected by
+    // admission (a big fork runs alone), not by shrinking a heap the code was told it could have.
+    MachineResources.withHeapBound(List("-Xmx3g"), configured) shouldBe List("-Xmx3g")
+    // ...and asking for less is equally left alone.
+    MachineResources.withHeapBound(List("-Xmx64m"), configured) shouldBe List("-Xmx64m")
   }
 
   test("one number decides both what a fork may use and what it is charged") {

--- a/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/BspServerDaemon.scala
@@ -195,7 +195,7 @@ object BspServerDaemon {
     // There is deliberately NO separate user knob for the fork-memory budget. Users already control
     // both dimensions of what forks cost, at the level each belongs to: `parallelism` /
     // `parallelismRatio` in the user config bound how many forks run at once, and
-    // `testRunnerMaxMemory` (or a project's own jvmOptions) bounds how big each one is. A third
+    // `testRunnerHeap` (or a project's own jvmOptions) bounds how big each one is. A third
     // machine-level number would overlap both and, because the daemon is shared and long-lived,
     // could only have been delivered by environment — which the daemon inherits from whichever
     // client happened to cold-start it and every later client silently reuses. A setting that

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -688,7 +688,7 @@ class MultiWorkspaceBspServer(
       config = ServerConfigDto(
         parallelism = config.effectiveParallelism,
         compileServerMaxMemory = config.compileServerMaxMemory,
-        testRunnerMaxMemory = config.testRunnerMaxMemory,
+        testRunnerHeap = config.testRunnerHeap,
         maxCachedWorkspaces = config.maxCachedWorkspacesFor(Runtime.getRuntime.maxMemory()),
         bspReadTimeoutMillis = config.effectiveBspReadTimeoutMillis.toLong,
         compileServerIdleTimeoutMillis = config.effectiveCompileServerIdleTimeoutMillis,
@@ -2378,7 +2378,11 @@ class MultiWorkspaceBspServer(
                     pool = jvmPool,
                     eventQueue = eventQueue,
                     options = TestRunner.Options(
-                      jvmOptions = serverConfig.testRunnerMaxMemory.map(m => s"-Xmx$m").toList ++ projectJvmOptions ++ testOptions.jvmOptions,
+                      // Only what someone asked for, in precedence order: the project's own options, then this run's `--jvm-opt`. The configured heap is NOT
+                      // prepended here — it goes in as the default the pool falls back to, so a fork carries exactly one `-Xmx` and it is the one that
+                      // decided the heap. See MachineResources.withHeapBound.
+                      jvmOptions = projectJvmOptions ++ testOptions.jvmOptions,
+                      defaultHeapMb = MachineResources.forkHeapMb(serverConfig.testRunnerHeap),
                       testArgs = testOptions.testArgs,
                       idleTimeout = idleTimeout,
                       environment = testEnv,

--- a/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TestRunner.scala
@@ -1,5 +1,6 @@
 package bleep.bsp
 
+import bleep.MachineResources
 import bleep.bsp.protocol.KillReason
 import bleep.bsp.protocol.{BleepBspProtocol, OutputChannel, ProcessExit, SuiteOutcome, TestStatus}
 import bleep.model.{CrossProjectName, SuiteName, TestName}
@@ -21,6 +22,10 @@ object TestRunner {
   /** Options for the test runner */
   case class Options(
       jvmOptions: List[String],
+      /** Heap for a fork whose `jvmOptions` state no `-Xmx` — the `testRunnerHeap` user setting, or bleep's default when it is unset. A project that states its
+        * own `-Xmx` runs with that instead; this number is a default, not a ceiling over it.
+        */
+      defaultHeapMb: Long,
       testArgs: List[String],
       idleTimeout: FiniteDuration,
       environment: Map[String, String],
@@ -30,6 +35,7 @@ object TestRunner {
   object Options {
     val default: Options = Options(
       jvmOptions = Nil,
+      defaultHeapMb = MachineResources.DefaultForkHeapMb,
       testArgs = Nil,
       idleTimeout = 2.minutes,
       environment = Map.empty,
@@ -74,7 +80,7 @@ object TestRunner {
   ): IO[TaskDag.TaskResult] = {
     val runnerClass = "bleep.testing.runner.ForkedTestRunner"
 
-    pool.acquire(suiteName, classpath, options.jvmOptions, runnerClass, options.environment, options.workingDirectory).use { jvm =>
+    pool.acquire(suiteName, classpath, options.jvmOptions, options.defaultHeapMb, runnerClass, options.environment, options.workingDirectory).use { jvm =>
       // Recorded here rather than in the pool because this is the only place that knows both which JVM was handed out and what is about to run on it. The pid
       // joins these to the fork_start/fork_end pair, which is what lets a test run be reconstructed: which suites shared a JVM, and which JVM was killed
       // under which suite.

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -178,6 +178,24 @@ object Main {
         }
       )
 
+    /** A knob that was renamed: the old spelling keeps working, writes the same field, and says what to type instead. */
+    def renamedValue[A](oldKnob: String, newKnob: String, metavar: String)(
+        update: (model.BspServerConfig, A) => model.BspServerConfig
+    )(using argument: Argument[A]): Opts[Logger => BleepCommand] =
+      Opts.subcommand(oldKnob, s"(deprecated: use `bleep server config $newKnob`)")(
+        Opts.argument[A](metavar).map { value => (logger: Logger) =>
+          commands.server
+            .ServerConfigSet(logger, userPaths, newKnob, config => update(config, value), deprecatedAlias = Some(s"bleep server config $oldKnob"))
+        }
+      )
+
+    def renamed(oldKnob: String, newKnob: String)(update: model.BspServerConfig => model.BspServerConfig): Opts[Logger => BleepCommand] =
+      Opts.subcommand(oldKnob, s"(deprecated: use `bleep server config $newKnob`)")(
+        Opts.unit.map(_ =>
+          (logger: Logger) => commands.server.ServerConfigSet(logger, userPaths, newKnob, update, deprecatedAlias = Some(s"bleep server config $oldKnob"))
+        )
+      )
+
     def positive(knob: String)(n: Int): Unit =
       if (n < 1) throw new BleepException.Text(s"$knob must be >= 1, got $n")
 
@@ -233,10 +251,18 @@ object Main {
           if (fraction <= 0 || fraction > 1) throw new BleepException.Text(s"heap-pressure-threshold must be in (0, 1], got $fraction")
       }((config, fraction) => config.copy(heapPressureThreshold = Some(fraction))),
       set("heap-pressure-threshold-clear", "remove the setting (back to default: 0.80)")(_.copy(heapPressureThreshold = None)),
-      setValue[String]("test-runner-max-memory", "max heap for forked test runner JVMs (e.g. 512m, 2g)", "size")(_ => ())((config, size) =>
-        config.copy(testRunnerMaxMemory = Some(size))
+      setValue[String](
+        "test-runner-heap",
+        "default heap for forked test runner JVMs (e.g. 512m, 2g). A project's own platform.jvmOptions -Xmx overrides it",
+        "size"
+      )(_ => ())((config, size) => config.copy(testRunnerHeap = Some(size))),
+      set("test-runner-heap-clear", s"remove the setting (back to bleep's default: ${MachineResources.DefaultForkHeapMb}m per test fork)")(
+        _.copy(testRunnerHeap = None)
       ),
-      set("test-runner-max-memory-clear", "remove the test runner max heap setting (back to the JVM default)")(_.copy(testRunnerMaxMemory = None)),
+      // Renamed because it never was a maximum: a project's own -Xmx has always outranked it, and calling it `max` had people believing a per-project heap
+      // could not exceed it.
+      renamedValue[String]("test-runner-max-memory", "test-runner-heap", "size")((config, size) => config.copy(testRunnerHeap = Some(size))),
+      renamed("test-runner-max-memory-clear", "test-runner-heap-clear")(_.copy(testRunnerHeap = None)),
       setValue[Int]("test-idle-timeout", "minutes a test suite may go without emitting an event before it is considered stuck (default: 2)", "minutes")(
         positive("test-idle-timeout")
       )((config, n) => config.copy(testIdleTimeoutMinutes = Some(n))),
@@ -1009,17 +1035,17 @@ object Main {
           List(
             Opts.subcommand[Logger => BleepCommand](
               "max-memory",
-              "(deprecated: use `bleep server config test-runner-max-memory`) set max heap for test runner JVMs (e.g. 512m, 2g)"
+              "(deprecated: use `bleep server config test-runner-heap`) set default heap for test runner JVMs (e.g. 512m, 2g)"
             )(
               Opts.argument[String]("size").map { size => (logger: Logger) => () =>
-                deprecatedKnob(logger, userPaths, "test-runner-max-memory", _.copy(testRunnerMaxMemory = Some(size)))
+                deprecatedKnob(logger, userPaths, "test-runner-heap", _.copy(testRunnerHeap = Some(size)))
               }
             ),
             Opts.subcommand[Logger => BleepCommand](
               "max-memory-clear",
-              "(deprecated: use `bleep server config test-runner-max-memory-clear`) remove test runner max heap setting (use JVM default)"
+              "(deprecated: use `bleep server config test-runner-heap-clear`) remove the test runner heap setting (use bleep's default)"
             )(
-              Opts((logger: Logger) => () => deprecatedKnob(logger, userPaths, "test-runner-max-memory-clear", _.copy(testRunnerMaxMemory = None)))
+              Opts((logger: Logger) => () => deprecatedKnob(logger, userPaths, "test-runner-heap-clear", _.copy(testRunnerHeap = None)))
             )
           ).foldK
         ),

--- a/bleep-cli/src/scala/bleep/commands/server/ServerConfigShow.scala
+++ b/bleep-cli/src/scala/bleep/commands/server/ServerConfigShow.scala
@@ -93,7 +93,7 @@ case class ServerConfigShow(
       row("read-timeout", config.bspReadTimeoutMinutes, status.map(_.config.bspReadTimeoutMillis / 60000)),
       row("idle-timeout", config.compileServerIdleTimeoutMinutes, status.map(_.config.compileServerIdleTimeoutMillis / 60000)),
       row("heap-pressure-threshold", config.heapPressureThreshold, status.map(_.config.heapPressureThreshold)),
-      row("test-runner-max-memory", config.testRunnerMaxMemory, status.flatMap(_.config.testRunnerMaxMemory)),
+      row("test-runner-heap", config.testRunnerHeap, status.flatMap(_.config.testRunnerHeap)),
       row("test-idle-timeout", config.testIdleTimeoutMinutes, status.map(_.config.testIdleTimeoutMinutes)),
       row("sourcegen-max-memory", config.sourcegenMaxMemory, None),
       row("ksp-runner-max-memory", config.kspRunnerMaxMemory, None)

--- a/bleep-cli/src/scala/bleep/commands/server/ServerStatus.scala
+++ b/bleep-cli/src/scala/bleep/commands/server/ServerStatus.scala
@@ -79,7 +79,7 @@ case class ServerStatus(logger: Logger, userPaths: UserPaths, id: Option[String]
         s"heap pressure ${config.heapPressureThreshold}"
     )
     config.compileServerMaxMemory.foreach(m => logger.info(s"           compile server max memory $m"))
-    config.testRunnerMaxMemory.foreach(m => logger.info(s"           test runner max memory $m"))
+    config.testRunnerHeap.foreach(m => logger.info(s"           test runner heap $m per fork, unless the project states its own"))
     logger.info("           (as booted — edits on disk apply on restart)")
   }
 

--- a/bleep-cli/src/scala/bleep/commands/server/tui/ServerTopView.scala
+++ b/bleep-cli/src/scala/bleep/commands/server/tui/ServerTopView.scala
@@ -454,7 +454,10 @@ object ServerTopView {
       fieldOf("Idle timeout", s"${booted.compileServerIdleTimeoutMillis / 60000} minutes with no client before shutting down"),
       fieldOf("Heap pressure", s"new compiles wait above ${(booted.heapPressureThreshold * 100).toInt}% heap"),
       fieldOf("Max memory", booted.compileServerMaxMemory.getOrElse("bleep's default")),
-      fieldOf("Test runner", booted.testRunnerMaxMemory.map(m => s"$m per forked test JVM").getOrElse("the JVM default")),
+      fieldOf(
+        "Test runner",
+        booted.testRunnerHeap.map(m => s"$m per forked test JVM, unless the project states its own").getOrElse("bleep's default per forked test JVM")
+      ),
       Line.empty(),
       lineOf("  These were read when the server started. `bleep server config show` compares them with the file on disk,", Palette.textDim),
       lineOf("  and `bleep server restart` applies anything that has changed since.", Palette.textDim)

--- a/bleep-core/src/scala/bleep/MachineResources.scala
+++ b/bleep-core/src/scala/bleep/MachineResources.scala
@@ -415,8 +415,8 @@ object MachineResources {
     * So bleep states a bound rather than inheriting one. Every comparable tool does: Gradle defaults `Test.maxHeapSize` to 512m, Maven Surefire runs a single
     * fork, sbt runs tests in-process. 2GB is comfortable for ordinary JVM test suites and small enough that CPU, not memory, decides how wide a build runs.
     *
-    * A fork that genuinely needs more says so — `testRunnerMaxMemory` / `sourcegenMaxMemory` / `kspRunnerMaxMemory`, or the project's own `jvmOptions` — and if
-    * it then exceeds that, it gets an `OutOfMemoryError` naming the limit: attributable to the code that caused it, instead of a SIGKILL landing on whichever
+    * A fork that genuinely needs more says so — `testRunnerHeap` / `sourcegenMaxMemory` / `kspRunnerMaxMemory`, or the project's own `jvmOptions` — and if it
+    * then exceeds that, it gets an `OutOfMemoryError` naming the limit: attributable to the code that caused it, instead of a SIGKILL landing on whichever
     * process the kernel happened to pick.
     */
   val DefaultForkHeapMb: Long = 2048L
@@ -427,14 +427,18 @@ object MachineResources {
   def forkHeapMb(configured: Option[String]): Long =
     configured.flatMap(parseMemoryMb).getOrElse(DefaultForkHeapMb)
 
-  /** The options a fork is actually started with: whatever the build asked for, plus [[DefaultForkHeapMb]] if it stated no `-Xmx`.
+  /** The options a fork is actually started with: whatever the build asked for, plus `defaultHeapMb` if it stated no `-Xmx`.
+    *
+    * A fork ends up with exactly one `-Xmx`, which is the point. Configured heaps used to be prepended to the build's own options and left to JVM last-one-wins
+    * to resolve, so `java -Xmx1g … -Xmx3g` was a normal argv and the number a fork ran with could not be read off either source alone. It also made the config
+    * knob look like a ceiling while behaving as a default. Now the choice is made here, once, and the argv states the answer.
     *
     * Returned rather than applied in place because for pooled forks these options are also the pool key — a JVM started with an imposed bound must not be
     * handed to a caller who asked for a different one.
     */
-  def withHeapBound(jvmOptions: List[String]): List[String] =
+  def withHeapBound(jvmOptions: List[String], defaultHeapMb: Long): List[String] =
     if (jvmOptions.exists(_.startsWith("-Xmx"))) jvmOptions
-    else jvmOptions :+ s"-Xmx${DefaultForkHeapMb}m"
+    else jvmOptions :+ s"-Xmx${defaultHeapMb}m"
 
   /** What a forked JVM whose heap is capped at `heapMb` costs the machine.
     *
@@ -458,8 +462,8 @@ object MachineResources {
     * very nearly the binding constraint anyway. Being stingy costs a SIGKILL.
     *
     * This is only where the budget STARTS; [[retuneLoop]] then tracks what the machine can actually spare. There is deliberately no user knob for it: users
-    * already bound how many forks run (`parallelism`/`parallelismRatio`) and how big each one is (`testRunnerMaxMemory`, or a project's jvmOptions), which
-    * between them are the two things a fork-memory budget would be expressing.
+    * already bound how many forks run (`parallelism`/`parallelismRatio`) and how big each one is (`testRunnerHeap`, or a project's jvmOptions), which between
+    * them are the two things a fork-memory budget would be expressing.
     *
     * The server's FOOTPRINT is subtracted rather than its bare `-Xmx`, since it is a JVM too: an `-Xmx8g` daemon sits at ~8.9GB RSS, and counting it as 8GB
     * quietly handed the difference to the fork budget.

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -29,12 +29,16 @@ trait JvmPool {
 
   /** Acquire a JVM suitable for the given classpath and options.
     *
+    * `defaultHeapMb` is the heap this fork gets if `jvmOptions` states no `-Xmx` of its own — the caller's configured default, not a ceiling over what the
+    * caller asked for. See [[MachineResources.withHeapBound]].
+    *
     * Returns a Resource that will release the JVM back to the pool when done.
     */
   def acquire(
       label: String,
       classpath: List[Path],
       jvmOptions: List[String],
+      defaultHeapMb: Long,
       runnerClass: String,
       environment: Map[String, String],
       workingDirectory: Option[Path]
@@ -391,6 +395,7 @@ object JvmPool {
         label: String,
         classpath: List[Path],
         jvmOptions: List[String],
+        defaultHeapMb: Long,
         runnerClass: String,
         environment: Map[String, String],
         workingDirectory: Option[Path]
@@ -398,7 +403,7 @@ object JvmPool {
       // Bound the fork before anything else looks at these options. Everything downstream — the pool
       // key, the spawn, and what the governor is told this costs — must agree on the heap the JVM
       // will actually run with, and that is only true if the bound is applied once, here.
-      val boundedOptions = MachineResources.withHeapBound(jvmOptions)
+      val boundedOptions = MachineResources.withHeapBound(jvmOptions, defaultHeapMb)
       val key = JvmKey(classpath, boundedOptions, environment, workingDirectory)
 
       // NO machine CPU reservation here. The caller already holds one.

--- a/bleep-model/src/scala/bleep/model/BleepConfig.scala
+++ b/bleep-model/src/scala/bleep/model/BleepConfig.scala
@@ -1,7 +1,7 @@
 package bleep.model
 
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.{Decoder, Encoder}
+import io.circe.{ACursor, Decoder, Encoder}
 
 case class BleepConfig(
     compileServerMode: Option[CompileServerMode],
@@ -40,8 +40,16 @@ case class BspServerConfig(
     parallelismRatio: Option[Double],
     /** Idle timeout for test suites in minutes — resets each time a test completes */
     testIdleTimeoutMinutes: Option[Int],
-    /** Max heap for forked test runner JVMs, e.g. "512m", "2g". None = JVM default */
-    testRunnerMaxMemory: Option[String],
+    /** Default heap for forked test runner JVMs, e.g. "512m", "2g". None = [[bleep.MachineResources.DefaultForkHeapMb]].
+      *
+      * A default, not a ceiling: a project that states its own `-Xmx` in `platform.jvmOptions` runs with that instead, and this number does not apply. That is
+      * the right way round, because how much heap a suite needs is a property of the code, which lives in the build, while this setting belongs to whoever owns
+      * the machine. What protects the machine from a project asking for a lot is admission, not clamping — [[bleep.MachineResources]] charges a fork its whole
+      * footprint and will run an oversized one alone rather than alongside others.
+      *
+      * Was `testRunnerMaxMemory`, which named a ceiling it never was; the old key is still read.
+      */
+    testRunnerHeap: Option[String],
     /** Max heap for forked sourcegen JVMs, e.g. "500m", "2g". None = JVM default */
     sourcegenMaxMemory: Option[String],
     /** Max heap for forked KSP runner JVMs (`KSPJvmMain`), e.g. "512m", "1500m". KSP bundles its own Analysis-API kotlinc which is memory-hungry on real builds
@@ -158,7 +166,7 @@ object BspServerConfig {
     parallelism = None,
     parallelismRatio = None,
     testIdleTimeoutMinutes = None,
-    testRunnerMaxMemory = None,
+    testRunnerHeap = None,
     sourcegenMaxMemory = None,
     kspRunnerMaxMemory = None,
     compileServerMaxMemory = None,
@@ -168,6 +176,16 @@ object BspServerConfig {
     maxCachedWorkspaces = None
   )
 
-  implicit val decoder: Decoder[BspServerConfig] = deriveDecoder
+  /** `testRunnerHeap` was called `testRunnerMaxMemory` until it was renamed to say what it does. Config files on disk outlive a rename, so the old key is read
+    * as the new one — someone who set it once should not silently lose the setting to an upgrade. Writing always uses the new name, so a config rewritten by
+    * any `bleep server config` command migrates itself.
+    */
+  private val migrateLegacyKeys: ACursor => ACursor =
+    _.withFocus(_.mapObject { obj =>
+      if (obj.contains("testRunnerHeap")) obj
+      else obj("testRunnerMaxMemory").fold(obj)(legacy => obj.add("testRunnerHeap", legacy).remove("testRunnerMaxMemory"))
+    })
+
+  implicit val decoder: Decoder[BspServerConfig] = deriveDecoder[BspServerConfig].prepare(migrateLegacyKeys)
   implicit val encoder: Encoder[BspServerConfig] = deriveEncoder
 }

--- a/bleep-tests/src/scala/bleep/BspServerConfigTest.scala
+++ b/bleep-tests/src/scala/bleep/BspServerConfigTest.scala
@@ -35,14 +35,27 @@ class BspServerConfigTest extends AnyFunSuite with Matchers {
   // setting does nothing — which is exactly how `bspServer:` survived in the docs for so long.
   test("the YAML shape documented in compile-servers.mdx actually decodes") {
     val documented =
-      """{"compileServerMode":{"mode":"shared"},"bspServerConfig":{"compileServerMaxMemory":"4g","heapPressureThreshold":0.85,"testRunnerMaxMemory":"2g","bspReadTimeoutMinutes":30}}"""
+      """{"compileServerMode":{"mode":"shared"},"bspServerConfig":{"compileServerMaxMemory":"4g","heapPressureThreshold":0.85,"testRunnerHeap":"2g","bspReadTimeoutMinutes":30}}"""
     val config = decode[bleep.model.BleepConfig](documented).fold(throw _, identity)
     config.compileServerModeOrDefault shouldBe bleep.model.CompileServerMode.Shared
     val bsp = config.bspServerConfigOrDefault
     bsp.compileServerMaxMemory shouldBe Some("4g")
     bsp.heapPressureThreshold shouldBe Some(0.85)
-    bsp.testRunnerMaxMemory shouldBe Some("2g")
+    bsp.testRunnerHeap shouldBe Some("2g")
     bsp.bspReadTimeoutMinutes shouldBe Some(30)
+  }
+
+  // The rename is only safe if it is invisible to people who already set the old key: their config file
+  // is not rewritten by an upgrade, so a decoder that only knew the new name would silently drop the
+  // setting and start their test forks on a different heap than they configured.
+  test("a config written before the rename still sets the test fork heap") {
+    val legacy = """{"bspServerConfig":{"testRunnerMaxMemory":"2g"}}"""
+    decode[bleep.model.BleepConfig](legacy).fold(throw _, identity).bspServerConfigOrDefault.testRunnerHeap shouldBe Some("2g")
+  }
+
+  test("when both names are present the current one wins") {
+    val both = """{"bspServerConfig":{"testRunnerMaxMemory":"2g","testRunnerHeap":"3g"}}"""
+    decode[bleep.model.BleepConfig](both).fold(throw _, identity).bspServerConfigOrDefault.testRunnerHeap shouldBe Some("3g")
   }
 
   test("the key the docs used to name (bspServer) really is silently ignored") {

--- a/bleep-tests/src/scala/bleep/IntegrationTestHarness.scala
+++ b/bleep-tests/src/scala/bleep/IntegrationTestHarness.scala
@@ -54,7 +54,7 @@ abstract class IntegrationTestHarness extends AnyFunSuite {
     // process are tiny, so a few hundred megs is plenty.
     bspServerConfig = Some(
       model.BspServerConfig.default.copy(
-        testRunnerMaxMemory = Some("512m"),
+        testRunnerHeap = Some("512m"),
         kspRunnerMaxMemory = Some("384m"),
         // Pin in-process BSP parallelism to 1 for ITs. The outer `bleep test bleep-tests` already runs `effectiveParallelism = cores` ForkedTestRunner JVMs in
         // parallel; without this cap each IT's in-process BSP would also fork up to `cores` JVMs (`JvmPool.create(maxParallelism, …)` in MultiWorkspaceBspServer

--- a/bleep-tests/src/scala/bleep/RemoteCacheIT.scala
+++ b/bleep-tests/src/scala/bleep/RemoteCacheIT.scala
@@ -18,7 +18,7 @@ class RemoteCacheIT extends IntegrationTestHarness {
     compileServerMode = Some(model.CompileServerMode.NewEachInvocation),
     authentications = None,
     logTiming = None,
-    bspServerConfig = Some(model.BspServerConfig.default.copy(testRunnerMaxMemory = Some("512m"))),
+    bspServerConfig = Some(model.BspServerConfig.default.copy(testRunnerHeap = Some("512m"))),
     remoteCacheCredentials = Some(model.RemoteCacheCredentials(accessKeyId = "test-access-key", secretAccessKey = "test-secret-key"))
   )
 

--- a/bleep-tests/src/scala/bleep/ServerConfigKnobsTest.scala
+++ b/bleep-tests/src/scala/bleep/ServerConfigKnobsTest.scala
@@ -29,7 +29,7 @@ class ServerConfigKnobsTest extends AnyFunSuite with Matchers {
       bspReadTimeoutMinutes = Some(15),
       compileServerIdleTimeoutMinutes = Some(120),
       heapPressureThreshold = Some(0.85),
-      testRunnerMaxMemory = Some("2g"),
+      testRunnerHeap = Some("2g"),
       testIdleTimeoutMinutes = Some(5),
       sourcegenMaxMemory = Some("500m"),
       kspRunnerMaxMemory = Some("1500m")

--- a/bleep-tests/src/scala/bleep/ServerTopTest.scala
+++ b/bleep-tests/src/scala/bleep/ServerTopTest.scala
@@ -59,7 +59,7 @@ class ServerTopTest extends AnyFunSuite with Matchers {
     config = ServerConfigDto(
       parallelism = 18,
       compileServerMaxMemory = Some("12g"),
-      testRunnerMaxMemory = None,
+      testRunnerHeap = None,
       maxCachedWorkspaces = 12,
       bspReadTimeoutMillis = 30 * 60000L,
       compileServerIdleTimeoutMillis = 60 * 60000L,

--- a/bleep-tests/src/scala/bleep/TestHeapPropagationIT.scala
+++ b/bleep-tests/src/scala/bleep/TestHeapPropagationIT.scala
@@ -1,0 +1,122 @@
+package bleep
+
+/** The heap a forked test JVM actually runs with.
+  *
+  * Every assertion is made from *inside* the fork, against `Runtime.maxMemory`, because that is the only number that cannot be wrong: the options bleep
+  * assembles are evidence of intent, not of what the JVM did with them. This suite exists because a plausible-looking experiment once "proved" that
+  * `platform.jvmOptions` never reached the fork at all — it had set `-Xmx3m`, expecting a JVM that refuses to start, and HotSpot quietly rounded it up to a
+  * heap the suite ran fine in. Nothing in the build or the CLI reported the number, so there was no way to tell.
+  *
+  * [[IntegrationTestHarness.testConfig]] sets `testRunnerHeap` to 512m, which is the configured default these tests are measured against.
+  */
+class TestHeapPropagationIT extends IntegrationTestHarness {
+
+  /** The suite asserts its own heap, so a fork started with the wrong `-Xmx` fails the test rather than quietly passing. Ranges, not equality: `maxMemory` is
+    * what the GC made of `-Xmx`, which is the same order but not always the same number.
+    */
+  private def suiteExpectingHeapMb(loMb: Long, hiMb: Long): String =
+    s"""package example
+       |
+       |import org.scalatest.funsuite.AnyFunSuite
+       |
+       |class HeapTest extends AnyFunSuite {
+       |  test("the forked test jvm runs with the heap the build asked for") {
+       |    val maxMb = Runtime.getRuntime.maxMemory / (1024 * 1024)
+       |    assert(maxMb >= ${loMb}L && maxMb <= ${hiMb}L, s"expected a heap in [$loMb, $hiMb] MB, got $${maxMb}MB")
+       |  }
+       |}
+       |""".stripMargin
+
+  private def yamlWithJvmOptions(jvmOptions: Option[String]): String =
+    s"""projects:
+       |  mytest:
+       |    dependencies: org.scalatest::scalatest:3.2.15
+       |    isTestProject: true
+       |    platform:
+       |      name: jvm${jvmOptions.fold("")(opts => s"\n      jvmOptions: $opts")}
+       |    scala:
+       |      version: 3.3.3
+       |""".stripMargin
+
+  private val mytest = model.CrossProjectName(model.ProjectName("mytest"), None)
+
+  /** The default a fork gets here when the build states nothing.
+    *
+    * Read from the same place the server reads it — the user config on disk (`MultiWorkspaceBspServer` loads it fresh per request), NOT
+    * [[IntegrationTestHarness.testConfig]], which the in-process server does not consult for this. Computing it rather than hardcoding it is what keeps these
+    * assertions true on a developer machine that has set `testRunnerHeap` and on CI, which has no config file at all.
+    */
+  private val configuredDefaultMb: Long =
+    MachineResources.forkHeapMb(BleepConfigOps.loadOrDefault(userPaths).orThrow.bspServerConfigOrDefault.testRunnerHeap)
+
+  private def runTests(started: Started, jvmOptions: List[String]): Either[BleepException, Unit] =
+    commands.ReactiveBsp
+      .test(
+        watch = false,
+        projects = Array(mytest),
+        displayMode = commands.DisplayMode.NoTui,
+        jvmOptions = jvmOptions,
+        testArgs = Nil,
+        only = Nil,
+        exclude = Nil,
+        includeTags = Nil,
+        excludeTags = Nil,
+        flamegraph = false,
+        cancel = false,
+        junitReportDir = None,
+        clientEnv = Map.empty
+      )
+      .run(started)
+
+  integrationTest("platform.jvmOptions -Xmx is the heap the fork runs with") { ws =>
+    ws.yaml(yamlWithJvmOptions(Some("-Xmx256m")))
+    ws.file("mytest/src/scala/HeapTest.scala", suiteExpectingHeapMb(loMb = 180, hiMb = 320))
+    val (started, _, _) = ws.start()
+    runTests(started, Nil).orThrow
+    succeed
+  }
+
+  integrationTest("a project that states nothing gets the configured testRunnerHeap") { ws =>
+    ws.yaml(yamlWithJvmOptions(None))
+    ws.file("mytest/src/scala/HeapTest.scala", suiteExpectingHeapMb(loMb = configuredDefaultMb * 8 / 10, hiMb = configuredDefaultMb))
+    val (started, _, _) = ws.start()
+    runTests(started, Nil).orThrow
+    succeed
+  }
+
+  integrationTest("a project may ask for MORE heap than testRunnerHeap — it is a default, not a ceiling") {
+    // The load-bearing case for the whole design: the project asks for more than the machine-level
+    // default and must get it. If this ever fails, a machine setting has started overriding what the
+    // build says its own code needs, and the only fix would live outside the repo.
+    //
+    // Derived from the configured default rather than a fixed number, so it is genuinely "more than
+    // the default" wherever it runs. `-Xmx` is a ceiling and nothing is committed up front, so asking
+    // for a large one costs a reservation, not the memory.
+    ws =>
+      val requestedMb = configuredDefaultMb + 512
+      ws.yaml(yamlWithJvmOptions(Some(s"-Xmx${requestedMb}m")))
+      ws.file("mytest/src/scala/HeapTest.scala", suiteExpectingHeapMb(loMb = requestedMb * 9 / 10, hiMb = requestedMb))
+      val (started, _, _) = ws.start()
+      runTests(started, Nil).orThrow
+      succeed
+  }
+
+  integrationTest("--jvm-opt on the command line outranks the project's own -Xmx") { ws =>
+    ws.yaml(yamlWithJvmOptions(Some("-Xmx256m")))
+    ws.file("mytest/src/scala/HeapTest.scala", suiteExpectingHeapMb(loMb = 600, hiMb = 900))
+    val (started, _, _) = ws.start()
+    runTests(started, List("-Xmx768m")).orThrow
+    succeed
+  }
+
+  integrationTest("the assertion is load-bearing: a wrong heap fails the suite") {
+    // Without this, every test above would still pass if the fork ignored `-Xmx` entirely and ran on
+    // some large ambient default — which is the exact failure this suite exists to catch.
+    ws =>
+      ws.yaml(yamlWithJvmOptions(Some("-Xmx256m")))
+      ws.file("mytest/src/scala/HeapTest.scala", suiteExpectingHeapMb(loMb = 4096, hiMb = 8192))
+      val (started, _, _) = ws.start()
+      assert(runTests(started, Nil).isLeft, "a suite asserting a heap the fork was not given must fail")
+      succeed
+  }
+}

--- a/docs/guides/compile-servers.mdx
+++ b/docs/guides/compile-servers.mdx
@@ -338,14 +338,19 @@ The test runner is a separate forked JVM. It does **not** share heap with
 the compile server, and neither does anything else your build forks — your
 code is compiled inside the server, but run inside a fork. A project that
 needs more memory for its tests says so in `bleep.yaml` with
-`platform.jvmOptions`; this setting is the build-wide default underneath
-that. See
+`platform.jvmOptions`; this setting is the default underneath that, for
+projects that state no `-Xmx` of their own. It is a default, not a
+ceiling — a project asking for `-Xmx4g` gets 4 GB even when this says
+`1g`. See
 [Memory & Parallelism](/docs/usage/resource-management#per-fork-heap).
 
 ```bash
-bleep server config test-runner-max-memory 2g
-bleep server config test-runner-max-memory-clear
+bleep server config test-runner-heap 2g
+bleep server config test-runner-heap-clear
 ```
+
+The old spelling, `test-runner-max-memory`, still works and writes the
+same setting.
 
 Reach for this when test suites OOM (Testcontainers spinning up
 big stacks, generated-fixture tests with large classpaths).
@@ -541,7 +546,7 @@ compileServerMode:
 bspServerConfig:
   compileServerMaxMemory: 4g
   parallelism: 4
-  testRunnerMaxMemory: 2g
+  testRunnerHeap: 2g
   bspReadTimeoutMinutes: 30
 ```
 

--- a/docs/reference/cli/config/test-runner.mdx
+++ b/docs/reference/cli/config/test-runner.mdx
@@ -18,7 +18,7 @@ bleep config test-runner <subcommand>
 
 ## `bleep config test-runner max-memory`
 
-<p>(deprecated: use `bleep server config test-runner-max-memory`) set max heap for test runner JVMs (e.g. 512m, 2g)</p>
+<p>(deprecated: use `bleep server config test-runner-heap`) set default heap for test runner JVMs (e.g. 512m, 2g)</p>
 
 ### Synopsis
 
@@ -34,5 +34,5 @@ bleep config test-runner max-memory <size>
 
 ## `bleep config test-runner max-memory-clear`
 
-<p>(deprecated: use `bleep server config test-runner-max-memory-clear`) remove test runner max heap setting (use JVM default)</p>
+<p>(deprecated: use `bleep server config test-runner-heap-clear`) remove the test runner heap setting (use bleep's default)</p>
 

--- a/docs/reference/cli/server/config.mdx
+++ b/docs/reference/cli/server/config.mdx
@@ -188,9 +188,29 @@ bleep server config heap-pressure-threshold <fraction>
 
 <p>remove the setting (back to default: 0.80)</p>
 
+## `bleep server config test-runner-heap`
+
+<p>default heap for forked test runner JVMs (e.g. 512m, 2g). A project's own platform.jvmOptions -Xmx overrides it</p>
+
+### Synopsis
+
+```bash
+bleep server config test-runner-heap <size>
+```
+
+### Arguments
+
+| Argument | Type |
+|----------|------|
+| `size` | one |
+
+## `bleep server config test-runner-heap-clear`
+
+<p>remove the setting (back to bleep's default: 2048m per test fork)</p>
+
 ## `bleep server config test-runner-max-memory`
 
-<p>max heap for forked test runner JVMs (e.g. 512m, 2g)</p>
+<p>(deprecated: use `bleep server config test-runner-heap`)</p>
 
 ### Synopsis
 
@@ -206,7 +226,7 @@ bleep server config test-runner-max-memory <size>
 
 ## `bleep server config test-runner-max-memory-clear`
 
-<p>remove the test runner max heap setting (back to the JVM default)</p>
+<p>(deprecated: use `bleep server config test-runner-heap-clear`)</p>
 
 ## `bleep server config test-idle-timeout`
 

--- a/docs/usage/resource-management.mdx
+++ b/docs/usage/resource-management.mdx
@@ -56,13 +56,33 @@ If that distinction bites, the symptom tells you which side you are on: an `OutO
 
 ### Precedence for a test fork
 
-Three sources are concatenated, and **the last `-Xmx` wins**:
+A test fork is started with **exactly one `-Xmx`**, chosen from the first of these that states one:
 
-1. `testRunnerMaxMemory` from user config — the build-wide baseline
-2. the project's `platform.jvmOptions` — the per-project exception
-3. `--jvm-opt` on the command line — this run only
+1. `--jvm-opt` on the command line — this run only
+2. the project's `platform.jvmOptions` — what this code needs, checked into the build
+3. `testRunnerHeap` from user config — the default for projects that state nothing
+4. bleep's own default, 2 GB
 
-So a global baseline can be set once, a heavy project can override it, and a one-off investigation can override both without editing anything.
+**`testRunnerHeap` is a default, not a ceiling.** A project that sets `-Xmx` in `platform.jvmOptions` overrides it, in either direction — a project may ask for *more* heap than the machine-level setting, and it gets it:
+
+```yaml
+# user config says testRunnerHeap: 1g …
+projects:
+  my-heavy-tests:
+    isTestProject: true
+    platform:
+      jvmOptions: -Xmx4g    # … and this suite still forks with 4 GB
+```
+
+That is the right way round: how much heap a suite needs is a property of the code, and the code is what lives in the repo. Nothing silently shrinks a heap the build asked for. What protects the machine from one project asking for a lot is *admission* — bleep charges a fork its whole footprint and will run an oversized one on its own rather than alongside others — not clamping.
+
+To see what a fork was actually given, `bleep server config show` prints the configured default, and the test view reports each fork's heap. If you want to check from inside a suite, `Runtime.getRuntime.maxMemory` is the number that settles it. Do **not** test this by setting an absurdly small `-Xmx` and expecting a crash: the JVM quietly rounds a too-small heap up to something it can start with, so `-Xmx3m` proves nothing.
+
+:::info Renamed
+
+`testRunnerHeap` was called `testRunnerMaxMemory`, and `bleep server config test-runner-max-memory` is now `bleep server config test-runner-heap`. The old name never was a maximum — a project's own `-Xmx` has always outranked it. Existing config files and the old command keep working.
+
+:::
 
 ### The other forked processes
 
@@ -70,7 +90,7 @@ Sourcegen scripts and KSP runners are sized in user config, since they are bleep
 
 | Setting | Sizes |
 | --- | --- |
-| `testRunnerMaxMemory` | test runner JVMs (all projects) |
+| `testRunnerHeap` | test runner JVMs, for projects that state no `-Xmx` of their own |
 | `sourcegenMaxMemory` | sourcegen scripts |
 | `kspRunnerMaxMemory` | KSP (Kotlin symbol processing) runners |
 | `compileServerMaxMemory` | the compile server itself — **not** a fork; the long-lived heap your compiles run inside |


### PR DESCRIPTION
## The problem

A test fork was started with **two** `-Xmx`: the configured `testRunnerMaxMemory` prepended to whatever the project asked for, with JVM last-one-wins deciding which took effect.

```
java -XX:… -Xmx4g -Dbleep.probe=yes -Duser.dir=… -Xmx6g -cp … ForkedTestRunner
```

That made the knob read as a ceiling a project could not exceed, while behaving as a default any project could override. Nothing logged or displayed the number a fork actually ran with, so neither source answered the question on its own.

This started as an investigation into a report that `platform.jvmOptions` never reached the test fork at all — evidenced by setting `-Xmx3m`, a heap "the JVM cannot start with", and watching 158 tests pass anyway. The option does reach the fork. HotSpot quietly rounds a too-small heap up (measured: `-Xmx3m` → `maxMemory` 8 MB), so the control proved nothing, and the conclusion drawn from it — that a per-project heap could not exceed the machine-level cap — was the opposite of the truth.

## What changed

- **One `-Xmx` per fork.** `MachineResources.withHeapBound` takes the default as a parameter instead of having it prepended by the caller. First stated wins: `--jvm-opt` → the project's `platform.jvmOptions` → the configured default → bleep's 2g. The bound is still applied in exactly one place, so the pool key, the spawn and the governor's cost model keep reading the same number.
- **Renamed to `testRunnerHeap`** (`bleep server config test-runner-heap` / `-clear`), because that is what it is. The old CLI knob is a deprecated alias that writes the new field, and the decoder still reads the old `testRunnerMaxMemory` JSON key — an upgrade must not silently move someone's test forks onto a different heap.
- **Displays stopped overstating it.** `server status`, `server config show` and the `top` TUI now say the value applies unless the project states its own, and the unset case reads "bleep's default" rather than "the JVM default" — it never was the JVM's.
- **Machine protection stays with admission**, where it already was: the governor charges a fork its whole footprint and runs an oversized one alone, rather than shrinking a heap the code was told it could have.
- **Docs**: rewritten precedence section in `resource-management.mdx` (including that a project can override the machine setting *upward*, with an example, and a warning not to test this with an absurd `-Xmx`), updated `compile-servers.mdx`, regenerated CLI reference.

## Tests

New `TestHeapPropagationIT` asserts `Runtime.maxMemory` **from inside the fork** — the only number that cannot be wrong:

- a project's `-Xmx` is the heap the fork runs with
- a project that states nothing gets the configured default
- **a project may ask for more than the configured default and gets it** — the load-bearing case
- `--jvm-opt` outranks the project's own `-Xmx`
- a deliberately wrong expectation fails, so the suite cannot pass by ignoring heap entirely

`MachineResourcesTest` gains the default-vs-ceiling case; `BspServerConfigTest` gains legacy-key and both-keys-present cases. The legacy path is also verified live: this repo's own config still uses the old key, and the IT measured the fork at exactly the heap it configures.

Full build compiles; all touched suites pass.

## Note

Pre-existing and untouched: `IntegrationTestHarness.testConfig` caps test-fork heap at 512m "to fit the GHA budget", but the in-process BSP server reloads user config from disk (`MultiWorkspaceBspServer.scala:2117`) and never consults it. The new IT computes its expectations from the config the server actually reads, so it is correct either way, but that harness cap is not doing what its comment claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)