### PR TITLE
test forks: a shadowed bleep-test-runner, and the link work behind it (#667, #673)

### DIFF
--- a/bleep-bsp-tests/src/scala/bleep/analysis/LinkDagIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/LinkDagIntegrationTest.scala
@@ -259,7 +259,7 @@ class LinkDagIntegrationTest extends AnyFunSuite with Matchers {
           )
         },
         discover = (_, _) => sys.error("DiscoverTask should not appear in a link DAG"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear in a link DAG"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear in a link DAG"),
         sourcegen = (_, _) => sys.error("SourcegenTask should not appear here"),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -305,7 +305,7 @@ class LinkDagIntegrationTest extends AnyFunSuite with Matchers {
             )
           ),
         discover = (_, _) => sys.error("DiscoverTask should not appear in a link DAG"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear in a link DAG"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear in a link DAG"),
         sourcegen = (_, _) => sys.error("SourcegenTask should not appear here"),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -351,7 +351,7 @@ class LinkDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (_, _) => IO.pure(TaskResult.Success),
         link = (_, _) => IO.pure((TaskResult.Failure("Link error", List.empty), LinkResult.Failure("Link error", List.empty))),
         discover = (_, _) => IO.pure((TaskResult.Success, TaskDag.DiscoveryResult(Nil, 0, isTestProject = false))),
