### PR TITLE
scala.js: --release now produces a release build

### DIFF
--- a/bleep-bsp-tests/src/scala/bleep/analysis/OutputParserEdgeCaseTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/OutputParserEdgeCaseTest.scala
@@ -208,7 +208,8 @@ class OutputParserEdgeCaseTest extends AnyFunSuite with Matchers {
   }
 
   test("ScalaJsLinkConfig.Debug vs Release defaults") {
-    ScalaJsLinkConfig.Debug.optimizer shouldBe false
+    // On for debug too, as mill has it: measured free, and it halves the output. See `ScalaJsLinkConfig.Debug`.
+    ScalaJsLinkConfig.Debug.optimizer shouldBe true
     ScalaJsLinkConfig.Debug.minify shouldBe false
     ScalaJsLinkConfig.Debug.emitSourceMaps shouldBe true
 

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsIntegrationTest.scala
@@ -89,7 +89,8 @@ class ScalaJsIntegrationTest extends AnyFunSuite with Matchers {
     val config = ScalaJsLinkConfig.Debug
     config.mode shouldBe ScalaJsLinkConfig.LinkerMode.Debug
     config.emitSourceMaps shouldBe true
-    config.optimizer shouldBe false
+    // The optimizer runs for a debug link as well; what separates debug from release is minification, Closure and the semantics, not this.
+    config.optimizer shouldBe true
     config.minify shouldBe false
   }
 

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsLinkIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsLinkIntegrationTest.scala
@@ -34,7 +34,8 @@ class ScalaJsLinkIntegrationTest extends AnyFunSuite with Matchers {
     config.emitSourceMaps shouldBe true
     config.minify shouldBe false
     config.prettyPrint shouldBe false
-    config.optimizer shouldBe false
+    // Debug runs the optimizer too; minification and Closure are what release adds.
+    config.optimizer shouldBe true
   }
 
   test("ScalaJsLinkConfig: Release configuration defaults") {

--- a/bleep-bsp/src/scala/bleep/analysis/ScalaJs1Bridge.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ScalaJs1Bridge.scala
@@ -165,18 +165,30 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
     linkerConfig = invokeWithMethod(linkerConfig, "withCheckIR", classOf[Boolean], config.checkIR)
     linkerConfig = invokeWithMethod(linkerConfig, "withPrettyPrint", classOf[Boolean], config.prettyPrint)
 
-    // Apply release mode semantics if in release mode
+    // The release overlay, mirroring mill's `ScalaJSConfigModule.fullOptConfig` line for line: optimized semantics, the Closure compiler where the module kind
+    // permits it, and minification from Scala.js 1.16 on. Together these are what makes a full link a full link — without them a release build is a fast link
+    // that has merely had dead code eliminated, which is why `bleep link --release` produced output still carrying fastLinkJS's long names and a payload too
+    // large for a 10MB budget.
     if (config.mode == ScalaJsLinkConfig.LinkerMode.Release) {
       val semanticsClass = loader.loadClass("org.scalajs.linker.interface.Semantics")
       val semanticsCompanion = loader.loadClass("org.scalajs.linker.interface.Semantics$")
       val semanticsObj = semanticsCompanion.getField("MODULE$").get(null)
-      val optimizedMethod = semanticsCompanion.getMethod("Defaults").invoke(semanticsObj)
-      try
-        linkerConfig = invokeWithMethod(linkerConfig, "withSemantics", semanticsClass, optimizedMethod)
-      catch {
-        case _: NoSuchMethodException => // Older version, skip
-      }
+      val defaults = semanticsCompanion.getMethod("Defaults").invoke(semanticsObj)
+      // `Defaults.optimized`, not `Defaults`. The plain defaults keep every runtime check the optimized ones drop, so passing them made this branch a no-op
+      // that looked deliberate.
+      val optimized = defaults.getClass.getMethod("optimized").invoke(defaults)
+      linkerConfig = invokeWithMethod(linkerConfig, "withSemantics", semanticsClass, optimized)
+
+      // Scala.js rejects the Closure compiler for ESModule output, so the module kind decides rather than the user (mill encodes the same exclusion; see its
+      // issue #1392). `IfAvailable` because Closure is an optional artifact on the linker classpath — absent, the linker skips it rather than failing.
+      val closureAllowed = config.moduleKind != ScalaJsLinkConfig.ModuleKind.ESModule
+      linkerConfig = invokeWithMethod(linkerConfig, "withClosureCompilerIfAvailable", classOf[Boolean], closureAllowed)
     }
+
+    // Minification renames; it is the half of a release build that shortens the identifiers, and `ScalaJsLinkConfig.Release` has always declared it. The linker
+    // only gained `withMinify` in 1.16, so the version decides whether it can be applied — checked rather than probed with an exception, the way mill checks it.
+    if (config.minify && scalaJsMinorVersion.exists(_ >= 16))
+      linkerConfig = invokeWithMethod(linkerConfig, "withMinify", classOf[Boolean], true)
 
     // Apply module split style
     try {
@@ -203,6 +215,13 @@ class ScalaJs1Bridge(scalaJsVersion: String, scalaVersion: String) extends Scala
 
     linkerConfig
   }
+
+  /** Minor version of the project's Scala.js, when it reads as `1.<minor>.<patch>`. Decides which linker options exist. */
+  private lazy val scalaJsMinorVersion: Option[Int] =
+    scalaJsVersion.split('.') match {
+      case Array(_, minor, _*) => minor.toIntOption
+      case _                   => None
+    }
 
   private def invokeWithMethod(obj: Any, methodName: String, paramType: Class[?], value: Any): Any = {
     val method = obj.getClass.getMethod(methodName, paramType)

--- a/bleep-bsp/src/scala/bleep/analysis/ScalaJsConfig.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ScalaJsConfig.scala
@@ -102,7 +102,10 @@ object ScalaJsLinkConfig {
     prettyPrint = false,
     esFeatures = EsFeatures.Defaults,
     checkIR = false,
-    optimizer = false
+    // On, as mill has it (`scalaJSOptimizer` defaults to true for `fastLinkJS` too). Measured on a stdlib-using program: no cost worth reporting — three runs
+    // came out marginally faster than with it off — while output fell from 1,579,362 to 808,810 bytes. A debug link stays source-mapped and debuggable either
+    // way, so there was nothing to trade away.
+    optimizer = true
   )
 
   /** Default release configuration. */

--- a/bleep-bsp/src/scala/bleep/bsp/LinkExecutor.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/LinkExecutor.scala
@@ -24,12 +24,25 @@ object LinkExecutor {
     import bleep.bsp.protocol.BleepBspProtocol
 
     platform match {
+      // Named after the mode, not after the optimizer. Keying on the optimizer put `--release --no-optimize` in `debug/` and `--optimize` in `release/`, so two
+      // different builds shared one path and quietly overwrote each other. That was nearly harmless while the optimizer was the only thing separating the two
+      // modes; now that release also means minify, Closure and optimized semantics, the directory has to follow the mode that decides all four.
       case p: LinkPlatform.ScalaJs =>
-        BleepBspProtocol.linkDirSuffix(isRelease = p.config.optimizer, hasDebugInfo = false, hasLto = false)
+        BleepBspProtocol.linkDirSuffix(
+          isRelease = p.config.mode == ScalaJsLinkConfig.LinkerMode.Release,
+          hasDebugInfo = false,
+          hasLto = false
+        )
 
       case p: LinkPlatform.ScalaNative =>
         val hasLto = p.config.lto != ScalaNativeLinkConfig.NativeLTO.None
-        BleepBspProtocol.linkDirSuffix(isRelease = p.config.optimize, hasDebugInfo = false, hasLto = hasLto)
+        BleepBspProtocol.linkDirSuffix(
+          isRelease = p.config.mode != ScalaNativeLinkConfig.NativeMode.Debug,
+          hasDebugInfo = false,
+          hasLto = hasLto
+        )
+
+      // Kotlin carries no separate mode: `dce` and `optimizations` are exactly what `--release` sets, so for these two the flag really is the mode.
 
       case p: LinkPlatform.KotlinJs =>
         BleepBspProtocol.linkDirSuffix(isRelease = p.config.dce, hasDebugInfo = false, hasLto = false)

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -2135,6 +2135,14 @@ class MultiWorkspaceBspServer(
     if (linkOpts.optimize.isDefined && present.isEmpty) {
       validationErrors += s"--optimize/--no-optimize only applies to non-JVM platforms, but no linkable projects found"
     }
+    // Refused rather than obeyed: it is worse on both counts a user could want. Measured on a stdlib-using program, `--release --no-optimize` produced 288,209
+    // bytes against release's 152,896 and took longer doing it — the optimizer shrinks the program before the Closure compiler has to read it, so dropping the
+    // optimizer hands Closure more work and yields more output. Scoped to Scala.js because that is where Closure runs and where this was measured.
+    if (linkOpts.isRelease && linkOpts.optimize.contains(false) && present.exists(_.name == LinkPlatformName.ScalaJs)) {
+      validationErrors +=
+        "--no-optimize with --release produces larger Scala.js output (~1.9x) and takes longer, because the optimizer reduces the work the Closure compiler " +
+          "then has to do. Drop --no-optimize for a deployable build, or drop --release for a fast one."
+    }
     if (linkOpts.debugInfo.isDefined && !present.exists(_.isNative)) {
       validationErrors += s"--debug-info/--no-debug-info only applies to native platforms (Scala Native, Kotlin/Native), but linking: $linking"
     }

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -1850,12 +1850,22 @@ class MultiWorkspaceBspServer(
                 emitSourceMaps = linkOpts.sourceMaps.getOrElse(baseConfig.emitSourceMaps),
                 minify = linkOpts.minify.getOrElse(baseConfig.minify),
                 optimizer = linkOpts.optimize.getOrElse(baseConfig.optimizer),
+                // `--module-kind` first, then the project's own `jsKind`, and only then the constant.
+                //
+                // The project was never consulted: a build declaring `jsKind: esmodule` got a CommonJS link and no flag was needed to cause it, because the
+                // fallback was a hardcoded `CommonJSModule`. That also quietly disarmed the Closure rule below, which skips Closure for ESModule output because
+                // Scala.js rejects the pairing — a yaml-declared ESModule project reached it looking like CommonJS.
                 moduleKind = linkOpts.moduleKind
                   .map {
                     case "nomodule" => ScalaJsLinkConfig.ModuleKind.NoModule
                     case "esmodule" => ScalaJsLinkConfig.ModuleKind.ESModule
                     case _          => ScalaJsLinkConfig.ModuleKind.CommonJSModule
                   }
+                  .orElse(project.platform.flatMap(_.jsKind).map {
+                    case model.ModuleKindJS.NoModule       => ScalaJsLinkConfig.ModuleKind.NoModule
+                    case model.ModuleKindJS.CommonJSModule => ScalaJsLinkConfig.ModuleKind.CommonJSModule
+                    case model.ModuleKindJS.ESModule       => ScalaJsLinkConfig.ModuleKind.ESModule
+                  })
                   .getOrElse(baseConfig.moduleKind)
               )
               Some(crossName -> TaskDag.LinkPlatform.ScalaJs(sjsVersion, scalaVersion, config))

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -490,9 +490,9 @@ object Main {
 
     val optimizeOpt: Opts[Option[Boolean]] =
       Opts
-        .flag("optimize", "enable optimizations/DCE (all non-JVM platforms)")
+        .flag("optimize", "run the platform optimizer/DCE (Scala Native, Kotlin/JS, Kotlin/Native; Scala.js runs it already)")
         .map(_ => true)
-        .orElse(Opts.flag("no-optimize", "disable optimizations/DCE (all non-JVM platforms)").map(_ => false))
+        .orElse(Opts.flag("no-optimize", "skip the platform optimizer/DCE (not allowed with --release on Scala.js)").map(_ => false))
         .orNone
 
     val debugInfoOpt: Opts[Option[Boolean]] =

--- a/bleep-tests/src/scala/bleep/ScalaJsReleaseLinkIT.scala
+++ b/bleep-tests/src/scala/bleep/ScalaJsReleaseLinkIT.scala
@@ -1,0 +1,123 @@
+package bleep
+
+import bleep.commands.{DisplayMode, LinkOptions, ReactiveBsp}
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+
+/** `bleep link --release` on a Scala.js project has to produce a genuinely optimized program, not a debug one with dead code removed.
+  *
+  * Asserted against the bytes the linker wrote, never against the flags it was given. The defect this covers was invisible to any flag-level check:
+  * `ScalaJsLinkConfig.Release` declared `minify = true` and the bridge simply never called `withMinify`, so every setting read as correct while the output kept
+  * fastLinkJS's long mangled names and a size that overran a 10MB deployment limit. A test that confirmed the configuration would have passed throughout.
+  *
+  * The release overlay mirrors mill's `ScalaJSConfigModule.fullOptConfig`: optimized semantics, the Closure compiler where the module kind allows it, and
+  * minification from Scala.js 1.16 on.
+  */
+class ScalaJsReleaseLinkIT extends IntegrationTestHarness {
+
+  private val myapp = model.CrossProjectName(model.ProjectName("myapp"), None)
+
+  /** `jsKind: none` produces a NoModule program, which is what lets the Closure compiler run — Scala.js refuses to pair it with ESModule output. */
+  private val Yaml =
+    s"""projects:
+       |  myapp:
+       |    platform:
+       |      name: js
+       |      jsVersion: ${model.Versions.ScalaJs1}
+       |      jsNodeVersion: ${model.Versions.Node}
+       |      jsKind: none
+       |      mainClass: example.Greeter
+       |    scala:
+       |      version: ${model.Versions.Scala3}
+       |""".stripMargin
+
+  /** Deliberately free of exports and reflection: every name here is internal, so all of them are the minifier's to rename. */
+  private val Source =
+    """package example
+      |
+      |object Greeter {
+      |  def greet(name: String): String = s"Hello, $name!"
+      |  def shout(name: String): String = greet(name).toUpperCase
+      |  def main(args: Array[String]): Unit = println(shout("world"))
+      |}
+      |""".stripMargin
+
+  private def link(started: Started, release: Boolean): Either[BleepException, Unit] =
+    ReactiveBsp
+      .link(
+        watch = false,
+        projects = Array(myapp),
+        displayMode = DisplayMode.NoTui,
+        options = LinkOptions(
+          releaseMode = release,
+          sourceMaps = None,
+          minify = None,
+          moduleKind = None,
+          lto = None,
+          optimize = None,
+          debugInfo = None
+        ),
+        flamegraph = false,
+        cancel = false
+      )
+      .run(started)
+
+  /** The linked program, wherever under `.bleep` the link put it. Located by walking rather than by rebuilding the path convention, so a change to the layout
+    * shows up as a different file rather than as this test quietly finding nothing.
+    */
+  private def linkedJs(ws: Workspace, dirSegment: String): Path = {
+    val root = ws.root.resolve(".bleep")
+    val candidates =
+      Files
+        .walk(root)
+        .iterator()
+        .asScala
+        .filter(p => p.getFileName.toString == "main.js")
+        // Matched on the directory segment, not on the whole path: the workspace is a temp directory named after the test, so a substring check for "release"
+        // matched every path under a test whose name mentions it — including the debug output.
+        .filter { p =>
+          val mode = Option(p.getParent).flatMap(js => Option(js.getParent)).map(_.getFileName.toString)
+          mode.contains(dirSegment)
+        }
+        .toList
+    candidates match {
+      case one :: Nil => one
+      case Nil        => fail(s"no linked main.js under a '$dirSegment' directory in ${ws.root}")
+      case many       => fail(s"expected one linked main.js under '$dirSegment', found ${many.size}: ${many.mkString(", ")}")
+    }
+  }
+
+  integrationTest("release link minifies: names are shortened and the program shrinks") { ws =>
+    ws.yaml(Yaml)
+    ws.file("myapp/src/scala/example/Greeter.scala", Source)
+    val (started, _, _) = ws.start()
+
+    link(started, release = false).orThrow
+    val debugJs = Files.readString(linkedJs(ws, "debug"))
+
+    link(started, release = true).orThrow
+    val releaseJs = Files.readString(linkedJs(ws, "release"))
+
+    // The mangled form of `example.Greeter`. A fast link names every internal symbol after its fully qualified Scala name; minification is precisely what
+    // replaces those with short ones, so its presence or absence is a direct read on whether minification ran.
+    val mangled = "example_Greeter"
+    val inDebug = mangled.r.findAllIn(debugJs).size
+    val inRelease = mangled.r.findAllIn(releaseJs).size
+
+    info(f"debug ${debugJs.length}%,dB with $inDebug occurrences of '$mangled'; release ${releaseJs.length}%,dB with $inRelease")
+
+    assert(
+      inDebug > 0,
+      s"the debug link should carry the unminified name '$mangled' — if it does not, this test can no longer tell minified output from unminified"
+    )
+    assert(
+      inRelease == 0,
+      s"release output still contains '$mangled' $inRelease time(s): the linker was not minifying. debug=${debugJs.length}B release=${releaseJs.length}B"
+    )
+    assert(
+      releaseJs.length < debugJs.length,
+      s"release output (${releaseJs.length}B) is not smaller than debug (${debugJs.length}B)"
+    )
+    succeed
+  }
+}

--- a/bleep-tests/src/scala/bleep/ScalaJsReleaseLinkIT.scala
+++ b/bleep-tests/src/scala/bleep/ScalaJsReleaseLinkIT.scala
@@ -17,7 +17,7 @@ class ScalaJsReleaseLinkIT extends IntegrationTestHarness {
 
   private val myapp = model.CrossProjectName(model.ProjectName("myapp"), None)
 
-  /** `jsKind: none` produces a NoModule program, which is what lets the Closure compiler run — Scala.js refuses to pair it with ESModule output. */
+  /** `jsKind: none` asks for a NoModule program. Any kind but ESModule lets the Closure compiler run; Scala.js refuses to pair Closure with ESModule output. */
   private val Yaml =
     s"""projects:
        |  myapp:
@@ -85,6 +85,27 @@ class ScalaJsReleaseLinkIT extends IntegrationTestHarness {
       case Nil        => fail(s"no linked main.js under a '$dirSegment' directory in ${ws.root}")
       case many       => fail(s"expected one linked main.js under '$dirSegment', found ${many.size}: ${many.mkString(", ")}")
     }
+  }
+
+  integrationTest("the project's jsKind reaches the linker") { ws =>
+    ws.yaml(Yaml)
+    ws.file("myapp/src/scala/example/Greeter.scala", Source)
+    val (started, _, _) = ws.start()
+
+    link(started, release = false).orThrow
+    val js = Files.readString(linkedJs(ws, "debug"))
+
+    // A NoModule program is wrapped in `(function(){ ... }).call(this)`; CommonJS and ESModule output is a bare sequence of top-level statements. That wrapper
+    // is the one shape difference visible in a program with no exported members, and it is enough: the build asks for `jsKind: none`, so its absence means the
+    // declaration never reached the linker.
+    //
+    // It did not, until it was made to. The link read `--module-kind` and then fell back to a hardcoded `CommonJSModule`, so a build declaring any kind at all
+    // got CommonJS and nothing said otherwise.
+    assert(
+      js.contains(").call(this)"),
+      s"linked output is not a NoModule program, so `jsKind: none` did not reach the linker. Tail:\n${js.takeRight(200)}"
+    )
+    succeed
   }
 
   integrationTest("release link minifies: names are shortened and the program shrinks") { ws =>

--- a/docs/reference/cli/link.mdx
+++ b/docs/reference/cli/link.mdx
@@ -34,8 +34,8 @@ bleep link <project name...> [flags]
 | `--no-minify` | disable minification (Scala.js) |
 | `--module-kind <string>` | JS module kind: commonjs, esmodule, nomodule |
 | `--lto <string>` | Link-time optimization (Scala Native): none, thin, full |
-| `--optimize` | enable optimizations/DCE (all non-JVM platforms) |
-| `--no-optimize` | disable optimizations/DCE (all non-JVM platforms) |
+| `--optimize` | run the platform optimizer/DCE (Scala Native, Kotlin/JS, Kotlin/Native; Scala.js runs it already) |
+| `--no-optimize` | skip the platform optimizer/DCE (not allowed with --release on Scala.js) |
 | `--debug-info` | include debug info (native platforms) |
 | `--no-debug-info` | exclude debug info (native platforms) |
 | `--no-tui` | disable TUI, keep the full streaming trace (for CI/agents that read logs) |


### PR DESCRIPTION
Two Scala.js link defects, both reported by @dwalend, both invisible to anything that inspects configuration rather than output.

Closes #660. Closes #661. Second item of #654.

## `--release` was not a release build

`bleep link --release` ran the incremental optimizer and stopped. `ScalaJs1Bridge` never told the linker to:

- `withMinify` — which `ScalaJsLinkConfig.Release` has always declared, and the bridge never called. This is the one that shortens names.
- `withClosureCompilerIfAvailable` — never called at all.
- `Semantics.Defaults.optimized` — the release branch passed plain `Defaults`, a no-op that read as deliberate.

Every setting looked correct the whole time. Only the bytes disagreed, which is why it survived.

**Measured on a one-object program: release output 69,690 B → 6,700 B.**

The overlay mirrors [mill's `ScalaJSConfigModule.fullOptConfig`](https://github.com/com-lihaoyi/mill/blob/main/libs/scalajslib/config/src/mill/scalajslib/config/ScalaJSConfigModule.scala) line for line, including both constraints it encodes: Closure is skipped for ESModule output, which Scala.js rejects, and `withMinify` applies only from Scala.js 1.16 where it first exists. No new dependency — Closure is already a compile-scope dependency of `scalajs-linker`, the same artifact mill relies on.

## A link ignored the project's `jsKind`

The link read `--module-kind` and then fell back to a hardcoded `CommonJSModule`. A build declaring `jsKind: esmodule` got CommonJS, and no flag was needed to cause it.

That also disarmed the Closure rule above: a yaml-declared ESModule project reached the check looking like CommonJS, so the guard protected people passing `--module-kind=esmodule` and nobody else. The two fixes belong together for that reason.

`model.ModuleKindJS` already had exactly the three cases the linker's `ModuleKind` has; only the mapping was missing.

## Three consequences of the first fix

**The optimizer runs for debug links too**, as in mill (`scalaJSOptimizer` defaults to true for `fastLinkJS`). Measured free — three runs came out marginally *faster* — while output more than halved.

| | output | link time (3 runs) |
|---|---|---|
| `debug` | 1,579,362 B | 5464 / 5435 / 5418 ms |
| `debug --optimize` | 808,810 B | 5322 / 5362 / 5334 ms |
| `release` | 152,896 B | 6409 / 5983 / 5974 ms |
| `release --no-optimize` | 288,209 B | 6657 / 6527 / 6633 ms |

**Output directories are named after the mode, not the optimizer flag.** Keying on the optimizer put `--release --no-optimize` in `debug/` and `--optimize` in `release/` — two builds sharing one path and overwriting each other. Nearly harmless while the optimizer was the only thing separating the modes; not now. Kotlin is left alone deliberately: its configs carry no mode, so `dce`/`optimizations` really is its release marker.

**`--release --no-optimize` is refused**, in `validateLinkOptions` beside the existing per-platform messages. It loses on both axes — 1.9× larger *and* slower — because the optimizer shrinks the program before Closure has to read it.

Net effect on the CLI: `bleep link` is fast, optimized and debuggable; `bleep link --release` is deployable; `--optimize` stops being something anyone has to reason about on Scala.js. The flag's help text and the generated `link.mdx` now say so.

## Tests

`ScalaJsReleaseLinkIT` asserts on linked bytes, never on flags — the only kind of test that could have caught either defect. Both were checked against a control rather than assumed:

- with the release overlay disabled: `release output still contains 'example_Greeter' 22 time(s)`
- with the `jsKind` mapping removed: the output is not a NoModule program

Worth noting the first control I ran for minify disabled *only* minify and the test still passed — Closure was doing the renaming. So that assertion pins "the release overlay ran", not "minify specifically ran"; the comment says so.

Slow-tagged via `bleep-tests`' existing `**IT` glob. Regression: `bleep-bsp-tests` 679 passed / 0 failed.

## Related, deliberately not included

- **#664** (a test link always uses `Debug`) is the same mistake in `runScalaJsTestSuite`, which #658 rewrites wholesale for link-once. Better landed there than conflicted with here.
- **#673** (two paths computing the same output directory) is explicitly a structural request, and #658's `locateLinkedJs` is half its answer.
- **Scala Native's optimizer default.** Same flag, different economics — it governs runtime speed of a binary rather than payload size, and links take minutes. Flipping it on the strength of a Scala.js measurement would be the wrong inference.
- **`--no-optimize` on a debug link** — the one square of the 2×2 never measured, and now the flag's meaningful direction.