### PR TITLE
one pipe for both in-process BSP transports

### DIFF
--- a/bleep-bsp-tests/src/scala/bleep/analysis/BspTestHarness.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BspTestHarness.scala
@@ -5,7 +5,7 @@ import ch.epfl.scala.bsp._
 import ryddig.{LogPatterns, Loggers}
 import com.github.plokhotnyuk.jsoniter_scala.core._
 
-import java.io.{PipedInputStream, PipedOutputStream}
+import java.io.{InputStream, OutputStream}
 import java.nio.file.Path
 import java.util.concurrent.{ArrayBlockingQueue, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
@@ -13,7 +13,7 @@ import scala.collection.mutable
 
 /** Test harness for BSP server integration tests.
   *
-  * Starts a BspServer with piped streams, sends requests via JSON-RPC, and collects responses/notifications.
+  * Starts a BspServer over a pair of [[bleep.bsp.InMemoryPipe]]s, sends requests via JSON-RPC, and collects responses/notifications.
   *
   * Usage:
   * {{{
@@ -36,6 +36,17 @@ object BspTestHarness {
     case class TaskProgress(taskId: String, message: Option[String]) extends BspEvent
     case class TaskFinish(taskId: String, statusCode: Int, message: Option[String]) extends BspEvent
   }
+
+  /** The client's reader thread ended before the reply to `method` arrived. Nothing dispatches that reply. A request that kept waiting would wait out its whole
+    * timeout before reporting anything.
+    *
+    * @param method
+    *   the BSP method whose reply is lost
+    * @param cause
+    *   what ended the reader thread
+    */
+  case class ReaderThreadEndedException(method: String, cause: Throwable)
+      extends RuntimeException(s"The BSP reader thread ended before the reply to $method arrived", cause)
 
   /** Handle for an async request that can be cancelled */
   trait RequestHandle[R] {
@@ -192,22 +203,17 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
   import JsonRpcCodecs.given
 
   def use[A](f: BspClient => A): A = {
-    // Create pipes for bidirectional communication
-    // Client writes to clientToServer, server reads from it
-    // Server writes to serverToClient, client reads from it
-    val clientToServer = new PipedOutputStream()
-    val serverInput = new PipedInputStream(clientToServer, 65536)
-
-    val serverToClient = new PipedOutputStream()
-    val clientInput = new PipedInputStream(serverToClient, 65536)
+    // Two pipes carry the two directions. InMemoryPipe explains why not `java.io.PipedInputStream`.
+    val clientToServer = new InMemoryPipe(65536)
+    val serverToClient = new InMemoryPipe(65536)
 
     // The production server. It has no way to be handed build state directly — it compiles the
     // build its client sends — so the configs are lowered into the same payload a real bleep
     // client would send, and delivered through build/initialize below.
     val harnessAnalysisCache = new bleep.analysis.AnalysisCache
     val server = new MultiWorkspaceBspServer(
-      serverInput,
-      serverToClient,
+      clientToServer.source,
+      serverToClient.sink,
       Loggers.stderr(LogPatterns.logFile),
       machine = bleep.MachineResources.forThisMachine(totalCpu = Runtime.getRuntime.availableProcessors(), logger = Loggers.stderr(LogPatterns.logFile)),
       heapMonitor = HeapMonitor.system,
@@ -236,25 +242,25 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
     serverThread.setDaemon(true)
     serverThread.start()
 
-    val client = new BspClientImpl(clientInput, clientToServer, buildPayload)
+    val client = new BspClientImpl(serverToClient.source, clientToServer.sink, buildPayload)
 
     try f(client)
     finally {
       try client.shutdown()
       catch { case _: Exception => () }
       try {
-        clientToServer.close()
-        clientInput.close()
-        serverInput.close()
-        serverToClient.close()
+        clientToServer.sink.close()
+        clientToServer.source.close()
+        serverToClient.sink.close()
+        serverToClient.source.close()
       } catch { case _: Exception => () }
       serverThread.interrupt()
     }
   }
 
   private class BspClientImpl(
-      in: PipedInputStream,
-      out: PipedOutputStream,
+      in: InputStream,
+      out: OutputStream,
       buildPayload: Option[BspBuildData.Payload]
   ) extends BspClient {
 
@@ -268,13 +274,16 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
     // Fallback queue for responses to unknown request IDs (shouldn't happen, but safety)
     private val defaultResponseQueue = new ArrayBlockingQueue[JsonRpcResponse](100)
 
+    /** What ended the reader thread. A closed stream at shutdown ends the reader too. Nothing waits for a reply by then. */
+    private val readerEndedBy = new java.util.concurrent.atomic.AtomicReference[Throwable](null)
+
     // Reader thread for handling responses and notifications
     private val readerRunnable: Runnable = () =>
       try
         while (true)
           readAndDispatch()
       catch {
-        case _: Exception => () // Shutdown
+        case ended: Exception => readerEndedBy.set(ended)
       }
     private val readerThread = new Thread(readerRunnable, "bsp-test-reader")
     readerThread.setDaemon(true)
@@ -302,12 +311,10 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
         read += r
       }
 
-      // Try to parse as response or notification
-      val json = new String(content, "UTF-8")
-
-      // Check if it has an "id" field (response) or just "method" (notification)
-      if (json.contains("\"result\"") || json.contains("\"error\"")) {
-        // It's a response - route to correct pending request
+      // The request codec reads `method` and skips every other key. Only a notification declares `method`. 
+      val envelope = readFromArray[JsonRpcRequest](content)
+      if (envelope.method != null) handleNotification(envelope)
+      else {
         val response = readFromArray[JsonRpcResponse](content)
         val responseId: Option[Int] = response.id match {
           case RpcId.IntId(i)    => Some(i)
@@ -322,9 +329,6 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
           case None =>
             defaultResponseQueue.put(response)
         }
-      } else if (json.contains("\"method\"")) {
-        // It's a notification
-        handleNotification(content)
       }
     }
 
@@ -344,9 +348,7 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
       if (sb.isEmpty) null else sb.toString
     }
 
-    private def handleNotification(content: Array[Byte]): Unit = {
-      val notification = readFromArray[JsonRpcNotification](content)
-
+    private def handleNotification(notification: JsonRpcRequest): Unit =
       notification.method match {
         case "build/logMessage" =>
           notification.params.foreach { params =>
@@ -412,6 +414,27 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
 
         case _ => ()
       }
+
+    /** Waits for one reply, and gives up as soon as the reader thread that would deliver it ends.
+      *
+      * @return
+      *   the reply, or null once `timeoutMs` passes with no reply
+      * @throws ReaderThreadEndedException
+      *   when the reader thread ended before the reply arrived
+      */
+    private def pollUntilReaderEnds(queue: ArrayBlockingQueue[JsonRpcResponse], timeoutMs: Long, method: String): JsonRpcResponse = {
+      val deadlineNanos = System.nanoTime() + timeoutMs * 1000000L
+      var response: JsonRpcResponse = null
+      while (response == null && System.nanoTime() < deadlineNanos) {
+        response = queue.poll(200, TimeUnit.MILLISECONDS)
+        // The reader dispatches a reply before it ends. The poll above takes such a reply. An empty poll after the
+        // reader ended means no reply is coming.
+        if (response == null) {
+          val ended = readerEndedBy.get()
+          if (ended != null) throw ReaderThreadEndedException(method, ended)
+        }
+      }
+      response
     }
 
     /** Create and send a request, returning a handle for async use */
@@ -446,7 +469,7 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
 
         override def await(): R =
           try {
-            val response = queue.poll(120, TimeUnit.SECONDS)
+            val response = pollUntilReaderEnds(queue, 120000, method)
             if (response == null) {
               throw new RuntimeException(s"Timeout waiting for response to $method")
             }
@@ -455,7 +478,7 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
 
         override def awaitWithTimeout(timeoutMs: Long): Option[R] =
           try {
-            val response = queue.poll(timeoutMs, TimeUnit.MILLISECONDS)
+            val response = pollUntilReaderEnds(queue, timeoutMs, method)
             if (response == null) None
             else Some(processResponse(response, method))
           } finally pendingRequests.remove(id)
@@ -496,7 +519,7 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
       }
 
       try {
-        val response = queue.poll(120, TimeUnit.SECONDS)
+        val response = pollUntilReaderEnds(queue, 120000, method)
         if (response == null) {
           throw new RuntimeException(s"Timeout waiting for response to $method")
         }

--- a/bleep-bsp-tests/src/scala/bleep/analysis/BspTestHarness.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/BspTestHarness.scala
@@ -311,7 +311,7 @@ class BspTestHarness(workspaceRoot: Path, projectConfigs: Option[List[BspTestHar
         read += r
       }
 
-      // The request codec reads `method` and skips every other key. Only a notification declares `method`. 
+      // The request codec reads `method` and skips every other key. Only a notification declares `method`.
       val envelope = readFromArray[JsonRpcRequest](content)
       if (envelope.method != null) handleNotification(envelope)
       else {

--- a/bleep-bsp-tests/src/scala/bleep/analysis/PipedStreamThreadAffinityTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/PipedStreamThreadAffinityTest.scala
@@ -13,10 +13,10 @@ import java.io.{IOException, PipedInputStream, PipedOutputStream}
   *
   * The symptom was a BSP client parked in `CompletableFuture.get()` waiting for a reply while the server sat in `PipedInputStream.read` waiting for a request
   * neither of them could still deliver — reproducible by running several build-driving integration tests at once, and vanishing as soon as anything perturbed
-  * the timing.
+  * the timing, which is what made it look like a deadlock rather than a race.
   *
-  * These tests pin the behaviour rather than the workaround: if a future JDK stops tracking thread liveness this way, they fail and the socket pair the
-  * transport now uses can be reconsidered.
+  * These tests pin the JDK behaviour rather than the replacement: if a future JDK stops tracking thread liveness this way, they fail and `InMemoryPipe` can be
+  * reconsidered. That `InMemoryPipe` itself is free of the hazard is covered by `InMemoryPipeTest`, not here.
   */
 class PipedStreamThreadAffinityTest extends AnyFunSuite with Matchers {
 
@@ -50,27 +50,4 @@ class PipedStreamThreadAffinityTest extends AnyFunSuite with Matchers {
     thrown.getMessage shouldBe "Write end dead"
   }
 
-  test("a socket pair has no such thread affinity") {
-    val listener = new java.net.ServerSocket(0, 1, java.net.InetAddress.getLoopbackAddress)
-    val clientEnd = new java.net.Socket(java.net.InetAddress.getLoopbackAddress, listener.getLocalPort)
-    val serverEnd = listener.accept()
-    listener.close()
-
-    try {
-      val writer = new Thread(() => clientEnd.getOutputStream.write('a'), "short-lived-writer")
-      writer.start()
-      writer.join()
-
-      val reader = new Thread(() => serverEnd.getInputStream.read(): Unit, "short-lived-reader")
-      reader.start()
-      reader.join()
-
-      // Both threads that touched the connection are dead, and it still works from a third.
-      clientEnd.getOutputStream.write('b')
-      serverEnd.getInputStream.read() shouldBe 'b'
-    } finally {
-      clientEnd.close()
-      serverEnd.close()
-    }
-  }
 }

--- a/bleep-bsp-tests/src/scala/bleep/bsp/BleepStatusEndpointTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/bsp/BleepStatusEndpointTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import ryddig.{LogPatterns, Loggers}
 
-import java.io.{BufferedReader, InputStreamReader, PipedInputStream, PipedOutputStream}
+import java.io.{BufferedReader, InputStreamReader}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Path, Paths}
 import java.util.concurrent.atomic.AtomicBoolean
@@ -24,11 +24,9 @@ class BleepStatusEndpointTest extends AnyFunSuite with Matchers {
     val registry = new ConnectionRegistry(() => System.currentTimeMillis())
 
     private val logger = Loggers.stderr(LogPatterns.logFile)
-    private val clientToServer = new PipedOutputStream()
-    private val serverInput = new PipedInputStream(clientToServer, 65536)
-    private val serverToClient = new PipedOutputStream()
-    private val clientInput = new PipedInputStream(serverToClient, 65536)
-    private val reader = new BufferedReader(new InputStreamReader(clientInput, StandardCharsets.UTF_8))
+    private val clientToServer = new InMemoryPipe(65536)
+    private val serverToClient = new InMemoryPipe(65536)
+    private val reader = new BufferedReader(new InputStreamReader(serverToClient.source, StandardCharsets.UTF_8))
 
     private val analysisCache = new bleep.analysis.AnalysisCache
 
@@ -45,8 +43,8 @@ class BleepStatusEndpointTest extends AnyFunSuite with Matchers {
     )
 
     private val server = new MultiWorkspaceBspServer(
-      serverInput,
-      serverToClient,
+      clientToServer.source,
+      serverToClient.sink,
       logger,
       machine = bleep.MachineResources.forThisMachine(totalCpu = 4, logger = logger),
       heapMonitor = HeapMonitor.system,
@@ -64,9 +62,9 @@ class BleepStatusEndpointTest extends AnyFunSuite with Matchers {
     def request(method: String, params: String): io.circe.Json = {
       val body = s"""{"jsonrpc":"2.0","id":1,"method":"$method","params":$params}"""
       val bytes = body.getBytes(StandardCharsets.UTF_8)
-      clientToServer.write(s"Content-Length: ${bytes.length}\r\n\r\n".getBytes(StandardCharsets.UTF_8))
-      clientToServer.write(bytes)
-      clientToServer.flush()
+      clientToServer.sink.write(s"Content-Length: ${bytes.length}\r\n\r\n".getBytes(StandardCharsets.UTF_8))
+      clientToServer.sink.write(bytes)
+      clientToServer.sink.flush()
       readMessage()
     }
 

--- a/bleep-bsp-tests/src/scala/bleep/bsp/InMemoryPipeTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/bsp/InMemoryPipeTest.scala
@@ -1,0 +1,88 @@
+package bleep.bsp
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+
+/** These tests assert what [[InMemoryPipe]] does that `java.io.PipedInputStream` does not.
+  *
+  * The BSP server writes replies and notifications from Cats Effect blocking regions. Cats Effect retires the carrier thread of such a region. A pipe that ends
+  * its reader when a writing thread exits loses every message written after that point.
+  */
+class InMemoryPipeTest extends AnyFunSuite with Matchers {
+
+  private def readFully(pipe: InMemoryPipe, length: Int): String = {
+    val destination = new Array[Byte](length)
+    var read = 0
+    while (read < length) {
+      val taken = pipe.source.read(destination, read, length - read)
+      if (taken < 0) fail(s"The pipe reached its end after $read of $length bytes")
+      read += taken
+    }
+    new String(destination, StandardCharsets.UTF_8)
+  }
+
+  test("a read after the writing thread exits waits for the next writer") {
+    val pipe = new InMemoryPipe(64)
+
+    val first = new Thread(() => pipe.sink.write("first".getBytes(StandardCharsets.UTF_8)), "first-writer")
+    first.start()
+    first.join()
+
+    readFully(pipe, 5) shouldBe "first"
+
+    // `java.io.PipedInputStream` throws `Write end dead` here. This read finds the pipe empty and waits.
+    val reader = new Thread(() => readFully(pipe, 6): Unit, "waiting-reader")
+    reader.setDaemon(true)
+    reader.start()
+    reader.join(500)
+    reader.isAlive shouldBe true
+
+    val second = new Thread(() => pipe.sink.write("second".getBytes(StandardCharsets.UTF_8)), "second-writer")
+    second.start()
+    second.join()
+    reader.join(5000)
+    reader.isAlive shouldBe false
+  }
+
+  test("bytes arrive in the order they were written across a wrap of the buffer") {
+    val pipe = new InMemoryPipe(8)
+
+    pipe.sink.write("abcdef".getBytes(StandardCharsets.UTF_8))
+    readFully(pipe, 6) shouldBe "abcdef"
+
+    pipe.sink.write("ghijkl".getBytes(StandardCharsets.UTF_8))
+    readFully(pipe, 6) shouldBe "ghijkl"
+  }
+
+  test("a read returns the end of the stream once the sink closes and the buffer empties") {
+    val pipe = new InMemoryPipe(64)
+
+    pipe.sink.write("last".getBytes(StandardCharsets.UTF_8))
+    pipe.sink.close()
+
+    readFully(pipe, 4) shouldBe "last"
+    pipe.source.read(new Array[Byte](4), 0, 4) shouldBe -1
+  }
+
+  test("a write after the source closes raises PipeClosedByReaderException") {
+    val pipe = new InMemoryPipe(64)
+    pipe.source.close()
+
+    a[PipeClosedByReaderException] should be thrownBy pipe.sink.write("dropped".getBytes(StandardCharsets.UTF_8))
+  }
+
+  test("a write larger than the capacity crosses to a reader that drains as it goes") {
+    val pipe = new InMemoryPipe(16)
+    val payload = ("0123456789" * 40).getBytes(StandardCharsets.UTF_8)
+
+    val writer = new Thread(() => pipe.sink.write(payload), "bulk-writer")
+    writer.setDaemon(true)
+    writer.start()
+
+    readFully(pipe, payload.length) shouldBe new String(payload, StandardCharsets.UTF_8)
+    writer.join(5000)
+    writer.isAlive shouldBe false
+  }
+}

--- a/bleep-bsp/src/scala/bleep/bsp/InMemoryPipe.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/InMemoryPipe.scala
@@ -1,0 +1,125 @@
+package bleep.bsp
+
+import java.io.{IOException, InputStream, OutputStream}
+import java.util.concurrent.locks.ReentrantLock
+
+/** Moves bytes from one thread to another inside one JVM.
+  *
+  * `java.io.PipedInputStream` records the thread that wrote most recently. Its `read` throws `Write end dead` once that thread has exited and the buffer has
+  * run empty, even while other threads keep writing. Cats Effect retires the carrier thread of a blocking region. A BSP notification sent from such a region
+  * leaves a retired thread recorded. This pipe records no thread. A read blocks until a write arrives or until [[sink]] closes.
+  *
+  * @param capacity
+  *   how many bytes the pipe keeps before a write blocks
+  */
+final class InMemoryPipe(capacity: Int) {
+
+  private val bytes = new Array[Byte](capacity)
+  private val lock = new ReentrantLock()
+  private val notEmpty = lock.newCondition()
+  private val notFull = lock.newCondition()
+
+  private var head = 0
+  private var count = 0
+  private var sinkClosed = false
+  private var sourceClosed = false
+
+  /** Reads what [[sink]] wrote. A read returns -1 once [[sink]] has closed and the buffer has run empty. */
+  val source: InputStream = new InputStream {
+
+    override def read(): Int = {
+      val one = new Array[Byte](1)
+      if (read(one, 0, 1) < 0) -1 else one(0) & 0xff
+    }
+
+    override def read(destination: Array[Byte], offset: Int, length: Int): Int =
+      if (length == 0) 0
+      else {
+        lock.lock()
+        try {
+          while (count == 0 && !sinkClosed && !sourceClosed) notEmpty.await()
+          if (count == 0) -1
+          else {
+            val taken = math.min(length, count)
+            val toEnd = math.min(taken, capacity - head)
+            System.arraycopy(bytes, head, destination, offset, toEnd)
+            System.arraycopy(bytes, 0, destination, offset + toEnd, taken - toEnd)
+            head = (head + taken) % capacity
+            count -= taken
+            notFull.signalAll()
+            taken
+          }
+        } finally lock.unlock()
+      }
+
+    override def available(): Int = {
+      lock.lock()
+      try count
+      finally lock.unlock()
+    }
+
+    override def close(): Unit = {
+      lock.lock()
+      try {
+        sourceClosed = true
+        notEmpty.signalAll()
+        notFull.signalAll()
+      } finally lock.unlock()
+    }
+  }
+
+  /** Writes bytes for [[source]] to read. A write blocks while the pipe is full. Every write is visible to [[source]] before the call returns, which leaves
+    * `flush` nothing to do.
+    */
+  val sink: OutputStream = new OutputStream {
+
+    override def write(byte: Int): Unit = {
+      val one = new Array[Byte](1)
+      one(0) = byte.toByte
+      write(one, 0, 1)
+    }
+
+    /** @throws PipeClosedByReaderException
+      *   when [[source]] is closed
+      * @throws PipeClosedByWriterException
+      *   when this sink is closed
+      */
+    override def write(written: Array[Byte], offset: Int, length: Int): Unit = {
+      lock.lock()
+      try {
+        var done = 0
+        while (done < length) {
+          while (count == capacity && !sourceClosed && !sinkClosed) notFull.await()
+          if (sourceClosed) throw PipeClosedByReaderException()
+          if (sinkClosed) throw PipeClosedByWriterException()
+          val room = math.min(length - done, capacity - count)
+          val tail = (head + count) % capacity
+          val toEnd = math.min(room, capacity - tail)
+          System.arraycopy(written, offset + done, bytes, tail, toEnd)
+          System.arraycopy(written, offset + done + toEnd, bytes, 0, room - toEnd)
+          count += room
+          done += room
+          notEmpty.signalAll()
+        }
+      } finally lock.unlock()
+    }
+
+    override def flush(): Unit = ()
+
+    override def close(): Unit = {
+      lock.lock()
+      try {
+        sinkClosed = true
+        notEmpty.signalAll()
+        notFull.signalAll()
+      } finally lock.unlock()
+    }
+  }
+}
+
+/** Thrown when a write arrives after the reading end closed. The bytes of that write reach no reader. */
+case class PipeClosedByReaderException() extends IOException("The reading end of this pipe is closed")
+
+/** Thrown when a write arrives after the writing end closed. */
+case class PipeClosedByWriterException() extends IOException("The writing end of this pipe is closed")
+

--- a/bleep-bsp/src/scala/bleep/bsp/InMemoryPipe.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/InMemoryPipe.scala
@@ -122,4 +122,3 @@ case class PipeClosedByReaderException() extends IOException("The reading end of
 
 /** Thrown when a write arrives after the writing end closed. */
 case class PipeClosedByWriterException() extends IOException("The writing end of this pipe is closed")
-

--- a/bleep-bsp/src/scala/bleep/bsp/InProcessBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/InProcessBspServer.scala
@@ -3,10 +3,9 @@ package bleep.bsp
 import cats.effect.{IO, Resource}
 import ryddig.Logger
 
-import java.net.{InetAddress, ServerSocket, Socket}
 import java.util.concurrent.CompletableFuture
 
-/** Creates an in-process BSP server connected via piped streams.
+/** Creates an in-process BSP server connected through a pair of [[InMemoryPipe]]s.
   *
   * Used by integration tests to avoid launching a separate JVM process. The BSP server runs in a daemon thread within the same JVM.
   */
@@ -15,33 +14,10 @@ object InProcessBspServer {
   def connect(logger: Logger): Resource[IO, BspConnection] =
     Resource.make(
       IO.blocking {
-        // A loopback socket pair, not piped streams.
-        //
-        // `PipedInputStream` remembers the last thread that read from it and the last thread that wrote to it, and once either of those threads dies it refuses
-        // to go on — "Read end dead" from the writer, "Write end dead" from the reader. Both ends here live on cats-effect pools: reads ran on
-        // `io-compute-blocker-N` and writes on `io-compute-N`, both picking a different thread from call to call, and blocker threads are created on demand and
-        // retired once idle. So a perfectly healthy connection would break the moment the pool happened to retire a thread that had touched it, leaving the
-        // client parked in `CompletableFuture.get()` waiting for a reply and the server parked in `read` waiting for the request — which is what running
-        // several build-driving integration tests at once reliably produced, and what any timing change made disappear.
-        //
-        // Sockets have no such affinity (`PipedStreamThreadAffinityTest` pins both halves of that), and they are what the out-of-process server already speaks,
-        // so the in-process path now differs from the real one in one fewer respect. Bound to the loopback address so nothing outside the machine can reach it,
-        // and the listener is closed as soon as both ends are connected.
-        val listener = new ServerSocket(0, 1, InetAddress.getLoopbackAddress)
-        val (clientSocket, serverSocket) =
-          try {
-            // Backlog of 1 is enough for the connect to complete into the queue before `accept` runs, so doing both on this thread cannot deadlock.
-            val client = new Socket(InetAddress.getLoopbackAddress, listener.getLocalPort)
-            val server = listener.accept()
-            client.setTcpNoDelay(true)
-            server.setTcpNoDelay(true)
-            (client, server)
-          } finally listener.close()
-
-        val serverIn = serverSocket.getInputStream
-        val clientOut = clientSocket.getOutputStream
-        val clientIn = clientSocket.getInputStream
-        val serverOut = serverSocket.getOutputStream
+        // Two pipes carry the two directions. A megabyte of slack keeps a sourcegen run that logs faster than the
+        // client reads from blocking the server.
+        val clientToServer = new InMemoryPipe(1048576)
+        val serverToClient = new InMemoryPipe(1048576)
 
         // Use CompletableFuture (not a Deferred) so the server thread can signal exit without
         // bouncing through cats-effect from a non-IO thread. IO.fromCompletableFuture bridges
@@ -60,8 +36,8 @@ object InProcessBspServer {
               // One server per in-process run, so fresh daemon-scoped state is correct here.
               val server =
                 new MultiWorkspaceBspServer(
-                  serverIn,
-                  serverOut,
+                  clientToServer.source,
+                  serverToClient.sink,
                   logger,
                   machine = machine,
                   heapMonitor = HeapMonitor.system,
@@ -78,7 +54,9 @@ object InProcessBspServer {
                 exitCode = 1
                 logger.error(s"In-process BSP server failed: ${e.getClass.getName}: ${e.getMessage}", e)
             } finally {
-              try serverSocket.close()
+              try serverToClient.sink.close()
+              catch { case _: Exception => () }
+              try clientToServer.source.close()
               catch { case _: Exception => () }
               exited.complete(exitCode): Unit
             }
@@ -86,20 +64,20 @@ object InProcessBspServer {
         }
         serverThread.start()
 
-        new InProcessConnection(clientIn, clientOut, clientSocket, exited)
+        new InProcessConnection(serverToClient.source, clientToServer.sink, exited)
       }
     )(_.close)
 
   private class InProcessConnection(
       val input: java.io.InputStream,
       val output: java.io.OutputStream,
-      clientSocket: Socket,
       exited: CompletableFuture[java.lang.Integer]
   ) extends BspConnection {
     def serverExited: IO[Int] = IO.fromCompletableFuture(IO.pure(exited)).map(_.intValue)
     def close: IO[Unit] = IO.blocking {
-      // Closing the socket closes both of its streams, and gives the server a clean end-of-input rather than a stream that merely stops producing.
-      try clientSocket.close()
+      try output.close()
+      catch { case _: Exception => () }
+      try input.close()
       catch { case _: Exception => () }
     }
   }


### PR DESCRIPTION
Takes @dwalend's `InMemoryPipe` from #658 (commit cherry-picked, authorship preserved) and finishes the job it started.

Closes #665.

## Two transports, one hazard

bleep had two in-process BSP transports built on `java.io.PipedInputStream`. Both carry the same defect: the JDK records the thread that last wrote, and `read` throws `Write end dead` once that thread has exited — however many other threads are still writing. Cats Effect retires the carrier thread of a blocking region, so a healthy connection breaks the moment the pool happens to retire a thread that touched it.

The observed symptom was a client parked in `CompletableFuture.get()` waiting for a reply while the server sat in `PipedInputStream.read` waiting for a request neither could still deliver. Reproducible by running several build-driving integration tests at once, and vanishing as soon as anything perturbed the timing — which is what made it read as a deadlock rather than a race.

**`InProcessBspServer`** had been given a loopback socket pair to escape it. That worked, but it is heavier than the problem: a port, an accept, a timeout to guess. `InMemoryPipe` records no thread and needs none of that, so both transports now use it and the socket pair is gone.

**`BspTestHarness`** still had raw pipes — my earlier fix never touched this file — and its reader also swallowed the reason it stopped:

```scala
catch { case _: Exception => () } // Shutdown
```

Any exception ended the reader silently, and every request after it waited its full timeout for a reply nobody would deliver. That is how a one-line cause presents as a suite producing no output until the idle timeout kills it. The reader now records what ended it.

## Why his pipe rather than my socket pair

`InMemoryPipe` is a ring buffer behind a `ReentrantLock` with two conditions. No OS resources, no port, no accept timeout, distinct `PipeClosedByReaderException` / `PipeClosedByWriterException`, and it is deterministically testable in-process. `InMemoryPipeTest` covers five cases including the one that matters — *"a read after the writing thread exits waits for the next writer"*.

## Tests

`PipedStreamThreadAffinityTest` keeps the two tests pinning the JDK behaviour, since they are the reason neither transport may use `PipedInputStream`. Its third test asserted that a socket pair is immune; that no longer describes anything bleep uses, so it is gone — `InMemoryPipeTest` covers the replacement.

- `bleep-bsp-tests` (non-slow): **696 passed, 0 failed**
- The six-suite platform matrix that originally produced the deadlock: **58 passed, 0 failed**, 4.8x parallelism

## Note on #658

This is the second piece taken from that PR, after `AlienValue` came across in #659. #658 predates #656 and reports `CONFLICTING`, so harvesting the separable pieces seems kinder than asking for a rebase of 27 files onto a tree that moved underneath it. Still unharvested there and worth it: resolving the two Scala.js adapter artifacts in **one** coursier fetch (two fetches put both versions of a shared dependency on the classpath), linking a test project **once** rather than once per suite, and cancellation that actually kills the node process rather than closing a socket a spinning suite never notices.