-        test = (_, _) => sys.error("TestSuiteTask should not appear in this DAG"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear in this DAG"),
         sourcegen = (_, _) => sys.error("SourcegenTask should not appear here"),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")

--- a/bleep-bsp-tests/src/scala/bleep/analysis/OutputParserEdgeCaseTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/OutputParserEdgeCaseTest.scala
@@ -209,7 +209,7 @@ class OutputParserEdgeCaseTest extends AnyFunSuite with Matchers {
 
   test("ScalaJsLinkConfig.Debug vs Release defaults") {
     // On for debug too, as mill has it: measured free, and it halves the output. See `ScalaJsLinkConfig.Debug`.
-    ScalaJsLinkConfig.Debug.optimizer shouldBe true
+    ScalaJsLinkConfig.Debug.optimizer shouldBe false
     ScalaJsLinkConfig.Debug.minify shouldBe false
     ScalaJsLinkConfig.Debug.emitSourceMaps shouldBe true
 

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsIntegrationTest.scala
@@ -89,8 +89,8 @@ class ScalaJsIntegrationTest extends AnyFunSuite with Matchers {
     val config = ScalaJsLinkConfig.Debug
     config.mode shouldBe ScalaJsLinkConfig.LinkerMode.Debug
     config.emitSourceMaps shouldBe true
-    // The optimizer runs for a debug link as well; what separates debug from release is minification, Closure and the semantics, not this.
-    config.optimizer shouldBe true
+    // Off for a debug link, as on every other platform. Release turns it on, along with minification, Closure and the optimized semantics.
+    config.optimizer shouldBe false
     config.minify shouldBe false
   }
 

--- a/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsLinkIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/ScalaJsLinkIntegrationTest.scala
@@ -34,8 +34,8 @@ class ScalaJsLinkIntegrationTest extends AnyFunSuite with Matchers {
     config.emitSourceMaps shouldBe true
     config.minify shouldBe false
     config.prettyPrint shouldBe false
-    // Debug runs the optimizer too; minification and Closure are what release adds.
-    config.optimizer shouldBe true
+    // Off for debug, matching Scala Native and the Kotlin platforms; `--optimize` opts in. Release adds it along with minification and Closure.
+    config.optimizer shouldBe false
   }
 
   test("ScalaJsLinkConfig: Release configuration defaults") {

--- a/bleep-bsp-tests/src/scala/bleep/analysis/SourcegenDagIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/SourcegenDagIntegrationTest.scala
@@ -301,7 +301,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (t, _) => IO(order.add(s"compile:${t.project.value}"): Unit).as(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (t, _) => IO(order.add(s"sourcegen:${t.script.main}"): Unit).as(TaskResult.Success),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -351,7 +351,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
           else IO.pure(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => IO(sourcegenCalled.set(true)).as(TaskResult.Success),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -401,7 +401,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
           else IO.pure(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => IO.pure(TaskResult.Failure("script threw", Nil)),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -450,7 +450,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
           else IO.pure(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => IO.pure(TaskResult.Success), // up-to-date fast path
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -497,7 +497,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (_, _) => IO.pure(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => IO.pure(TaskResult.Success),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -550,7 +550,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (_, _) => IO.pure(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => IO.pure(TaskResult.Failure("boom", Nil)),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -601,7 +601,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
           else IO.pure(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, taskKill) => taskKill.get.map(reason => TaskResult.Killed(reason)),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -649,7 +649,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (t, _) => record(s"compile:${t.project.value}").as(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) =>
           record("sourcegen:start") >>
             IO.sleep(scala.concurrent.duration.DurationInt(100).millis) >>
@@ -696,7 +696,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (_, _) => IO.raiseError(new RuntimeException("bleep-test-runner resolution returned no jars")),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => sys.error("SourcegenTask should not appear here"),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")
@@ -749,7 +749,7 @@ class SourcegenDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (_, _) => IO.pure(TaskResult.Success),
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => IO.raiseError(new RuntimeException("generator blew up")),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => sys.error("ResolveSymbolProcessorsTask should not appear here")

--- a/bleep-bsp-tests/src/scala/bleep/analysis/SymbolProcessorDagIntegrationTest.scala
+++ b/bleep-bsp-tests/src/scala/bleep/analysis/SymbolProcessorDagIntegrationTest.scala
@@ -110,7 +110,7 @@ class SymbolProcessorDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (ct, _) => IO { timeline.add(s"compile:${ct.project.value}"); TaskResult.Success },
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => sys.error("SourcegenTask should not appear here"),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (kspt, _) => IO { timeline.add(s"ksp:${kspt.project.value}"); (TaskResult.Success, 2) }
@@ -143,7 +143,7 @@ class SymbolProcessorDagIntegrationTest extends AnyFunSuite with Matchers {
         compile = (ct, _) => IO { compileInvoked.set(true); finishedTasks.add(ct.project.value -> TaskResult.Success); TaskResult.Success },
         link = (_, _) => sys.error("LinkTask should not appear here"),
         discover = (_, _) => sys.error("DiscoverTask should not appear here"),
-        test = (_, _) => sys.error("TestSuiteTask should not appear here"),
+        test = (_, _, _) => sys.error("TestSuiteTask should not appear here"),
         sourcegen = (_, _) => sys.error("SourcegenTask should not appear here"),
         annotationProcessor = (_, _) => sys.error("ResolveAnnotationProcessorsTask should not appear here"),
         symbolProcessor = (_, _) => IO((TaskResult.Failure("simulated KSP misconfig", Nil), 0))

--- a/bleep-bsp/src/scala/bleep/analysis/ScalaJsConfig.scala
+++ b/bleep-bsp/src/scala/bleep/analysis/ScalaJsConfig.scala
@@ -102,10 +102,13 @@ object ScalaJsLinkConfig {
     prettyPrint = false,
     esFeatures = EsFeatures.Defaults,
     checkIR = false,
-    // On, as mill has it (`scalaJSOptimizer` defaults to true for `fastLinkJS` too). Measured on a stdlib-using program: no cost worth reporting — three runs
-    // came out marginally faster than with it off — while output fell from 1,579,362 to 808,810 bytes. A debug link stays source-mapped and debuggable either
-    // way, so there was nothing to trade away.
-    optimizer = true
+    // Off, like every other linkable platform's debug mode: `--optimize` turns it on, and release turns it on for you.
+    //
+    // Not because it is expensive. Measured on a upickle-deriving program, the optimizer costs 0.1-0.4s on a 1.5s link and saves 42% of the output
+    // (2,140,186 bytes against 3,034,721). It is off because none of that matters for a debug link — nobody ships one — while a Scala.js default that
+    // disagreed with Scala Native, Kotlin/JS and Kotlin/Native made `--optimize` mean "on" everywhere except here, where it already was. Consistency is
+    // worth more than 900KB of output nobody deploys, and the flag is there for anyone who wants it back.
+    optimizer = false
   )
 
   /** Default release configuration. */

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -2583,7 +2583,7 @@ class MultiWorkspaceBspServer(
                 case (Some(model.PlatformId.Native), true) =>
                   runKotlinNativeTestSuite(started, testTask, testEnv, eventQueue, taskKillSignal)
                 case (Some(model.PlatformId.Native), false) =>
-                  runScalaNativeTestSuite(started, testTask, classpath, testEnv, eventQueue, taskKillSignal)
+                  runScalaNativeTestSuite(started, testTask, classpath, testEnv, linkResults, eventQueue, taskKillSignal)
                 case _ =>
                   // JVM (default) - use JvmPool
                   val projectDir =
@@ -3553,6 +3553,7 @@ class MultiWorkspaceBspServer(
       testTask: TaskDag.TestSuiteTask,
       classpath: List[Path],
       testEnv: Map[String, String],
+      linkResults: java.util.concurrent.ConcurrentHashMap[CrossProjectName, TaskDag.LinkResult],
       eventQueue: Queue[IO, Option[TaskDag.DagEvent]],
       killSignal: Deferred[IO, KillReason]
   ): IO[TaskDag.TaskResult] = {
@@ -3560,44 +3561,19 @@ class MultiWorkspaceBspServer(
     val snVersion = project.platform.flatMap(_.nativeVersion).getOrElse {
       throw new IllegalStateException(s"Scala Native version not found for ${testTask.project.value}")
     }
-    val scalaVersion = project.scala.flatMap(_.version).getOrElse {
-      throw new IllegalStateException(s"Scala version not found for ${testTask.project.value}")
-    }
-
-    val projectPaths = started.projectPaths(testTask.project)
-    val outputDir = projectPaths.classes.getParent.resolve("link-output")
-    val logger = createLinkLogger()
 
     val framework = ScalaNativeTestRunner.detectFramework(classpath)
-    val testMainClass = ScalaNativeTestRunner.getTestMainClass(framework)
-    val toolchain = bleep.analysis.ScalaNativeToolchain.forVersion(snVersion.scalaNativeVersion, scalaVersion.scalaVersion)
-    val binaryPath = outputDir.resolve(s"${testTask.project.value}-test")
-    val workDir = outputDir.resolve("native-work")
-
-    val nativeLogger = new bleep.analysis.ScalaNativeToolchain.Logger {
-      def trace(message: => String): Unit = logger.trace(message)
-      def debug(message: => String): Unit = logger.debug(message)
-      def info(message: => String): Unit = logger.info(message)
-      def warn(message: => String): Unit = logger.warn(message)
-      def error(message: => String): Unit = logger.error(message)
-      def running(command: Seq[String]): Unit = logger.info(s"Running: ${command.mkString(" ")}")
-    }
 
     for {
       startTs <- IO.realTime.map(_.toMillis)
       lastActivityAt <- IO.monotonic.flatMap(Ref.of[IO, FiniteDuration])
       // Note: TaskStarted is already emitted by DAG executor - don't duplicate it here
-      linkResult <- ScalaNativeTestRunner.linkTestBinary(
-        toolchain,
-        classpath.map(_.toAbsolutePath),
-        testMainClass,
-        bleep.analysis.ScalaNativeLinkConfig.Debug,
-        binaryPath,
-        workDir,
-        nativeLogger,
-        killSignal
-      )
-      taskResult <- linkResult match {
+      taskResult <- linkResults.get(testTask.project) match {
+        // The binary the DAG's link wrote, rather than one linked here.
+        //
+        // This used to link its own, once per suite, and every suite computed the same output path — so a three-suite project linked four times and the last
+        // three raced each other for one file. The DAG's link is not merely equivalent, it is identical: `LinkExecutor` resolves an absent main class to
+        // `ScalaNativeTestRunner.TestMainClass` when the task is a test, which is the same constant `getTestMainClass` returns for every framework.
         case TaskDag.LinkResult.NativeSuccess(binary, _) =>
           boundPlatformRun(lastActivityAt, killSignal) {
             Dispatcher.sequential[IO].use { dispatcher =>
@@ -3655,15 +3631,17 @@ class MultiWorkspaceBspServer(
                 }
             }
           }
-        case _ =>
+        // No binary to run. The DAG links before it discovers, and discovery produced this suite, so this means the two got out of step rather than that the
+        // link failed — a failed link would have stopped the suite ever being scheduled. Named accordingly instead of blaming the linker.
+        case other =>
           val endTs = System.currentTimeMillis()
           val durationMs = endTs - startTs
+          val message =
+            s"no Scala Native binary for ${testTask.project.value}: expected the DAG's link to have produced one, got ${Option(other).getOrElse("nothing")}"
           eventQueue
-            .offer(
-              Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, SuiteOutcome.Errored("Native linking failed", None), durationMs, endTs))
-            )
+            .offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, SuiteOutcome.Errored(message, None), durationMs, endTs)))
             .void >>
-            IO.pure(TaskDag.TaskResult.Failure("Native linking failed", List.empty))
+            IO.pure(TaskDag.TaskResult.Failure(message, List.empty))
       }
     } yield taskResult
   }

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -3287,12 +3287,24 @@ class MultiWorkspaceBspServer(
       .find(p => p.name.value == "bleep-test-runner")
       .map(p => started.projectPaths(p).classes)
 
-    val testRunnerClasses = testRunnerFromBuild match {
-      case Some(path) => List(path)
+    val (testRunnerClasses, testRuntimeJars) = testRunnerFromBuild match {
+      case Some(path) => (List(path), Nil)
       case None       => fetchTestRunnerViaCoursier(started, project, resolved)
     }
 
-    val classpath = (classesDir :: resourceDirs) ++ dependencyClasspath ++ testRunnerClasses
+    // `bleep-test-runner` goes ahead of the project's own dependencies; the test runtime stays behind them.
+    //
+    // A build that depends on bleep itself — scripts, plugins, anything pulling `build.bleep::bleep-core` — drags a *released* `bleep-test-runner` in
+    // transitively. Appended last, that copy came first on the classpath, and first-match-wins classloading handed the fork the released runner instead of the
+    // one this server speaks to. The two disagree about the protocol: the released runner reads commands from stdin, while this server waits for a connect-back
+    // on a loopback socket. Neither side ever moves, and the spawn dies 60 seconds later on the accept timeout — with the fork still alive and blocked in
+    // `readLine`, which is why it never looked like a crash.
+    //
+    // Only the runner moves. It is safe to put first because its jar contains nothing but `bleep/testing/runner`, so it can shadow only itself, and it is the
+    // only thing here whose identity must come from the server rather than from the project. The junit runtime is the opposite case: those versions are chosen
+    // to match what the project itself resolved, [[assertCoherentJunitClasspath]] checks that they do, and promoting them over the project's own jars would
+    // quietly make this server the arbiter of a version it deliberately follows.
+    val classpath = (classesDir :: resourceDirs) ++ testRunnerClasses ++ dependencyClasspath ++ testRuntimeJars
     MultiWorkspaceBspServer.assertCoherentJunitClasspath(project, classpath)
     classpath
   }
@@ -3316,14 +3328,16 @@ class MultiWorkspaceBspServer(
     * What that costs when it is wrong: the runner used to declare 1.9.1/5.9.1, coursier reconciles to the *highest* version rather than to ours, and a stale
     * `junit-jupiter-engine` landed ahead of the aligned one — a kotest 6 project then died in discovery with `NoSuchMethodError: ReflectionUtils.returnsVoid`.
     */
-  private def fetchTestRunnerViaCoursier(started: Started, project: CrossProjectName, resolved: ResolvedProject): List[Path] = {
+  private def fetchTestRunnerViaCoursier(started: Started, project: CrossProjectName, resolved: ResolvedProject): (List[Path], List[Path]) = {
     val testRuntimeJars = MultiWorkspaceBspServer.fetchTestRuntimeDeps(started, project, resolved)
     val testRunnerJars = fetchBleepTestRunnerOnly(started)
     if (testRunnerJars.isEmpty)
       throw new RuntimeException("bleep-test-runner resolution returned no jars")
-    // `distinct` because these are two independent resolutions and `test-interface` is in both: rule 1 always contributes it, and a *published*
-    // `bleep-test-runner` also declares it at compile scope. Exact-path equality, so two genuinely different jars that share a filename both survive.
-    (testRunnerJars ++ testRuntimeJars).distinct
+    // Kept apart because they land in different places on the fork's classpath — the runner ahead of the project's dependencies, the runtime behind them; see
+    // [[getTestClasspath]]. The runtime side drops anything the runner already contributes, because `test-interface` is in both: rule 1 always contributes it,
+    // and a *published* `bleep-test-runner` also declares it at compile scope. Exact-path equality, so two genuinely different jars that share a filename both
+    // survive.
+    (testRunnerJars.distinct, testRuntimeJars.distinct.filterNot(testRunnerJars.contains))
   }
 
   /** The forked runner speaks this server's `TestProtocol` over the fork's stdin/stdout, so it must be built from the same code as the server. Two ways to get

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -2474,10 +2474,14 @@ class MultiWorkspaceBspServer(
 
         // Create JVM pool for test execution. The machine governor caps concurrent forks (cores +
         // fork-memory budget) across ALL clients — the per-pool maxParallelism only bounds this run.
-        testResult <- JvmPool.create(maxParallelism, started.jvmCommand, started.buildPaths.buildDir, machine, BspMetrics.jvmPoolListener).use { jvmPool =>
-          // Per-test-run map populated by the AP DAG handler and read by the compile handler. KSP runs as a separate process and emits files directly; no
-          // intermediate compile-time data flow, so no equivalent map.
-          val apResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, AnnotationProcessorResult]()
+        testResult <- JvmPool.create(maxParallelism, started.jvmCommand, started.buildPaths.buildDir, machine, BspMetrics.jvmPoolListener).use {
+          jvmPool =>
+            // Per-test-run map populated by the AP DAG handler and read by the compile handler. KSP runs as a separate process and emits files directly; no
+            // intermediate compile-time data flow, so no equivalent map.
+            val apResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, AnnotationProcessorResult]()
+          // What each link produced, for the test handlers that need to run it. Same shape as `apResults`, and safe for the same reason: the DAG puts a
+          // LinkTask between compile and discover for every non-JVM test project, so a suite can only run after its project's link has finished.
+          val linkResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, TaskDag.LinkResult]()
 
           val compileHandler =
             makeCompileHandler(started, workspace, params.originId, apResults, diagnosticTracker, recorder)
@@ -2575,7 +2579,7 @@ class MultiWorkspaceBspServer(
                 case (Some(model.PlatformId.Js), true) =>
                   runKotlinJsTestSuite(started, testTask, testEnv, eventQueue, taskKillSignal)
                 case (Some(model.PlatformId.Js), false) =>
-                  runScalaJsTestSuite(started, testTask, classpath, testEnv, eventQueue, taskKillSignal)
+                  runScalaJsTestSuite(started, testTask, classpath, testEnv, linkResults, eventQueue, taskKillSignal)
                 case (Some(model.PlatformId.Native), true) =>
                   runKotlinNativeTestSuite(started, testTask, testEnv, eventQueue, taskKillSignal)
                 case (Some(model.PlatformId.Native), false) =>
@@ -2628,7 +2632,7 @@ class MultiWorkspaceBspServer(
                 val outputDir = projectPaths.targetDir
                 withLinkMetrics(linkTask, started.buildPaths.buildDir.toString) {
                   LinkExecutor.execute(linkTask, classpath.map(_.toAbsolutePath), None, outputDir, logger, killSignal)
-                }
+                }.flatTap { case (_, linkResult) => IO(linkResults.put(linkTask.project, linkResult)).void }
               }
 
           val apHandler = makeAnnotationProcessorHandler(started, params.originId, apResults)
@@ -3466,6 +3470,7 @@ class MultiWorkspaceBspServer(
       testTask: TaskDag.TestSuiteTask,
       classpath: List[Path],
       testEnv: Map[String, String],
+      linkResults: java.util.concurrent.ConcurrentHashMap[CrossProjectName, TaskDag.LinkResult],
       eventQueue: Queue[IO, Option[TaskDag.DagEvent]],
       killSignal: Deferred[IO, KillReason]
   ): IO[TaskDag.TaskResult] = {
@@ -3473,29 +3478,21 @@ class MultiWorkspaceBspServer(
     val sjsVersion = project.platform.flatMap(_.jsVersion).getOrElse {
       throw new IllegalStateException(s"Scala.js version not found for ${testTask.project.value}")
     }
-    val scalaVersion = project.scala.flatMap(_.version).getOrElse {
-      throw new IllegalStateException(s"Scala version not found for ${testTask.project.value}")
-    }
-
-    val projectPaths = started.projectPaths(testTask.project)
-    val outputDir = projectPaths.classes.getParent.resolve("link-output")
+    // No Scala version needed here any more: it was only ever used to describe the link this function used to run itself.
     val linkConfig = bleep.analysis.ScalaJsLinkConfig.Debug
-    val logger = createLinkLogger()
-
-    val linkTask = TaskDag.LinkTask(
-      project = testTask.project,
-      platform = TaskDag.LinkPlatform.ScalaJs(sjsVersion.scalaJsVersion, scalaVersion.scalaVersion, linkConfig),
-      releaseMode = false,
-      isTest = true
-    )
 
     for {
       startTs <- IO.realTime.map(_.toMillis)
       lastActivityAt <- IO.monotonic.flatMap(Ref.of[IO, FiniteDuration])
       // Note: TaskStarted is already emitted by DAG executor - don't duplicate it here
-      linkResult <- LinkExecutor.execute(linkTask, classpath.map(_.toAbsolutePath), None, outputDir, logger, killSignal)
-      taskResult <- linkResult match {
-        case (TaskDag.TaskResult.Success, TaskDag.LinkResult.JsSuccess(mainModule, _, _, _)) =>
+      taskResult <- linkResults.get(testTask.project) match {
+        // Taken from the link the DAG already ran, rather than linking again here.
+        //
+        // This used to run its own `LinkExecutor.execute` into a second output directory, once per suite. The work is identical every time and the DAG has
+        // already done it — `TaskDag` puts a LinkTask between compile and discover for exactly this reason — so an N-suite project paid for N linear links of
+        // the whole program. Worse, it was billed to the suites: linking happened inside each suite's own runtime, where it counted against the idle timeout
+        // that is supposed to be measuring a hung test.
+        case TaskDag.LinkResult.JsSuccess(mainModule, _, _, _) =>
           // Run the specific test suite via Node.js
           val nodeBinary = nodeBinaryFor(started, project)
           boundPlatformRun(lastActivityAt, killSignal) {
@@ -3535,11 +3532,17 @@ class MultiWorkspaceBspServer(
                 }
             }
           }
-        case (result, _) =>
+        // No link output to run. The DAG links before it discovers, and discovery is what produced this suite, so reaching here means the two got out of step
+        // rather than that the user did anything wrong — say so plainly instead of quietly linking again and hiding it.
+        case other =>
           val endTs = System.currentTimeMillis()
           val durationMs = endTs - startTs
-          eventQueue.offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, erroredOutcomeOf(result), durationMs, endTs))).void >>
-            IO.pure(result)
+          val failure = TaskDag.TaskResult.Failure(
+            s"no Scala.js link output for ${testTask.project.value}: expected the DAG's link to have produced one, got ${Option(other).getOrElse("nothing")}",
+            Nil
+          )
+          eventQueue.offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, erroredOutcomeOf(failure), durationMs, endTs))).void >>
+            IO.pure(failure)
       }
     } yield taskResult
   }

--- a/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/MultiWorkspaceBspServer.scala
@@ -1962,8 +1962,8 @@ class MultiWorkspaceBspServer(
         val discoverHandler: (TaskDag.DiscoverTask, Deferred[IO, KillReason]) => IO[(TaskDag.TaskResult, TaskDag.DiscoveryResult)] =
           (_, _) => sys.error("DiscoverTask should not appear in compile/link DAG")
 
-        val testHandler: (TaskDag.TestSuiteTask, Deferred[IO, KillReason]) => IO[TaskDag.TaskResult] =
-          (_, _) => sys.error("TestSuiteTask should not appear in compile/link DAG")
+        val testHandler: (TaskDag.TestSuiteTask, Option[TaskDag.LinkResult], Deferred[IO, KillReason]) => IO[TaskDag.TaskResult] =
+          (_, _, _) => sys.error("TestSuiteTask should not appear in compile/link DAG")
 
         val apHandler = makeAnnotationProcessorHandler(started, params.originId, apResults)
         val kspHandler = makeSymbolProcessorHandler(started, params.originId)
@@ -2479,9 +2479,6 @@ class MultiWorkspaceBspServer(
             // Per-test-run map populated by the AP DAG handler and read by the compile handler. KSP runs as a separate process and emits files directly; no
             // intermediate compile-time data flow, so no equivalent map.
             val apResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, AnnotationProcessorResult]()
-          // What each link produced, for the test handlers that need to run it. Same shape as `apResults`, and safe for the same reason: the DAG puts a
-          // LinkTask between compile and discover for every non-JVM test project, so a suite can only run after its project's link has finished.
-          val linkResults = new java.util.concurrent.ConcurrentHashMap[CrossProjectName, TaskDag.LinkResult]()
 
           val compileHandler =
             makeCompileHandler(started, workspace, params.originId, apResults, diagnosticTracker, recorder)
@@ -2562,65 +2559,66 @@ class MultiWorkspaceBspServer(
                 }
               }
 
-          val testHandler: (TaskDag.TestSuiteTask, Deferred[IO, KillReason]) => IO[TaskDag.TaskResult] = (testTask, taskKillSignal) =>
-            // getTestClasspath ends up in CoursierResolver.Direct.go which calls Fetch.eitherResult → Await.result(future, Duration.Inf).
-            // Without IO.blocking that runs synchronously on the IOFiber's compute thread, holding it for the entire resolve while
-            // every other fiber on the runtime — including the BSP pipe reader on the other end of an in-process server — has to
-            // queue behind it. Routing it through the blocker pool lets cats-effect grow a helper thread instead of starving compute.
-            IO.blocking(getTestClasspath(started, testTask.project)).flatMap { classpath =>
-              val project = started.build.explodedProjects(testTask.project)
-              val projectPlatform = project.platform.flatMap(_.name)
-              val isKotlin = project.kotlin.flatMap(_.version).isDefined
+          val testHandler: (TaskDag.TestSuiteTask, Option[TaskDag.LinkResult], Deferred[IO, KillReason]) => IO[TaskDag.TaskResult] =
+            (testTask, linkResult, taskKillSignal) =>
+              // getTestClasspath ends up in CoursierResolver.Direct.go which calls Fetch.eitherResult → Await.result(future, Duration.Inf).
+              // Without IO.blocking that runs synchronously on the IOFiber's compute thread, holding it for the entire resolve while
+              // every other fiber on the runtime — including the BSP pipe reader on the other end of an in-process server — has to
+              // queue behind it. Routing it through the blocker pool lets cats-effect grow a helper thread instead of starving compute.
+              IO.blocking(getTestClasspath(started, testTask.project)).flatMap { classpath =>
+                val project = started.build.explodedProjects(testTask.project)
+                val projectPlatform = project.platform.flatMap(_.name)
+                val isKotlin = project.kotlin.flatMap(_.version).isDefined
 
-              // Same env on every platform: a test that reads a var should not care whether it runs on the JVM, Node or a native binary.
-              val testEnv = computeTestEnvironment(started, testTask.project, testOptions.env)
+                // Same env on every platform: a test that reads a var should not care whether it runs on the JVM, Node or a native binary.
+                val testEnv = computeTestEnvironment(started, testTask.project, testOptions.env)
 
-              (projectPlatform, isKotlin) match {
-                case (Some(model.PlatformId.Js), true) =>
-                  runKotlinJsTestSuite(started, testTask, testEnv, eventQueue, taskKillSignal)
-                case (Some(model.PlatformId.Js), false) =>
-                  runScalaJsTestSuite(started, testTask, classpath, testEnv, linkResults, eventQueue, taskKillSignal)
-                case (Some(model.PlatformId.Native), true) =>
-                  runKotlinNativeTestSuite(started, testTask, testEnv, eventQueue, taskKillSignal)
-                case (Some(model.PlatformId.Native), false) =>
-                  runScalaNativeTestSuite(started, testTask, classpath, testEnv, linkResults, eventQueue, taskKillSignal)
-                case _ =>
-                  // JVM (default) - use JvmPool
-                  val projectDir =
-                    started.build.explodedProjects.get(testTask.project).flatMap(_.folder).map(rp => started.buildPaths.buildDir.resolve(rp.toString))
-                  // Project-level JVM options from platform config (e.g. -Djava.util.logging.manager for Quarkus)
-                  val projectJvmOptions = started.resolvedProject(testTask.project).platform match {
-                    case Some(p: ResolvedProject.Platform.Jvm) => p.options
-                    case _                                     => Nil
-                  }
-                  TestRunner.runSuite(
-                    project = testTask.project,
-                    suiteName = testTask.suiteName.value,
-                    selection = testTask.selection,
-                    classpath = classpath,
-                    pool = jvmPool,
-                    eventQueue = eventQueue,
-                    options = TestRunner.Options(
-                      // Only what someone asked for, in precedence order: the project's own options, then this run's `--jvm-opt`. The configured heap is NOT
-                      // prepended here — it goes in as the default the pool falls back to, so a fork carries exactly one `-Xmx` and it is the one that
-                      // decided the heap. See MachineResources.withHeapBound.
-                      jvmOptions = projectJvmOptions ++ testOptions.jvmOptions,
-                      defaultHeapMb = MachineResources.forkHeapMb(serverConfig.testRunnerHeap),
-                      testArgs = testOptions.testArgs,
-                      idleTimeout = idleTimeout,
-                      environment = testEnv,
-                      workingDirectory = projectDir
-                    ),
-                    resolveSourcePath = className =>
-                      bleep.analysis.ZincSourceLookup.relativeSourceForProject(
-                        bleep.analysis.AnalysisCache.Ref(analysisCache, started.buildPaths.workspaceKey),
-                        started.buildPaths.variantBuildDir(testTask.project).resolve(".zinc").resolve("analysis.zip"),
-                        className
+                (projectPlatform, isKotlin) match {
+                  case (Some(model.PlatformId.Js), true) =>
+                    runKotlinJsTestSuite(started, testTask, testEnv, eventQueue, taskKillSignal)
+                  case (Some(model.PlatformId.Js), false) =>
+                    runScalaJsTestSuite(started, testTask, classpath, testEnv, linkResult, eventQueue, taskKillSignal)
+                  case (Some(model.PlatformId.Native), true) =>
+                    runKotlinNativeTestSuite(started, testTask, testEnv, eventQueue, taskKillSignal)
+                  case (Some(model.PlatformId.Native), false) =>
+                    runScalaNativeTestSuite(started, testTask, classpath, testEnv, linkResult, eventQueue, taskKillSignal)
+                  case _ =>
+                    // JVM (default) - use JvmPool
+                    val projectDir =
+                      started.build.explodedProjects.get(testTask.project).flatMap(_.folder).map(rp => started.buildPaths.buildDir.resolve(rp.toString))
+                    // Project-level JVM options from platform config (e.g. -Djava.util.logging.manager for Quarkus)
+                    val projectJvmOptions = started.resolvedProject(testTask.project).platform match {
+                      case Some(p: ResolvedProject.Platform.Jvm) => p.options
+                      case _                                     => Nil
+                    }
+                    TestRunner.runSuite(
+                      project = testTask.project,
+                      suiteName = testTask.suiteName.value,
+                      selection = testTask.selection,
+                      classpath = classpath,
+                      pool = jvmPool,
+                      eventQueue = eventQueue,
+                      options = TestRunner.Options(
+                        // Only what someone asked for, in precedence order: the project's own options, then this run's `--jvm-opt`. The configured heap is NOT
+                        // prepended here — it goes in as the default the pool falls back to, so a fork carries exactly one `-Xmx` and it is the one that
+                        // decided the heap. See MachineResources.withHeapBound.
+                        jvmOptions = projectJvmOptions ++ testOptions.jvmOptions,
+                        defaultHeapMb = MachineResources.forkHeapMb(serverConfig.testRunnerHeap),
+                        testArgs = testOptions.testArgs,
+                        idleTimeout = idleTimeout,
+                        environment = testEnv,
+                        workingDirectory = projectDir
                       ),
-                    killSignal = taskKillSignal
-                  )
+                      resolveSourcePath = className =>
+                        bleep.analysis.ZincSourceLookup.relativeSourceForProject(
+                          bleep.analysis.AnalysisCache.Ref(analysisCache, started.buildPaths.workspaceKey),
+                          started.buildPaths.variantBuildDir(testTask.project).resolve(".zinc").resolve("analysis.zip"),
+                          className
+                        ),
+                      killSignal = taskKillSignal
+                    )
+                }
               }
-            }
 
           // Link handler for non-JVM platforms (Scala.js, Scala Native, Kotlin/JS, Kotlin/Native)
           val linkHandler: (TaskDag.LinkTask, Deferred[IO, KillReason]) => IO[(TaskDag.TaskResult, TaskDag.LinkResult)] =
@@ -2632,7 +2630,7 @@ class MultiWorkspaceBspServer(
                 val outputDir = projectPaths.targetDir
                 withLinkMetrics(linkTask, started.buildPaths.buildDir.toString) {
                   LinkExecutor.execute(linkTask, classpath.map(_.toAbsolutePath), None, outputDir, logger, killSignal)
-                }.flatTap { case (_, linkResult) => IO(linkResults.put(linkTask.project, linkResult)).void }
+                }
               }
 
           val apHandler = makeAnnotationProcessorHandler(started, params.originId, apResults)
@@ -3470,7 +3468,7 @@ class MultiWorkspaceBspServer(
       testTask: TaskDag.TestSuiteTask,
       classpath: List[Path],
       testEnv: Map[String, String],
-      linkResults: java.util.concurrent.ConcurrentHashMap[CrossProjectName, TaskDag.LinkResult],
+      linkResult: Option[TaskDag.LinkResult],
       eventQueue: Queue[IO, Option[TaskDag.DagEvent]],
       killSignal: Deferred[IO, KillReason]
   ): IO[TaskDag.TaskResult] = {
@@ -3485,14 +3483,14 @@ class MultiWorkspaceBspServer(
       startTs <- IO.realTime.map(_.toMillis)
       lastActivityAt <- IO.monotonic.flatMap(Ref.of[IO, FiniteDuration])
       // Note: TaskStarted is already emitted by DAG executor - don't duplicate it here
-      taskResult <- linkResults.get(testTask.project) match {
+      taskResult <- linkResult match {
         // Taken from the link the DAG already ran, rather than linking again here.
         //
         // This used to run its own `LinkExecutor.execute` into a second output directory, once per suite. The work is identical every time and the DAG has
         // already done it — `TaskDag` puts a LinkTask between compile and discover for exactly this reason — so an N-suite project paid for N linear links of
         // the whole program. Worse, it was billed to the suites: linking happened inside each suite's own runtime, where it counted against the idle timeout
         // that is supposed to be measuring a hung test.
-        case TaskDag.LinkResult.JsSuccess(mainModule, _, _, _) =>
+        case Some(TaskDag.LinkResult.JsSuccess(mainModule, _, _, _)) =>
           // Run the specific test suite via Node.js
           val nodeBinary = nodeBinaryFor(started, project)
           boundPlatformRun(lastActivityAt, killSignal) {
@@ -3538,7 +3536,7 @@ class MultiWorkspaceBspServer(
           val endTs = System.currentTimeMillis()
           val durationMs = endTs - startTs
           val failure = TaskDag.TaskResult.Failure(
-            s"no Scala.js link output for ${testTask.project.value}: expected the DAG's link to have produced one, got ${Option(other).getOrElse("nothing")}",
+            s"no Scala.js link output for ${testTask.project.value}: expected the DAG's link to have produced one, got ${other.getOrElse("nothing")}",
             Nil
           )
           eventQueue.offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, erroredOutcomeOf(failure), durationMs, endTs))).void >>
@@ -3553,7 +3551,7 @@ class MultiWorkspaceBspServer(
       testTask: TaskDag.TestSuiteTask,
       classpath: List[Path],
       testEnv: Map[String, String],
-      linkResults: java.util.concurrent.ConcurrentHashMap[CrossProjectName, TaskDag.LinkResult],
+      linkResult: Option[TaskDag.LinkResult],
       eventQueue: Queue[IO, Option[TaskDag.DagEvent]],
       killSignal: Deferred[IO, KillReason]
   ): IO[TaskDag.TaskResult] = {
@@ -3568,13 +3566,13 @@ class MultiWorkspaceBspServer(
       startTs <- IO.realTime.map(_.toMillis)
       lastActivityAt <- IO.monotonic.flatMap(Ref.of[IO, FiniteDuration])
       // Note: TaskStarted is already emitted by DAG executor - don't duplicate it here
-      taskResult <- linkResults.get(testTask.project) match {
+      taskResult <- linkResult match {
         // The binary the DAG's link wrote, rather than one linked here.
         //
         // This used to link its own, once per suite, and every suite computed the same output path — so a three-suite project linked four times and the last
         // three raced each other for one file. The DAG's link is not merely equivalent, it is identical: `LinkExecutor` resolves an absent main class to
         // `ScalaNativeTestRunner.TestMainClass` when the task is a test, which is the same constant `getTestMainClass` returns for every framework.
-        case TaskDag.LinkResult.NativeSuccess(binary, _) =>
+        case Some(TaskDag.LinkResult.NativeSuccess(binary, _)) =>
           boundPlatformRun(lastActivityAt, killSignal) {
             Dispatcher.sequential[IO].use { dispatcher =>
               val eventHandler = makeTestEventHandler(dispatcher, eventQueue, testTask.project, lastActivityAt)
@@ -3637,7 +3635,7 @@ class MultiWorkspaceBspServer(
           val endTs = System.currentTimeMillis()
           val durationMs = endTs - startTs
           val message =
-            s"no Scala Native binary for ${testTask.project.value}: expected the DAG's link to have produced one, got ${Option(other).getOrElse("nothing")}"
+            s"no Scala Native binary for ${testTask.project.value}: expected the DAG's link to have produced one, got ${other.getOrElse("nothing")}"
           eventQueue
             .offer(Some(TaskDag.DagEvent.SuiteFinished(testTask.project, testTask.suiteName, SuiteOutcome.Errored(message, None), durationMs, endTs)))
             .void >>

--- a/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
+++ b/bleep-bsp/src/scala/bleep/bsp/TaskDag.scala
@@ -873,7 +873,13 @@ object TaskDag {
       compile: (CompileTask, Deferred[IO, KillReason]) => IO[TaskResult],
       link: (LinkTask, Deferred[IO, KillReason]) => IO[(TaskResult, LinkResult)],
       discover: (DiscoverTask, Deferred[IO, KillReason]) => IO[(TaskResult, DiscoveryResult)],
-      test: (TestSuiteTask, Deferred[IO, KillReason]) => IO[TaskResult],
+      /** The second argument is what this project's link produced, taken from the executor's own record.
+        *
+        * Handed over rather than looked up, because a test path that has to find the linker's output itself will find it by rebuilding the path — and two
+        * derivations of one directory drift. Both platform paths did exactly that, from `classes.getParent` where the link used `targetDir`: the same directory
+        * by different arithmetic, with nothing keeping them equal. `None` for a JVM project, which links nothing.
+        */
+      test: (TestSuiteTask, Option[LinkResult], Deferred[IO, KillReason]) => IO[TaskResult],
       sourcegen: (SourcegenTask, Deferred[IO, KillReason]) => IO[TaskResult],
       annotationProcessor: (ResolveAnnotationProcessorsTask, Deferred[IO, KillReason]) => IO[(TaskResult, Int)],
       symbolProcessor: (RunSymbolProcessorsTask, Deferred[IO, KillReason]) => IO[(TaskResult, Int)],
@@ -1106,7 +1112,10 @@ object TaskDag {
                     // entirely. Previously this branch wrapped the whole thing in IO.uncancelable
                     // "so status events always fire", but that meant a wedged test framework
                     // could pin the BSP fiber indefinitely and block server shutdown.
-                    withRecovery(s"Test ${tt.suiteName.value}", taskKill)(handlers.test(tt, taskKill))
+                    dagRef.get.flatMap { dag =>
+                      val linkResult = dag.linkResults.get(TaskId.Link(tt.project))
+                      withRecovery(s"Test ${tt.suiteName.value}", taskKill)(handlers.test(tt, linkResult, taskKill))
+                    }
 
                   // These three emit their own Started/Finished pair, and the Finished carries the
                   // error message. Recovery therefore wraps ONLY the handler call, with the emit

--- a/bleep-cli/src/scala/bleep/Main.scala
+++ b/bleep-cli/src/scala/bleep/Main.scala
@@ -490,9 +490,13 @@ object Main {
 
     val optimizeOpt: Opts[Option[Boolean]] =
       Opts
-        .flag("optimize", "run the platform optimizer/DCE (Scala Native, Kotlin/JS, Kotlin/Native; Scala.js runs it already)")
+        .flag("optimize", "run the platform optimizer/DCE (Scala.js, Scala Native, Kotlin/JS, Kotlin/Native); on by default with --release")
         .map(_ => true)
-        .orElse(Opts.flag("no-optimize", "skip the platform optimizer/DCE (not allowed with --release on Scala.js)").map(_ => false))
+        .orElse(
+          Opts
+            .flag("no-optimize", "skip the platform optimizer/DCE; it is already off without --release (not allowed with --release on Scala.js)")
+            .map(_ => false)
+        )
         .orNone
 
     val debugInfoOpt: Opts[Option[Boolean]] =

--- a/bleep-core/src/scala/bleep/BleepExecutable.scala
+++ b/bleep-core/src/scala/bleep/BleepExecutable.scala
@@ -13,6 +13,21 @@ sealed trait BleepExecutable {
   def command: Path
   def args: List[String]
   def whole: List[String] = command.toString +: args
+
+  /** This bleep as a single path, for the callers that can only hold one — or a refusal, for the ones where that would be a lie.
+    *
+    * Only a [[BleepExecutable.Binary]] can honestly answer. The JVM forms are `java` plus `-cp <classpath> bleep.Main`, and their `command` is the *java*
+    * binary: handing that out on its own produces something that runs, does nothing resembling bleep, and reports no error — `java compile` is not a failed
+    * bleep invocation, it is a different program being asked for a class named `compile`. Prefer [[whole]], which is always the real invocation.
+    */
+  def asSinglePath: Path = this match {
+    case binary: BleepExecutable.Binary => binary.command
+    case other                          =>
+      throw new BleepException.Text(
+        s"this bleep runs as `${other.whole.mkString(" ")}`, so it cannot be named by a single path. Use the whole command instead — " +
+          "`bleepCommand()` from a script, `whole` from bleep itself."
+      )
+  }
 }
 
 object BleepExecutable {

--- a/bleep-core/src/scala/bleep/BleepExecutable.scala
+++ b/bleep-core/src/scala/bleep/BleepExecutable.scala
@@ -31,22 +31,34 @@ object BleepExecutable {
 
   def getCommand(resolver: CoursierResolver, pre: Prebootstrapped, forceJvm: Boolean): BleepExecutable =
     findCurrentBleep(pre.logger).getOrElse {
-      val latestRelease = model.BleepVersion.current.latestRelease
+      // The version we are, not the last release we descend from.
+      //
+      // This used to ask for `BleepVersion.current.latestRelease`, which drops the `+<n>-<sha>-SNAPSHOT` suffix — so a snapshot bleep handed out a *stable*
+      // bleep as its own relaunch command. That is not a smaller version of the right answer, it is the wrong one: what `getCommand` returns is written into
+      // launch configuration that outlives the session (`SetupIde` puts it in the BSP connection file, `SetupMcpServer` in the MCP command), so an IDE would go
+      // on starting a bleep that disagrees with both the build's `$version` and the jars published beside it. Client, server and test-runner must be one
+      // version; this is one of the places that decides.
+      //
+      // Asking for `current` also reaches the snapshot handling that already exists for it: [[FetchBleepRelease]] routes development versions to
+      // [[FetchBleepSnapshot]] — its own comment names this caller as a beneficiary, which it could not be while the suffix was being stripped here first.
+      // Where that cannot deliver, [[fetchBinaryOrLastPublished]] says so and takes the release instead, rather than leaving the caller with nothing.
+      val wanted = model.BleepVersion.current
       OsArch.current match {
         case image: OsArch.HasNativeImage if !forceJvm =>
-          pre.logger.warn(s"couldn't determine name of current Bleep executable. Setting up version ${latestRelease.value}")
-          val bin = FetchBleepRelease(latestRelease, pre.cacheLogger, pre.ec, image).orThrow
-          DownloadedBinary(bin)
+          pre.logger.warn(s"couldn't determine name of current Bleep executable. Setting up version ${wanted.value}")
+          DownloadedBinary(fetchBinaryOrLastPublished(wanted, pre, image))
         case other =>
           if (forceJvm) pre.logger.info(s"Setting up Bleep through a JVM as requested")
           else pre.logger.warn(s"There is no published graalvm native-image for $other. Setting up Bleep through a JVM")
 
-          val bleepCliDep = model.Dep.ScalaDependency(Organization("build.bleep"), ModuleName("bleep-cli"), latestRelease.value, fullCrossVersion = false)
+          // A locally published snapshot resolves from `~/.ivy2/local`, which `DefaultRepos` searches ahead of Maven Central, so this path needs no network
+          // when the jars were published beside the binary.
+          val bleepCliDep = model.Dep.ScalaDependency(Organization("build.bleep"), ModuleName("bleep-cli"), wanted.value, fullCrossVersion = false)
           val resolvedBleep = resolver.force(
             Set(bleepCliDep),
             model.VersionCombo.Jvm(model.VersionScala.Scala213),
             libraryVersionSchemes = SortedSet.empty,
-            context = s"resolving bleep ${latestRelease.value} from maven central",
+            context = s"resolving bleep ${wanted.value}",
             model.IgnoreEvictionErrors.No
           )
 
@@ -55,6 +67,31 @@ object BleepExecutable {
             jvmRunCommand.cmdArgs(jvmOptions = Nil, cp = resolvedBleep.jars, main = BleepMain, args = Nil)
           )
       }
+    }
+
+  /** The bleep we are, if it can be had — otherwise the release it descends from, said out loud.
+    *
+    * For a release there is nothing to fall back from: the download URL is built from the version. A *snapshot* is different in kind. It lives in the artifacts
+    * of its CI run, which need a token and expire after a week, so on a machine that has neither there is no way to produce this exact bleep, and no amount of
+    * correctness in the version we ask for changes that.
+    *
+    * Degrading rather than failing is a judgement about who is asking. `bleepscript.Started.bleepExecutable` hands this to a user's script so it can invoke
+    * bleep again, and a script that cannot run bleep at all is worse off than one running the previous release. So this is deliberately not the usual
+    * fail-loudly: it is fail-loudly-then-continue, and the warning names both versions because they are not interchangeable — anything version-sensitive the
+    * script goes on to do will happen under the release, not under this snapshot.
+    */
+  private def fetchBinaryOrLastPublished(wanted: model.BleepVersion, pre: Prebootstrapped, image: OsArch.HasNativeImage): Path =
+    FetchBleepRelease(wanted, pre.cacheLogger, pre.ec, image) match {
+      case Right(bin) => bin
+      // Only a snapshot has somewhere to fall back to. For a release `latestRelease` is the same version, so retrying would just fail the same way twice.
+      case Left(err) if wanted.isDevelopment =>
+        val published = wanted.latestRelease
+        pre.logger.warn(s"couldn't fetch bleep ${wanted.value}: ${err.getMessage}")
+        pre.logger.warn(
+          s"falling back to ${published.value}, the last release ${wanted.value} descends from. Whatever runs this bleep will run that version, not the one you are on."
+        )
+        FetchBleepRelease(published, pre.cacheLogger, pre.ec, image).orThrow
+      case Left(err) => throw err
     }
 
   def findCurrentBleep(logger: Logger): Option[BleepExecutable] = {

--- a/bleep-core/src/scala/bleep/ResolveProjects.scala
+++ b/bleep-core/src/scala/bleep/ResolveProjects.scala
@@ -25,6 +25,15 @@ trait ResolveProjects {
 object ResolveProjects {
   type Projects = SortedMap[model.CrossProjectName, Lazy[ResolvedProject]]
 
+  /** Maven's rule, in one place because it is needed in two: `provided` and `optional` do not travel to a consumer. A project that needs one says so itself.
+    *
+    * Load-bearing for `bleep-test-runner`, which declares a `provided` junit-platform-launcher pinned to the oldest platform bleep can run. That floor belongs
+    * on its own compile classpath and nowhere else — anything that inherits it inherits a junit-platform far older than the project's own, and bleep pairs the
+    * junit engines to whatever platform version a project resolved.
+    */
+  private[bleep] def providedOrOptional(dep: model.Dep): Boolean =
+    dep.configuration == Configuration.provided || dep.configuration == Configuration.optional
+
   case class Result(build: model.Build, projects: Projects, bspServerClasspathSource: bsp.BspServerClasspathSource)
 
   object InMemory extends ResolveProjects {
@@ -80,9 +89,16 @@ object ResolveProjects {
 
           if (transitiveBleepProjectNames.nonEmpty) b(crossName) = transitiveBleepProjectNames
 
+          // `provided`/`optional` are dropped here for the same reason they are dropped from `inherited` below, and it has to be said twice because these
+          // arrive by a different route: a bleep project's dependencies are copied into the consumer's OWN set, where the inherited-dep filter never sees
+          // them — and where the runtime branch would go on to promote them out of `provided` entirely.
+          //
+          // What that cost: an integration-test workspace depending on `build.bleep:bleep-test-runner` acquired its `provided` junit-platform floor, 1.0.0,
+          // as an ordinary dependency. `testRuntimeRules` then read that as the junit-platform the project resolved and asked for the engine that pairs with
+          // it — junit-vintage-engine 5.0.0, which does not exist — so the run died in resolution naming a version nobody had written down anywhere.
           val newDeps: SortedSet[model.Dep] =
             restDependencies ++ transitiveBleepProjectNames.view.flatMap(pn =>
-              bleepBuild.forceGet.build.explodedProjects(pn).dependencies.values.filterNot(isBleepDep)
+              bleepBuild.forceGet.build.explodedProjects(pn).dependencies.values.filterNot(dep => isBleepDep(dep) || providedOrOptional(dep))
             )
 
           (crossName, p.copy(dependencies = model.JsonSet(newDeps)))
@@ -284,9 +300,6 @@ object ResolveProjects {
 
       val inherited =
         build.transitiveDependenciesFor(crossName).flatMap { case (_, p) => p.dependencies.values }
-
-      def providedOrOptional(dep: model.Dep): Boolean =
-        dep.configuration == Configuration.provided || dep.configuration == Configuration.optional
 
       // Inherited `provided`/`optional` deps are dropped from BOTH classpaths, which is Maven's rule: those scopes do not travel to a consumer. A project that
       // needs one says so itself. Deliberate, and load-bearing — `bleep-test-runner` declares a `provided` junit-platform-launcher precisely so that

--- a/bleep-core/src/scala/bleep/javaapi/JStarted.scala
+++ b/bleep-core/src/scala/bleep/javaapi/JStarted.scala
@@ -37,5 +37,9 @@ final class JStarted(private[javaapi] val underlying: Started) extends bleepscri
   override def resolved(cross: bleepscript.CrossProjectName): bleepscript.ResolvedProject =
     JModel.resolvedProject(underlying.resolvedProject(JModel.toCross(cross)))
 
-  override def bleepExecutable(): Path = underlying.bleepExecutable.forceGet.command
+  override def bleepCommand(): java.util.List[String] = underlying.bleepExecutable.forceGet.whole.asJava
+
+  // `.command` used to be handed out here directly, which for a JVM-launched bleep is the path to `java` with `-cp <classpath> bleep.Main` dropped — a script
+  // asking how to run bleep got something that runs and is not bleep. `asSinglePath` says so instead.
+  override def bleepExecutable(): Path = underlying.bleepExecutable.forceGet.asSinglePath
 }

--- a/bleep-core/src/scala/bleep/testing/JvmPool.scala
+++ b/bleep-core/src/scala/bleep/testing/JvmPool.scala
@@ -7,10 +7,11 @@ import cats.syntax.all._
 import fs2.Stream
 
 import java.io._
-import java.net.{InetAddress, ServerSocket}
+import java.net.{InetAddress, ServerSocket, Socket, SocketTimeoutException}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration._
 import scala.util.Properties
@@ -94,11 +95,21 @@ object JvmPool {
 
   /** How long a freshly spawned fork gets to connect back on the protocol socket.
     *
-    * Generous, because it covers JVM startup on a cold, loaded CI runner, and bounded, because a fork that never connects would otherwise hang the suite with
-    * no diagnostics — the failure it usually indicates (bad JVM options, a test-runner jar the project's JVM cannot load) is one the child reports on its own
-    * stderr, which the spawn failure surfaces.
+    * Generous, because it covers JVM startup on a cold, loaded CI runner, and bounded, because a fork that never connects would otherwise hang the suite
+    * forever. What the timeout means depends on the fork's state when it fires, so the spawn failure reports that state rather than the bare timeout: a fork
+    * that has already exited hit a startup failure it described on its own stderr, while a fork still running never intended to connect at all.
     */
   private val ProtocolConnectTimeout: FiniteDuration = 60.seconds
+
+  /** Cap on how much of a failed fork's output is quoted back. Enough for a JVM startup error, which is the only thing a fork that never connected can have had
+    * time to write, and short enough that a fork which died mid-flood does not bury the message reporting it.
+    */
+  private val MaxChildOutputBytes: Int = 4096
+
+  /** How often the wait for a connect-back looks up to check whether the fork is still alive. Short enough that a fork dying on startup is reported at once,
+    * long enough that the check costs nothing next to [[ProtocolConnectTimeout]].
+    */
+  private val ProtocolPollInterval: FiniteDuration = 250.millis
 
   /** Create a new JVM pool with the given maximum concurrency.
     *
@@ -578,6 +589,74 @@ object JvmPool {
         }
       } yield jvm
 
+    /** Whatever the fork wrote before it stopped, read without ever blocking.
+      *
+      * Only bytes already sitting in the pipe are taken, and only up to [[MaxChildOutputBytes]]. Nothing is draining these streams at this point — the reader
+      * threads belong to `ManagedJvm`, which does not exist yet on this path — so a blocking read here would hang the very code whose job is to report a hang.
+      */
+    private def describeChildOutput(process: Process): String = {
+      val quoted =
+        List("stderr" -> drainAvailable(process.getErrorStream), "stdout" -> drainAvailable(process.getInputStream))
+          .collect { case (name, text) if text.trim.nonEmpty => s"\n  $name: ${text.trim}" }
+      if (quoted.isEmpty) " The fork wrote no output." else quoted.mkString
+    }
+
+    private def drainAvailable(stream: InputStream): String = {
+      val collected = new ByteArrayOutputStream
+      val buf = new Array[Byte](8192)
+      var more = true
+      while (more && collected.size < MaxChildOutputBytes) {
+        val ready = stream.available()
+        if (ready <= 0) more = false
+        else {
+          val n = stream.read(buf, 0, math.min(buf.length, math.min(ready, MaxChildOutputBytes - collected.size)))
+          if (n <= 0) more = false else collected.write(buf, 0, n)
+        }
+      }
+      new String(collected.toByteArray, StandardCharsets.UTF_8)
+    }
+
+    /** Wait for a freshly spawned fork to connect back, giving up the moment that becomes impossible rather than always serving the full sentence.
+      *
+      * Polled instead of one long `accept`, because the answer is usually available long before the deadline: a fork that died during JVM startup is never
+      * going to connect, and blocking on a process that no longer exists turned a fast, fully explained failure into a minutes-long stall — 32 suites of it, in
+      * the report that prompted this.
+      *
+      * What the give-up means depends entirely on the fork's state, which is why both branches say so. A fork that exited hit a startup failure and described
+      * it on its own stderr. A fork still running never intended to connect: that is what a protocol mismatch looks like, and the case that actually happened
+      * was a `bleep-test-runner` from the project's own dependencies shadowing the server's and waiting for orders on stdin. The two need opposite fixes and
+      * the bare "Accept timed out" they used to share told them apart not at all — it read as a slow machine, which neither of them is.
+      */
+    private def awaitProtocolConnection(listener: ServerSocket, process: Process, port: Int): Socket = {
+      val deadlineNanos = System.nanoTime() + ProtocolConnectTimeout.toNanos
+      listener.setSoTimeout(ProtocolPollInterval.toMillis.toInt)
+
+      def giveUp(reason: String): Nothing = {
+        // Read what the fork wrote before killing it. `destroyForcibly` closes these pipes as the process is reaped, and a read landing on the far side of
+        // that comes back "Stream closed", replacing the diagnosis this exists to produce.
+        val childOutput = describeChildOutput(process)
+        if (process.isAlive) {
+          process.destroyForcibly(): Unit
+          process.waitFor(5, TimeUnit.SECONDS): Unit
+        }
+        throw new IOException(s"Test JVM did not connect back on port $port: $reason.$childOutput")
+      }
+
+      var connected: Socket = null
+      while (connected == null)
+        try connected = listener.accept()
+        catch {
+          case _: SocketTimeoutException =>
+            if (!process.isAlive) giveUp(s"the fork exited with code ${process.exitValue()} without ever connecting")
+            else if (System.nanoTime() >= deadlineNanos)
+              giveUp(
+                s"the fork was still running $ProtocolConnectTimeout later and had not connected, so it is not speaking this server's protocol — check " +
+                  "whether another bleep-test-runner is shadowing the one bleep puts on the test classpath"
+              )
+        }
+      connected
+    }
+
     private def spawnJvm(
         label: String,
         key: JvmKey,
@@ -650,18 +729,11 @@ object JvmPool {
                   }
 
                 val protocolSocket =
-                  try {
-                    // A fork that never connects is a fork that will never answer. Bounded so a JVM that dies on startup (bad -Xmx, missing class) surfaces as
-                    // a spawn failure with the child's own stderr, rather than hanging the suite.
-                    protocolListener.setSoTimeout(ProtocolConnectTimeout.toMillis.toInt)
-                    protocolListener.accept()
-                  } catch {
+                  try awaitProtocolConnection(protocolListener, process, protocolPort)
+                  catch {
                     case e: Throwable =>
-                      process.destroyForcibly(): Unit
-                      throw new IOException(
-                        s"Test JVM did not connect back on port $protocolPort within $ProtocolConnectTimeout: ${e.getMessage}",
-                        e
-                      )
+                      if (process.isAlive) process.destroyForcibly(): Unit
+                      throw e
                   } finally protocolListener.close()
                 protocolSocket.setTcpNoDelay(true)
 

--- a/bleep-model/src/scala/bleep/model/Replacements.scala
+++ b/bleep-model/src/scala/bleep/model/Replacements.scala
@@ -177,9 +177,19 @@ object Replacements {
       ).flatten
     )
 
-  // note: bleepVersion may not be the running version in the case of `--dev`
-  // where the version found in the build is used instead.
-  // this is so that bleep-task dependencies can be resolved.
+  /** `bleepVersion` is what `${BLEEP_VERSION}` expands to, and it is always the build's own `$version` — never the version of the bleep doing the expanding.
+    * Both call sites pass it: `ResolveProjects` and `CoursierResolver.TemplatedVersions`.
+    *
+    * The distinction is invisible almost everywhere, because the CLI relaunches itself into the version a build asks for, so the two are the same value. They
+    * come apart only where that relaunch is deliberately waived — a snapshot binary, or `--dev` — and there the build's declaration is the one that wins.
+    *
+    * That is on purpose rather than an oversight. A build's scripts are compiled against the API of the bleep they name, so following the running bleep instead
+    * would break them on one machine, with an error pointing at the user's code rather than at the substitution. It is also what lets bleep build itself: its
+    * own `scripts` and `scripts-init` resolve published `build.bleep::*` artifacts through this template, and an in-tree edge would be circular.
+    *
+    * The cost is that a snapshot bleep can pair a build's older bleep libraries with a newer server. Only one thing has ever cared — a forked test JVM, where
+    * the project's `bleep-test-runner` and the server's meet on one classpath — and `getTestClasspath` settles that by ordering rather than by version.
+    */
   def versions(
       bleepVersion: Option[BleepVersion],
       versionCombo: VersionCombo,

--- a/bleep-tests/src/scala/bleep/BleepDepProvidedScopeIT.scala
+++ b/bleep-tests/src/scala/bleep/BleepDepProvidedScopeIT.scala
@@ -1,0 +1,57 @@
+package bleep
+
+/** A build may depend on bleep itself, and in an integration-test workspace those `build.bleep:*` deps are rewritten to bleep's own projects so the tests
+  * exercise the bleep being built rather than a published one. That rewrite copies each bleep project's dependencies into the consumer's own set — and it used
+  * to copy `provided` ones too, which Maven's rule says never travel to a consumer.
+  *
+  * `bleep-test-runner` is where that bites. It declares `provided org.junit.platform:junit-platform-launcher:1.0.0`, deliberately pinned to the oldest platform
+  * bleep can run, so the runner compiles against a floor and executes against whatever the project resolved. Copied into a consumer, that floor stops being a
+  * compile-time detail and becomes the junit-platform the project appears to have resolved — and `testRuntimeRules` pairs the junit engines to exactly that
+  * version. The workspace then asked for `junit-vintage-engine:5.0.0`, which has never existed, and the run died in resolution naming a version nobody wrote.
+  */
+class BleepDepProvidedScopeIT extends IntegrationTestHarness {
+
+  private val mytest = model.CrossProjectName(model.ProjectName("mytest"), None)
+
+  integrationTest("a bleep dependency does not bring its provided deps with it") { ws =>
+    ws.yaml(
+      """projects:
+        |  mytest:
+        |    dependencies:
+        |      - org.scalatest::scalatest:3.2.15
+        |      - build.bleep:bleep-test-runner:1.0.0-M11
+        |    isTestProject: true
+        |    platform:
+        |      name: jvm
+        |    scala:
+        |      version: 3.3.3
+        |""".stripMargin
+    )
+    ws.file(
+      "mytest/src/scala/T.scala",
+      """package example
+        |
+        |import org.scalatest.funsuite.AnyFunSuite
+        |
+        |class T extends AnyFunSuite {
+        |  test("runs despite depending on bleep") {
+        |    assert(1 + 1 == 2)
+        |  }
+        |}
+        |""".stripMargin
+    )
+    val (started, commands, storingLogger) = ws.start()
+
+    // Asserted on the classpath rather than only on the run succeeding, because this is a statement about what a dependency drags along. The floor is what to
+    // look for: any `org.junit.platform` here should be the project's own, and this project declares none.
+    val floor = started.resolvedProject(mytest).classpath.map(_.toString).filter(_.contains("junit-platform")).toList
+    assert(
+      floor.isEmpty,
+      s"bleep-test-runner's provided junit-platform floor reached a consumer's classpath:\n${floor.mkString("\n")}"
+    )
+
+    // And the run itself, since the version that floor produced was rejected during resolution — before any suite could start.
+    commands.test(projects = List(mytest), watch = false, only = None, exclude = None, includeTags = None, excludeTags = None)
+    assertSuitePassed(storingLogger, "example.T", tests = 1)
+  }
+}

--- a/bleep-tests/src/scala/bleep/BleepExecutableTest.scala
+++ b/bleep-tests/src/scala/bleep/BleepExecutableTest.scala
@@ -1,0 +1,58 @@
+package bleep
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Path
+
+/** How bleep describes its own invocation to whoever asks — `bleepscript.Started` hands this to user scripts so they can run bleep again.
+  *
+  * There are two shapes and they are not interchangeable. A native-image bleep is one path. A bleep on a JVM is `java -cp <classpath> bleep.Main`, several
+  * elements of which the first is `java`. The script API used to return `command` for both, so in the second case a script asking how to run bleep received the
+  * path to `java` with the arguments that make it bleep silently discarded — and `java compile` is not a bleep invocation that fails, it is a different program
+  * being asked for a class named `compile`.
+  */
+class BleepExecutableTest extends AnyFunSuite with Matchers {
+
+  private val bin = Path.of("/usr/local/bin/bleep")
+  private val java = Path.of("/opt/jvm/bin/java")
+  private val javaArgs = List("-Xmx2g", "-cp", "/a/bleep-cli.jar:/b/bleep-core.jar", "bleep.Main")
+
+  test("a binary is its own whole invocation, and can be named by one path") {
+    BleepExecutable.CurrentBinary(bin).whole shouldBe List(bin.toString)
+    BleepExecutable.CurrentBinary(bin).asSinglePath shouldBe bin
+    BleepExecutable.DownloadedBinary(bin).whole shouldBe List(bin.toString)
+    BleepExecutable.DownloadedBinary(bin).asSinglePath shouldBe bin
+  }
+
+  test("a JVM bleep keeps the arguments that make it bleep") {
+    // The regression this guards: everything after the java path is what distinguishes bleep from any other JVM program, so dropping it does not degrade the
+    // answer, it changes which program the caller runs.
+    BleepExecutable.CurrentJava(java, javaArgs).whole shouldBe (java.toString :: javaArgs)
+    BleepExecutable.DownloadedJava(java, javaArgs).whole shouldBe (java.toString :: javaArgs)
+  }
+
+  test("a JVM bleep refuses to be named by a single path, rather than answering with the java binary") {
+    List(BleepExecutable.CurrentJava(java, javaArgs), BleepExecutable.DownloadedJava(java, javaArgs)).foreach { exe =>
+      val thrown = intercept[BleepException.Text](exe.asSinglePath)
+      // The message has to carry the real invocation: a caller that cannot use one path needs to see what to use instead.
+      withClue(thrown.getMessage)(thrown.getMessage should include("bleep.Main"))
+      withClue(thrown.getMessage)(thrown.getMessage should include(java.toString))
+      // And it must not quietly be the java path, which is the shape of the bug.
+      withClue(thrown.getMessage)(thrown.getMessage should not be java.toString)
+    }
+  }
+
+  test("every case answers `whole`, so the script API always has something runnable to offer") {
+    // `asSinglePath` is allowed to refuse; `whole` never is. If a new case ever gets added, this is where a missing invocation shows up.
+    val all: List[BleepExecutable] = List(
+      BleepExecutable.CurrentBinary(bin),
+      BleepExecutable.DownloadedBinary(bin),
+      BleepExecutable.InheritedBinary(bin),
+      BleepExecutable.CurrentJava(java, javaArgs),
+      BleepExecutable.DownloadedJava(java, javaArgs)
+    )
+    all.foreach(exe => withClue(exe.toString)(exe.whole should not be empty))
+    all.foreach(exe => withClue(exe.toString)(exe.whole.head shouldBe exe.command.toString))
+  }
+}

--- a/bleep-tests/src/scala/bleep/FetchBleepSnapshotTest.scala
+++ b/bleep-tests/src/scala/bleep/FetchBleepSnapshotTest.scala
@@ -67,4 +67,18 @@ class FetchBleepSnapshotTest extends AnyFunSuite with Matchers {
     actual.collect { case Left(err) => err } shouldBe empty
     actual.collect { case Right(name) => name }.toSet shouldBe expected
   }
+
+  test("latestRelease is a different bleep — the last resort, never the first choice") {
+    // Both halves of how `BleepExecutable` treats it. For a snapshot the two are different *published* versions, so asking for `latestRelease` up front gets a
+    // real bleep that is simply not this one — which is what made the old behaviour quiet, since nothing downstream can tell an ordinary release from the one
+    // that was wanted. It is still what we fall back to when the snapshot cannot be fetched at all, but only after saying so.
+    val snapshot = model.BleepVersion("1.0.0-M12+119-d9303c0a-SNAPSHOT")
+    snapshot.latestRelease shouldBe model.BleepVersion("1.0.0-M12")
+    snapshot.latestRelease should not be snapshot
+    snapshot.latestRelease.isDevelopment shouldBe false
+
+    // And why the fallback is guarded on `isDevelopment`: for a release the two coincide, so retrying with it would fail the same way a second time.
+    val release = model.BleepVersion("1.0.0-M12")
+    release.latestRelease shouldBe release
+  }
 }

--- a/bleep-tests/src/scala/bleep/ScalaNativeSharedBinaryIT.scala
+++ b/bleep-tests/src/scala/bleep/ScalaNativeSharedBinaryIT.scala
@@ -1,0 +1,60 @@
+package bleep
+
+import java.nio.file.Files
+
+/** A Scala Native test project links once, for the project, and every suite runs the binary the linker produced.
+  *
+  * It used to link once per suite, on top of the link the dependency graph had already run — so a three-suite project linked four times. Worse than wasteful:
+  * every suite computed the same output path, so the three suite links wrote one file, concurrently, while suites were starting to execute it.
+  *
+  * Nothing tied the two computations together. The graph's link resolved its output under `targetDir` while the suite path rebuilt a path of its own from
+  * `classes.getParent` — which is the same directory, reached by different arithmetic, and neither knew about the other.
+  */
+class ScalaNativeSharedBinaryIT extends IntegrationTestHarness {
+
+  private val mytest = model.CrossProjectName(model.ProjectName("mytest"), None)
+
+  private def suite(n: Int): String =
+    s"""package example
+       |
+       |class Suite$n extends munit.FunSuite {
+       |  test("suite $n runs") {
+       |    assertEquals(1 + $n, ${1 + n})
+       |  }
+       |}
+       |""".stripMargin
+
+  integrationTest("every suite runs the one binary the project's link produced") { ws =>
+    ws.yaml(
+      s"""projects:
+         |  mytest:
+         |    dependencies: org.scalameta::munit:1.0.4
+         |    isTestProject: true
+         |    platform:
+         |      name: native
+         |      nativeVersion: ${model.Versions.ScalaNative05}
+         |      nativeGc: immix
+         |      nativeLto: none
+         |      nativeMode: debug
+         |    scala:
+         |      version: ${model.Versions.Scala3}
+         |""".stripMargin
+    )
+    // Three, because one suite cannot show the defect: the damage was suites racing each other for a single file.
+    (1 to 3).foreach(n => ws.file(s"mytest/src/scala/Suite$n.scala", suite(n)))
+    val (started, commands, storingLogger) = ws.start()
+
+    commands.test(projects = List(mytest), watch = false, only = None, exclude = None, includeTags = None, excludeTags = None)
+
+    (1 to 3).foreach(n => assertSuitePassed(storingLogger, s"example.Suite$n", tests = 1))
+
+    // The binary the per-suite link used to write, at the path all three suites computed for themselves. Asserted on rather than counting links, because the
+    // count is not observable from here while the stray path is: if anything links per suite again, this file comes back.
+    val strayBinary = started.projectPaths(mytest).classes.getParent.resolve("link-output").resolve("mytest-test")
+    assert(
+      !Files.exists(strayBinary),
+      s"a per-suite link wrote its own binary at $strayBinary — the suites should be running the one the project's link produced"
+    )
+    succeed
+  }
+}

--- a/bleep-tests/src/scala/bleep/ShadowedTestRunnerIT.scala
+++ b/bleep-tests/src/scala/bleep/ShadowedTestRunnerIT.scala
@@ -1,0 +1,86 @@
+package bleep
+
+/** A project may legitimately depend on bleep itself — build scripts, plugins, anything pulling `build.bleep::bleep-core`. That drags a *released*
+  * `bleep-test-runner` onto the project's own classpath, alongside the one the server puts there to drive the fork.
+  *
+  * Which of the two the fork loads is decided by classpath order, and it used to be the project's: `getTestClasspath` appended the server's runner after the
+  * dependencies, so first-match-wins classloading handed the fork the released copy. The two do not speak the same protocol — a released runner reads commands
+  * from stdin, while the server waits for a connect-back on a loopback socket — so neither side ever moved and every suite in the project died on the 60-second
+  * accept timeout, having run nothing.
+  *
+  * It presented as an infrastructure fault rather than a misconfiguration, which is what made it expensive to find: the fork was alive and healthy the whole
+  * time, blocked in `readLine`, so nothing crashed and there was no stderr to explain it. It was also invisible to every existing test, because bleep's own
+  * suites never put a second `bleep-test-runner` on a test classpath.
+  *
+  * The conflicting class comes from a sibling project rather than from a real released artifact. A dependency's classes reach the fork by the same route
+  * whether they arrive as a jar or as another project's output — both land in `dependencyClasspath` — and this way the test states the collision outright
+  * instead of resolving bleep's own release to imply it, and cannot rot when those releases age out.
+  */
+class ShadowedTestRunnerIT extends IntegrationTestHarness {
+
+  private val Yaml =
+    """projects:
+      |  legacy-runner:
+      |    platform:
+      |      name: jvm
+      |    scala:
+      |      version: 3.3.3
+      |  mytest:
+      |    dependencies: org.scalatest::scalatest:3.2.15
+      |    dependsOn: legacy-runner
+      |    isTestProject: true
+      |    platform:
+      |      name: jvm
+      |    scala:
+      |      version: 3.3.3
+      |""".stripMargin
+
+  /** Stands in for a `bleep-test-runner` predating the protocol socket: it waits for orders on stdin, which this server will never send. If the fork loads this
+    * class instead of the real runner, the spawn can only end in the accept timeout — which is the whole point, and what makes the assertion below meaningful.
+    */
+  private val LegacyRunner =
+    """package bleep.testing.runner
+      |
+      |object ForkedTestRunner {
+      |  def main(args: Array[String]): Unit = {
+      |    val in = new java.io.BufferedReader(new java.io.InputStreamReader(System.in))
+      |    while (in.readLine() != null) ()
+      |    Thread.sleep(Long.MaxValue)
+      |  }
+      |}
+      |""".stripMargin
+
+  private val Source =
+    """package example
+      |
+      |import org.scalatest.funsuite.AnyFunSuite
+      |
+      |class ShadowedTest extends AnyFunSuite {
+      |  test("the suite runs even though a dependency supplies its own ForkedTestRunner") {
+      |    assert(1 + 1 == 2)
+      |  }
+      |}
+      |""".stripMargin
+
+  private val mytest = model.CrossProjectName(model.ProjectName("mytest"), None)
+
+  integrationTest("a dependency's bleep-test-runner does not shadow the server's") { ws =>
+    ws.yaml(Yaml)
+    ws.file("legacy-runner/src/scala/bleep/testing/runner/ForkedTestRunner.scala", LegacyRunner)
+    ws.file("mytest/src/scala/ShadowedTest.scala", Source)
+    val (_, commands, storingLogger) = ws.start()
+
+    commands.test(
+      projects = List(mytest),
+      watch = false,
+      only = None,
+      exclude = None,
+      includeTags = None,
+      excludeTags = None
+    )
+
+    // Asserted on a passing count rather than on `commands.test` merely not throwing: a run that discovers a suite and executes none of it is the shape this
+    // whole family of bugs takes, and only a count rules it out.
+    assertSuitePassed(storingLogger, "example.ShadowedTest", tests = 1)
+  }
+}

--- a/bleep-tests/src/scala/bleep/SpawnFailureDiagnosticsIT.scala
+++ b/bleep-tests/src/scala/bleep/SpawnFailureDiagnosticsIT.scala
@@ -1,0 +1,63 @@
+package bleep
+
+/** When a test fork never connects back, the spawn failure has to say why — and the only witness is the fork itself.
+  *
+  * The message used to be "Accept timed out" and nothing else. That reads as a slow or overloaded machine, which sends anyone debugging it towards timeouts and
+  * memory budgets, and it is the one thing the failure never is: the fork connects within milliseconds of reaching `main`, so a timeout means it did not get
+  * there. The child's exit code and stderr say what stopped it, and both were being collected by the OS and dropped on the floor.
+  *
+  * Here the fork is given a JVM option no JVM accepts, so it dies during startup having written its complaint to stderr — the same shape as a bad `-Xmx`, a
+  * missing class, or an unreadable jar. The other shape, a fork that starts fine and simply does not speak this protocol, is covered by
+  * [[ShadowedTestRunnerIT]].
+  */
+class SpawnFailureDiagnosticsIT extends IntegrationTestHarness {
+
+  private val Yaml =
+    """projects:
+      |  mytest:
+      |    dependencies: org.scalatest::scalatest:3.2.15
+      |    isTestProject: true
+      |    platform:
+      |      name: jvm
+      |      jvmOptions: -XX:+ThisFlagDoesNotExist
+      |    scala:
+      |      version: 3.3.3
+      |""".stripMargin
+
+  private val Source =
+    """package example
+      |
+      |import org.scalatest.funsuite.AnyFunSuite
+      |
+      |class DoomedTest extends AnyFunSuite {
+      |  test("never runs, because its fork cannot start") {
+      |    assert(true)
+      |  }
+      |}
+      |""".stripMargin
+
+  private val mytest = model.CrossProjectName(model.ProjectName("mytest"), None)
+
+  integrationTest("a fork that dies on startup reports its exit code and its own stderr") { ws =>
+    ws.yaml(Yaml)
+    ws.file("mytest/src/scala/DoomedTest.scala", Source)
+    val (_, commands, storingLogger) = ws.start()
+
+    intercept[BleepException] {
+      commands.test(
+        projects = List(mytest),
+        watch = false,
+        only = None,
+        exclude = None,
+        includeTags = None,
+        excludeTags = None
+      )
+    }
+
+    val log = storingLogger.underlying.iterator.map(_.message.plainText).mkString("\n")
+    assert(log.contains("without ever connecting"), s"the spawn failure did not describe the fork's fate:\n$log")
+    // The JVM's own words. Quoting them is the entire point: this is the sentence that names the actual mistake, and no amount of detail about the timeout
+    // could substitute for it.
+    assert(log.contains("Unrecognized VM option"), s"the fork's stderr was not surfaced:\n$log")
+  }
+}

--- a/bleepscript/src/main/java/bleepscript/Started.java
+++ b/bleepscript/src/main/java/bleepscript/Started.java
@@ -26,5 +26,24 @@ public interface Started {
 
   ResolvedProject resolved(CrossProjectName cross);
 
+  /**
+   * The whole command that re-invokes this bleep, ready to hand to {@link Cli}.
+   *
+   * <p>Usually one element — the bleep binary. But a bleep started on a JVM runs as {@code java -cp
+   * <classpath> bleep.Main}, and then the invocation is several elements of which the first is
+   * {@code java}. Prefer this over {@link #bleepExecutable()}, which cannot represent that case.
+   *
+   * <pre>{@code
+   * Cli.command("bleep").args(started.bleepCommand()).args("compile").run(started);
+   * }</pre>
+   */
+  List<String> bleepCommand();
+
+  /**
+   * This bleep as a single path.
+   *
+   * <p>Throws when the invocation is not a bare binary — see {@link #bleepCommand()}, which always
+   * works and is what you want unless you specifically need a file on disk.
+   */
   Path bleepExecutable();
 }

--- a/docs/reference/cli/link.mdx
+++ b/docs/reference/cli/link.mdx
@@ -34,8 +34,8 @@ bleep link <project name...> [flags]
 | `--no-minify` | disable minification (Scala.js) |
 | `--module-kind <string>` | JS module kind: commonjs, esmodule, nomodule |
 | `--lto <string>` | Link-time optimization (Scala Native): none, thin, full |
-| `--optimize` | run the platform optimizer/DCE (Scala Native, Kotlin/JS, Kotlin/Native; Scala.js runs it already) |
-| `--no-optimize` | skip the platform optimizer/DCE (not allowed with --release on Scala.js) |
+| `--optimize` | run the platform optimizer/DCE (Scala.js, Scala Native, Kotlin/JS, Kotlin/Native); on by default with --release |
+| `--no-optimize` | skip the platform optimizer/DCE; it is already off without --release (not allowed with --release on Scala.js) |
 | `--debug-info` | include debug info (native platforms) |
 | `--no-debug-info` | exclude debug info (native platforms) |
 | `--no-tui` | disable TUI, keep the full streaming trace (for CI/agents that read logs) |


### PR DESCRIPTION
Started from a bug report: test JVMs failing to spawn with

```
Test JVM did not connect back on port … within 60 seconds: Accept timed out
```

Deterministic, selective by project, and unexplained. 151 of 153 failures in a
134-project build were this. Root-causing it turned up a chain of related defects
in how bleep hands work to forked processes, which is what this PR is.

Closes #667. Closes #673.

## The spawn timeout

A project may legitimately depend on bleep — build scripts, plugins, anything
pulling `build.bleep::bleep-core`. That drags a **released** `bleep-test-runner`
onto the project's own classpath, beside the one the server puts there to drive
the fork. `getTestClasspath` appended ours *last*, so first-match-wins
classloading handed the fork the project's copy.

The two do not speak the same protocol. A released runner reads commands from
stdin; this server waits for a connect-back on a loopback socket. Neither side
ever moves, and 60 seconds later the parent kills a perfectly healthy JVM.

Evidence, rather than inference:

- `jstack` on a live hung child: `main` blocked in `BufferedReader.readLine` on
  `System.in`, inside `ForkedTestRunner.main`.
- On the failing classpath, `bleep-test-runner-1.0.0-M11.jar` sat at position
  **807** and the server's snapshot at **985**.
- That M11 jar contains zero occurrences of `bleep.test.protocolPort` and no
  `java/net/Socket`; the snapshot has both.
- Standalone, with a complete classpath, the fork connects in **0.05s** — so a
  60-second timeout never meant "slow".

It looked like it discriminated by language ("Scala projects never get a JVM,
Java ones always do"), but the real split is *depends on bleep or not*: both
failing projects reach `build.bleep::bleep-core` transitively, and the Java ones
reach nothing of the sort.

Only the runner moves ahead of the project's dependencies. Its jar contains
nothing but `bleep/testing/runner`, so it can shadow only itself. The injected
junit runtime deliberately stays where it was — those versions are chosen to
match what the project resolved, and promoting them would make the server the
arbiter of a version it follows on purpose.

**Verified end to end on the build that reported it**: `dcorpus/extract-test`
322 passed (previously 32 suites timed out, 0 tests executed, 9 minutes) and
`dparsegen/test` 3300 passed.

## Why it took so long to see

The failure was unobservable by construction. `Accept timed out` reads as a slow
or starved machine, which it never is, and the two real causes need opposite
fixes: a fork that died during startup said why on its own stderr, and a fork
still running never intended to connect at all. Both were being collected by the
OS and discarded.

The spawn failure now reports the fork's fate and quotes its output, and polls so
a dead fork is reported at once instead of 60 seconds later. One bug found while
testing that: reading the streams *after* `destroyForcibly` returns
`"Stream closed"` and destroys the diagnosis, so the drain happens before the kill.

## #667 — every Scala Native suite linked its own binary into one shared path

`runScalaNativeTestSuite` linked its own binary per suite, on top of the link the
DAG had already run, and every suite derived the same output path — so a
three-suite project linked four times and the last three raced for one file.

The DAG's link is not an approximation of what the suites need, it is the same
thing: `LinkExecutor` resolves an absent main class to
`ScalaNativeTestRunner.TestMainClass` when the task is a test, which is the
constant `getTestMainClass` returns for every framework.

The regression test builds a three-suite native project — one suite cannot show a
race — and without the fix the inner run reports **0 passed, 3 failed**. This was
breaking runs, not merely wasting work; it needed more than one suite to appear,
which is why the single-suite framework matrices never caught it.

The Scala.js twin is fixed the same way, in its own commit.

## #673 — nothing tied the two output-directory computations together

Both test paths derived a directory from `classes.getParent` while the graph
derived one from `targetDir` — the same directory by different arithmetic, since
`classes = targetDir / "test-classes"`, equal only by coincidence.

Neither path computes a directory any more. `Handlers.test` now takes the link
result as an argument, looked up by the executor from its own state at dispatch
(`TaskId.Link(project)`), so `Dag.linkResults` is the single record. An
intermediate version of this PR carried a side map; it is gone.

Honest limit: the parameter is `Option`, because a JVM test project links
nothing, and the type cannot compel a caller to use what it is handed. What is
removed is the reason to go looking.

## Also in here

**A snapshot bleep nominated a stable release as itself.** `BleepExecutable.getCommand`
asked for `BleepVersion.current.latestRelease`, dropping the `+<n>-<sha>-SNAPSHOT`
suffix — so it produced a real bleep, just not this one, and that result is
written into configuration that outlives the session (`SetupIde` puts it in the
BSP connection file, `SetupMcpServer` in the MCP command). Now asks for the
running version, degrading to the release only when the snapshot genuinely cannot
be fetched, and saying so.

**Asking how to run bleep returned the path to `java`.** `bleepscript.Started.bleepExecutable`
handed out `BleepExecutable.command`; for a JVM-launched bleep that is `java`, with
`-cp <classpath> bleep.Main` silently dropped. `bleepCommand()` is the honest
answer; `bleepExecutable()` now refuses the cases it cannot represent.

**A bleep dependency dragged its `provided` scope into the consumer.** The
integration-test rewrite copied bleep projects' declared deps into the consumer's
*own* set, so `provided` arrived by a route the inherited-dep filter never sees.
`bleep-test-runner`'s deliberate junit-platform floor (1.0.0) then looked like the
platform the project had resolved, and the run asked for `junit-vintage-engine:5.0.0`,
which has never existed.

**The Scala.js optimizer is opt-in for a debug link, like every other platform.**
It was the one linkable platform whose debug mode optimized by default, so
`--optimize` meant "turn it on" everywhere except here. Measured on a
upickle-deriving program:

| Scala.js debug | time | output |
|---|---|---|
| optimizer on | 1.5–1.8 s | 2,140,186 B |
| optimizer off | 1.4 s | 3,034,721 B |

| Scala Native debug | time | output |
|---|---|---|
| optimizer off (default) | 3.2–3.4 s | 6,120,536 B |
| `--optimize` | 3.5–4.0 s | 5,177,096 B |

Neither difference is worth a platform disagreeing with its neighbours about what
the default is. Nobody deploys a debug link. `--release --no-optimize` stays refused.

**`${BLEEP_VERSION}` documented, not changed.** The note above
`Replacements.versions` claimed the running bleep's version was the normal
expansion and `--dev` the exception. It is the inverse: both call sites always
pass the build's own `$version`. Left as is deliberately — a build's scripts
compile against the API of the bleep they name, and bleep's own `scripts` /
`scripts-init` resolve published artifacts through that same template.

## Verification

`bleep test bleep-tests bleep-bsp-tests`: **1467 passed, 0 failed, 1 skipped**,
210 suites, no timeouts.

Every fix has a regression test that was confirmed to fail without it — including
by reverting the fix and re-running, not merely by writing an assertion.

## Not in here

**#664** is untouched and is the remaining one of the three: a Scala.js test link
still takes `ScalaJsLinkConfig.Debug` as a bare constant, so a project declaring
`jsKind: esmodule` silently gets a CommonJS test link. It is the only one of the
three with user-visible wrong behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
