### PR TITLE
mcp: an unmatched project name is an error, not silence

### DIFF
--- a/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
+++ b/bleep-cli/src/scala-3/bleep/mcp/BleepMcpServer.scala
@@ -592,22 +592,31 @@ class BleepMcpServer(logger: Logger, userPaths: UserPaths, ec: ExecutionContext)
     // ========================================================================
 
     private def resolveProjects(started: Started, names: List[String]): Array[model.CrossProjectName] =
-      if (names.isEmpty) {
-        started.chosenProjects(None)
-      } else {
-        names.flatMap { name =>
-          started.globs.projectNameMap.getOrElse(name, Array.empty[model.CrossProjectName])
-        }.toArray
-      }
+      if (names.isEmpty) started.chosenProjects(None)
+      else matchNames(names, started.globs.projectNameMap, "project")
 
     private def resolveTestProjects(started: Started, names: List[String]): Array[model.CrossProjectName] =
-      if (names.isEmpty) {
-        started.chosenTestProjects(None)
-      } else {
-        names.flatMap { name =>
-          started.globs.testProjectNameMap.getOrElse(name, Array.empty[model.CrossProjectName])
-        }.toArray
-      }
+      if (names.isEmpty) started.chosenTestProjects(None)
+      else matchNames(names, started.globs.testProjectNameMap, "test project")
+
+    /** Look every requested name up, and fail if any of them matched nothing.
+      *
+      * The command line has always rejected an unmatched name; this reached the same map with `getOrElse(name, Array.empty)` and dropped it without a word. The
+      * caller then got a green report about work that did not happen — `bleep.compile` on two projects, one of them mistyped, answered "1 projects compiled,
+      * all clear", and the only trace of the loss was a count the caller had to notice. Real builds have hidden compile errors and failing tests behind that
+      * silence for whole review cycles.
+      *
+      * Failing loudly is the point: an agent cannot see a project list it did not get, so the server has to be the one that notices.
+      */
+    private def matchNames(
+        names: List[String],
+        nameMap: Map[String, Array[model.CrossProjectName]],
+        what: String
+    ): Array[model.CrossProjectName] = {
+      val unmatched = names.filterNot(nameMap.contains)
+      if (unmatched.nonEmpty) throw new BleepException.Text(BleepMcpServer.unmatchedMessage(unmatched, nameMap.keys.toList, what))
+      names.flatMap(name => nameMap(name)).toArray
+    }
 
     /** A failed tool call is the only place the agent ever sees why the server died. If the server log records an OutOfMemoryError death, append that
       * explanation (with the fix) to the failure.
@@ -1216,6 +1225,32 @@ object BleepMcpServer {
   /** The definitive redirect for a `directory` that is not inside any bleep build. Worded for an agent mid-task: it must read as a final answer about the
     * project (so the agent switches to the right build tool immediately) and never as a transient bleep failure worth retrying.
     */
