### PR TITLE
drop an --add-opens that has never resolved on any supported JDK

### DIFF
--- a/bleep-core/src/scala/bleep/commands/Run.scala
+++ b/bleep-core/src/scala/bleep/commands/Run.scala
@@ -2,7 +2,7 @@ package bleep
 package commands
 
 import bleep.bsp.protocol.BleepBspProtocol
-import bleep.internal.{jvmRunCommand, TransitiveProjects}
+import bleep.internal.TransitiveProjects
 
 import java.nio.file.Files
 
@@ -108,7 +108,7 @@ case class Run(
       cwd = started.pre.buildPaths.cwd,
       resolvedJvm = started.resolvedJvm.forceGet,
       classpath = classpath,
-      jvmOptions = jvmRunCommand.scala3CompatOptions ++ jvmOptions,
+      jvmOptions = jvmOptions,
       mainClass = main,
       args = args,
       env = runEnv(started),

--- a/bleep-core/src/scala/bleep/internal/jvmRunCommand.scala
+++ b/bleep-core/src/scala/bleep/internal/jvmRunCommand.scala
@@ -6,11 +6,6 @@ import java.nio.file.Path
 
 object jvmRunCommand {
 
-  /** JVM options to suppress Scala 3 LazyVals sun.misc.Unsafe warnings */
-  val scala3CompatOptions: List[String] = List(
-    "--add-opens=java.base/sun.misc=ALL-UNNAMED"
-  )
-
   def apply(
       project: ResolvedProject,
       resolvedJvm: Lazy[ResolvedJvm],
@@ -36,7 +31,6 @@ object jvmRunCommand {
 
   def cmdArgs(jvmOptions: List[String], cp: List[Path], main: String, args: List[String]): List[String] =
     List[List[String]](
-      scala3CompatOptions,
       jvmOptions,
       List("-classpath", cp.mkString(File.pathSeparator), main),
       args


### PR DESCRIPTION
Fixes #672.

`jvmRunCommand.scala3CompatOptions` passed
`--add-opens=java.base/sun.misc=ALL-UNNAMED`, commented as *"JVM options to
suppress Scala 3 LazyVals sun.misc.Unsafe warnings"*. It suppresses nothing, and
emits a warning of its own on every script run:

```
WARNING: package sun.misc not in java.base
```

## Measured, not assumed

`sun.misc` has lived in `jdk.unsupported`, not `java.base`, since JDK 9. Running
`java --add-opens=java.base/sun.misc=ALL-UNNAMED -version` on the two ends of
what bleep supports:

| JDK | result |
|---|---|
| 24 (graalvm-community) | `WARNING: package sun.misc not in java.base` |
| 11 (zulu) | same warning |
| 24, targeting `jdk.unsupported/sun.misc` instead | no warning |

So the directive has been inert for the entire life of the flag — on every JDK
bleep runs on. Meanwhile the warning it claims to suppress keeps appearing:
bleep's own test output shows

```
WARNING: package sun.misc not in java.base
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by scala.runtime.LazyVals$
```

together, in the same run, with the flag applied.

The flag that actually governs this on JDK 23+ is
`--sun-misc-unsafe-memory-access`, which this build already sets under
`template-jvm`. That is why retargeting to `jdk.unsupported` is not the fix
here: nothing needs the open.

## The duplication was ours

The report notes the flag appearing twice and attributes it partly to the
coursier bootstrap. It is entirely bleep's:

1. `Run.scala` prepends `scala3CompatOptions` into `jvmOptions`
2. those flow to `JvmRunner.run` → `forkWith` → `jvmRunCommand.cmd`
3. `cmdArgs` prepends `scala3CompatOptions` **again**

Deleting the constant removes both occurrences.

## Verification

Regenerating the dev script with the built code and running a script through it:

| | before | after |
|---|---|---|
| `java.base/sun.misc` in the generated command | 1 | **0** |
| `package sun.misc not in java.base` in the run | 1 | **0** |

`bleep test --exclude-tag matrix`: 1281 passed, 0 failed. One unrelated timeout
in `KotlinNativeTestFrameworkIT`, which runs in 27s in isolation and goes quiet
past the outer 2-minute idle bound only under full-suite contention — it links a
Kotlin/Native binary and reports nothing while doing so. Not caused by this
change, which cannot affect link time; worth its own issue.

`-Werror` caught the orphaned import, which is a nice argument for `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