+  /** Say which names failed, and — where it can be worked out — why.
+    *
+    * The cross-target case is worth its own sentence because it is the one people actually hit: `MyProjectTest@jvm` names a cross target of a project that has
+    * none, and looks entirely reasonable to anyone who has seen `@jvm213` elsewhere in the same build.
+    */
+  def unmatchedMessage(unmatched: List[String], known: List[String], what: String): String = {
+    val sorted = known.sorted
+    val explanations = unmatched.map { name =>
+      val crossSuffixDropped = name.indexOf('@') match {
+        case -1 => None
+        case at => Option(name.take(at)).filter(sorted.contains)
+      }
+      val suggestions = crossSuffixDropped match {
+        case Some(base) => List(s"$base (it has no cross targets, so it is named without a suffix)")
+        case None       =>
+          val lower = name.toLowerCase
+          sorted.filter(k => k.toLowerCase == lower || k.toLowerCase.startsWith(lower) || lower.startsWith(k.toLowerCase)).take(5)
+      }
+      if (suggestions.isEmpty) s"  $name" else s"  $name — did you mean ${suggestions.mkString(", ")}?"
+    }
+    val header = if (unmatched.sizeIs == 1) s"no $what matches this name:" else s"no $what matches these names:"
+    // The full list last, so the specific complaint is not buried in it. Truncated because a large build has hundreds and the point is already made.
+    val all = if (sorted.sizeIs <= 40) sorted.mkString(", ") else sorted.take(40).mkString(", ") + s", … ${sorted.size - 40} more"
+    s"$header\n${explanations.mkString("\n")}\n\nknown ${what}s: $all"
+  }
+
   def notABleepBuild(directory: String): BleepException =
     new BleepException.Text(
       s"$directory is not part of a bleep build: no ${BuildLoader.BuildFileName} exists there or in any parent directory. " +

--- a/bleep-tests/src/scala/bleep/McpUnmatchedProjectTest.scala
+++ b/bleep-tests/src/scala/bleep/McpUnmatchedProjectTest.scala
@@ -1,0 +1,68 @@
+package bleep
+
+import bleep.mcp.BleepMcpServer
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** What the MCP server says when a caller names a project that does not exist.
+  *
+  * It used to say nothing. `resolveProjects` looked each name up with `getOrElse(name, Array.empty)`, so an unmatched name contributed no projects and no
+  * complaint, and the caller got a green report about work that did not happen — `bleep.compile` on two projects with one name mistyped answered "1 projects
+  * compiled, all clear". The only trace was a count the caller had to notice. Real builds hid compile errors and failing tests behind that for whole review
+  * cycles.
+  *
+  * An agent cannot see a project list it never received, so the server has to be the one that notices. These pin the noticing.
+  */
+class McpUnmatchedProjectTest extends AnyFunSuite with Matchers {
+
+  private val known = List("aws-common", "aws-common-test", "protocol", "protocol-test")
+
+  test("the message names the unmatched entry, not just the count") {
+    val message = BleepMcpServer.unmatchedMessage(List("protocl"), known, "project")
+    message should include("protocl")
+    message should startWith("no project matches this name:")
+  }
+
+  test("a cross-target suffix on a project that has none is explained, because that is the mistake people make") {
+    // The reported case: `DuckAlignerProtocolTest@jvm` — a cross-target name for a project with no cross targets, which looks entirely reasonable next to the
+    // `@jvm213` names a cross-built project in the same build really does have.
+    val message = BleepMcpServer.unmatchedMessage(List("protocol-test@jvm"), known, "project")
+    message should include("protocol-test@jvm")
+    message should include("it has no cross targets")
+    message should include("protocol-test (")
+  }
+
+  test("a near miss suggests the real name") {
+    // Both `aws-common` and `aws-common-test` are plausible for a truncated `aws-common-te`, and offering both is right — so this asserts that the suggestion
+    // is present, not that it is alone.
+    val message = BleepMcpServer.unmatchedMessage(List("aws-common-te"), known, "project")
+    val suggestionLine = message.linesIterator.find(_.contains("aws-common-te —")).getOrElse(fail(s"no suggestion line in:\n$message"))
+    suggestionLine should include("did you mean")
+    suggestionLine should include("aws-common-test")
+  }
+
+  test("several unmatched names are all reported, not just the first") {
+    val message = BleepMcpServer.unmatchedMessage(List("nope-one", "nope-two"), known, "project")
+    message should startWith("no project matches these names:")
+    message should include("nope-one")
+    message should include("nope-two")
+  }
+
+  test("the known names are listed, so the caller can correct without another round trip") {
+    val message = BleepMcpServer.unmatchedMessage(List("nope"), known, "project")
+    known.foreach(k => message should include(k))
+  }
+
+  test("a very large build truncates the list rather than burying the complaint") {
+    val many = (1 to 200).map(i => f"project$i%03d").toList
+    val message = BleepMcpServer.unmatchedMessage(List("nope"), many, "project")
+    message should include("160 more")
+    // The complaint comes before the list: header, then the offending name, then the known names.
+    message.linesIterator.toList(1) should include("nope")
+    message.indexOf("nope") should be < message.indexOf("known projects:")
+  }
+
+  test("the wording follows what was asked for, so a test-only tool does not talk about projects") {
+    BleepMcpServer.unmatchedMessage(List("nope"), known, "test project") should include("no test project matches")
+  }
+}


### PR DESCRIPTION
Fixes #662.

The command line has always rejected a project name that matches nothing. The
MCP server looked the same name up with `getOrElse(name, Array.empty)`, dropped
it, and reported success for the work that *did* happen:

```
bleep.compile  projects: ["AnyRealProject", "NoSuchProjectXyz"]
→ {"success":true,"errors":0,"summary":"Build: 1 projects compiled, all clear"}
```

The only trace of the loss was a count the caller had to notice. Per the report,
a real build hid **eleven compile errors and four failing tests** behind one such
name across three rounds of review.

An agent cannot see a project list it never received, so the server has to be
the one that notices.

## After

```
bleep.compile failed: no project matches this name:
  NoSuchProjectXyz

known projects: bleep-bsp, bleep-bsp-protocol, bleep-bsp-tests, bleep-cli, …
```

with `isError: true`. Both `resolveProjects` and `resolveTestProjects` had the
bug and both are fixed.

The message names every unmatched entry rather than only the first, suggests
near matches, and lists what does exist so the caller can correct without
another round trip.

**The cross-target case gets its own sentence**, because it is the one the
report actually hit — `SomethingTest@jvm`, a cross-target name for a project
that has no cross targets, which looks entirely reasonable next to the `@jvm213`
names a cross-built project in the same build really does have:

```
  protocol-test@jvm — did you mean protocol-test (it has no cross targets, so it is named without a suffix)?
```

## Verification

Seven unit tests on the message, plus a real MCP session driven over stdio — the
"After" block above is that session's actual reply, not a mock. `bleep test
--exclude-tag matrix` (the CI gate): 1287 passed, 0 failed.

## Why this shape of bug is worth caring about

This is the third instance found recently of the same failure class: work that
did not happen reported as success. The other two were a test project with zero
discovered suites exiting 0 (#656), and jqwik being discovered by nothing while
the run reported all clear (#656). A build tool that answers "all clear" when it
did nothing is worse than one that fails, because the caller stops looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
